### PR TITLE
Pin email_id=UUIDv7 contract (#162) + org notification migration 030 (#80)

### DIFF
--- a/db/migrations/030_add_org_notification_config.up.sql
+++ b/db/migrations/030_add_org_notification_config.up.sql
@@ -1,0 +1,38 @@
+-- ============================================================
+--  030_add_org_notification_config.sql
+--
+--  ARCH-SPEC §15 Schema Gap #1: organisations lacks the
+--  notification + retention settings columns SVC-09 reads and
+--  SVC-10 writes. Adds them with interim defaults so the org
+--  exists-row contract is satisfied before SVC-09 lands.
+--
+--  Defaults (per cybersiren-next.md §0c / issue #80):
+--    notification_threshold = 70          (risk score at/above which we notify)
+--    notification_channels  = ["webhook"] (SOAR/SIEM webhook is the demo default)
+--    retention_days         = 30          (per-org data retention window)
+--
+--  Supported channel values: "email", "webhook", "slack".
+--
+--  Idempotent: ADD COLUMN IF NOT EXISTS. Existing rows inherit the
+--  defaults at ALTER time (non-volatile defaults, no table rewrite).
+-- ============================================================
+
+ALTER TABLE organisations
+    ADD COLUMN IF NOT EXISTS notification_threshold INT   DEFAULT 70,
+    ADD COLUMN IF NOT EXISTS notification_channels  JSONB DEFAULT '["webhook"]'::jsonb,
+    ADD COLUMN IF NOT EXISTS retention_days         INT   DEFAULT 30;
+
+COMMENT ON COLUMN organisations.notification_threshold IS
+    'Risk score (0-100) at or above which SVC-09 dispatches a notification for '
+    'an emails.verdict. Interim default 70. Enforcement is in the application '
+    'layer (SVC-09), not a DB constraint.';
+
+COMMENT ON COLUMN organisations.notification_channels IS
+    'JSON array of enabled notification channels for this org. Supported values: '
+    '"email", "webhook", "slack". Default ["webhook"] (SOAR/SIEM POST is the '
+    'highest-value demo path). SVC-09 reads this; SVC-10 (org settings) writes it.';
+
+COMMENT ON COLUMN organisations.retention_days IS
+    'Per-org data retention window in days for ingested emails and derived '
+    'artifacts. Interim default 30. Consumed by the retention sweep (SVC-10 / '
+    'issue #159); not enforced by a DB constraint.';

--- a/shared/contracts/kafka/envelope.go
+++ b/shared/contracts/kafka/envelope.go
@@ -12,16 +12,32 @@ const SchemaVersion = 1
 // flatter AnalysisHeadersMessage / ScoresHeaderMessage types from
 // header.go (svc-04's authoritative contract).
 //
-// EmailID and OrgID are int64 BIGINT values so they line up with the
-// emails.internal_id / orgs.id PKs used by svc-04 and svc-08 when they
-// write to Postgres. The aggregator (svc-07) carries them along as the
-// partition key on every produce.
+// OrgID is an int64 BIGINT that lines up with the orgs.id PK used by svc-04
+// and svc-08 when they write to Postgres. EmailID is the canonical email
+// identifier: per ARCH-SPEC §1 its contract type is a UUIDv7 string, carried
+// as int64 only on an interim basis (see the EmailID field comment below).
+// The aggregator (svc-07) carries both along as the partition key on every
+// produce.
 //
 // FetchedAt is emails.fetched_at (partition discriminator on the emails
 // table). Producers SHOULD set this on analysis.plans and every scores.*
 // envelope meta so svc-07 can forward it verbatim on emails.scored; when
 // omitted, downstream consumers cannot address partitioned rows reliably.
 type MessageMeta struct {
+	// EmailID is the canonical, logical email identifier. ARCH-SPEC §1
+	// (Canonical Identifier Strategy) pins its contract type as a UUIDv7
+	// string: assigned once by SVC-01, carried verbatim in every Kafka
+	// message and Redis key, and used as the partition key end to end. It is
+	// distinct from the Postgres row identity (emails.internal_id BIGINT +
+	// fetched_at), which travels alongside it on emails.scored.
+	//
+	// It is typed int64 here only as an interim measure: SVC-01 currently
+	// emits time.Now().UnixNano()/1000 (a microsecond timestamp), leaking an
+	// int64 through the contract instead of a UUIDv7. Swapping the emitter to
+	// uuid.NewV7() — and widening this field to a UUIDv7 string — is tracked
+	// by issue #142, not this change. Until then, downstream code should treat
+	// email_id as an opaque identifier and not depend on its numeric shape, so
+	// that the #142 swap lands cleanly.
 	EmailID       int64     `json:"email_id"`
 	OrgID         int64     `json:"org_id"`
 	FetchedAt     time.Time `json:"fetched_at,omitempty"`


### PR DESCRIPTION
Closes #162
Closes #80

Day-0 bootstrap: two small, independent changes — a doc-only contract pin and a new migration.

## #162 — pin `email_id` = UUIDv7 in the envelope contract (doc-only)
`shared/contracts/kafka/envelope.go`: added a doc comment on `MessageMeta.EmailID` pinning the canonical contract type as a **UUIDv7 string** per ARCH-SPEC §1 — the logical id assigned by SVC-01, carried in every Kafka message / Redis key as the partition key, distinct from the `internal_id` BIGINT row identity. It documents *why* the field is still typed `int64` today (SVC-01 emits `time.Now().UnixNano()/1000`, leaking an int64) and that the emitter swap to `uuid.NewV7()` — widening the field to a string — is tracked by **#142**, not here.

No behavioral change: field definitions are unchanged (frozen), comment-only. The diff is comment-only; `go vet` + build + package lint are clean.

## #80 — migration 030: `organisations` notification config (ARCH-SPEC §15 Gap #1)
New `db/migrations/030_add_org_notification_config.up.sql` (030 is the next free number; 029 was highest). Up-only and idempotent, matching the existing `0NN` migrations:

    ALTER TABLE organisations
        ADD COLUMN IF NOT EXISTS notification_threshold INT   DEFAULT 70,
        ADD COLUMN IF NOT EXISTS notification_channels  JSONB DEFAULT '["webhook"]'::jsonb,
        ADD COLUMN IF NOT EXISTS retention_days         INT   DEFAULT 30;

Plus a `COMMENT ON COLUMN` for each. Unblocks SVC-09 and the org-settings page.

### ⚠️ Default-value divergence to reconcile (`notification_channels`)
The `notification_channels` default here is `'["webhook"]'`, per `cybersiren-next.md` §0c and the Day-0 task brief. This **diverges from the spec**, which is itself internally inconsistent:

| Source | `notification_channels` default |
|---|---|
| ARCH-SPEC §15 Gap #1 | `'[]'` |
| ARCH-SPEC §6a (SVC-09 table) & issue #80 body | `'["email"]'` |
| `cybersiren-next.md` §0c + task brief (followed here) | `'["webhook"]'` |

I followed the most recent planning decision (`["webhook"]` — the highest-value SOAR/SIEM demo channel). If the spec should win instead, say the word and I'll change the default before merge. `threshold = 70` and `retention_days = 30` are consistent everywhere. Columns are nullable-with-default to match §15 exactly (issue #80's body wrote `NOT NULL`, which contradicts the §15 column spec it points to).

## Verification
- **Migration applies cleanly against a migrated DB**: on an isolated Postgres migrated through 029, applying 030 reaches version 30 (not dirty); the three columns appear with the correct types/defaults, and a row that already existed at v29 inherits all three defaults (`70` / `["webhook"]` / `30`).
- **`make smoke` green end-to-end**: a fake email is driven `emails.raw → emails.verdict` (verdict `malware`, risk 85, source `model`) with migration 030 applied to the smoke DB.
- **`go test ./... -race -count=1`**: pass. golangci-lint clean for the changed package; CI on `main` is green and this PR adds no other Go code.

## Out of scope (intentionally untouched)
SVC-01 emitter (#142), `shared/contracts/kafka/*` field definitions, `shared/http/`.
