### PR TITLE
feat(svc-01): harden ingestion — auth, org_id, dedup, rate limit, multipart (#142)

### DIFF
--- a/services/svc-01-ingestion/cmd/ingestion/main.go
+++ b/services/svc-01-ingestion/cmd/ingestion/main.go
@@ -1,33 +1,45 @@
-// svc-01-ingestion accepts an ingest request over HTTP and emits emails.raw.
-// It no longer INSERTs the `emails` row — SVC-02 (the parser) is the
-// authoritative writer of the row + its junction tables. The row SVC-01 used to
-// write here would collide with SVC-02's insert (same (internal_id, fetched_at)
-// key) and make SVC-02 skip all of its writes, so ingestion now only
-// authenticates, mints the logical email_id, and publishes. NO Gmail/Outlook/
-// IMAP adapters yet.
+// svc-01-ingestion accepts an ingest request over HTTP (JSON or multipart) and
+// emits emails.raw. It authenticates the caller with an API key (shared/auth),
+// derives org_id from that key, rate-limits and de-duplicates per org, and
+// publishes. It no longer INSERTs the `emails` row — SVC-02 is the authoritative
+// writer (a pre-insert here would collide and make SVC-02 skip its writes).
 //
-// email_id / org_id remain int64 BIGINT values for now (the UUIDv7 migration is
-// tracked separately).
+// email_id / org_id are int64 BIGINT for now (UUIDv7 migration tracked
+// separately). NO Gmail/Outlook/IMAP adapters yet.
 package main
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"strconv"
 	"time"
 
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/rs/zerolog"
+	valkeygo "github.com/valkey-io/valkey-go"
 
+	dbsqlc "github.com/saif/cybersiren/db/sqlc"
+	"github.com/saif/cybersiren/shared/auth"
 	contracts "github.com/saif/cybersiren/shared/contracts/kafka"
 	kafkaproducer "github.com/saif/cybersiren/shared/kafka/producer"
 	"github.com/saif/cybersiren/shared/svckit"
 )
 
-const serviceName = "svc-01-ingestion"
-
-const stubOrgID int64 = 1
+const (
+	serviceName = "svc-01-ingestion"
+	// reqPerMin is the per-org ingest rate limit.
+	reqPerMin = 100
+	// dedupTTLSeconds is how long a (org, message_id) is remembered for dedup.
+	dedupTTLSeconds = 7 * 24 * 60 * 60
+	// maxUploadBytes caps a multipart email upload.
+	maxUploadBytes = 32 << 20
+)
 
 type ingestRequest struct {
 	EmailID       int64             `json:"email_id,omitempty"`
@@ -42,10 +54,14 @@ func main() {
 	if err := svckit.Run(svckit.Spec{
 		Name:           serviceName,
 		NeedsDB:        true,
+		NeedsValkey:    true,
 		ProducerTopics: []string{contracts.TopicEmailsRaw},
 		HTTPPort:       8081,
 		HTTPRoutes: func(mux *http.ServeMux, deps svckit.Deps) {
-			mux.HandleFunc("/ingest", ingestHandler(deps.Producers[contracts.TopicEmailsRaw], deps.Log))
+			authn := auth.New(dbsqlc.New(deps.Pool), deps.Cfg.Auth)
+			h := ingestHandler(deps.Valkey, deps.Pool, deps.Producers[contracts.TopicEmailsRaw], deps.Log)
+			// API-key auth runs first; the handler reads org_id from context.
+			mux.Handle("/ingest", authn.RequireAPIKey(h))
 		},
 	}); err != nil {
 		l := zerolog.New(os.Stderr)
@@ -54,34 +70,55 @@ func main() {
 	}
 }
 
-func ingestHandler(prod *kafkaproducer.Producer, log zerolog.Logger) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
+func ingestHandler(vk valkeygo.Client, pool *pgxpool.Pool, prod *kafkaproducer.Producer, log zerolog.Logger) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			http.Error(w, "POST required", http.StatusMethodNotAllowed)
 			return
 		}
 
-		var req ingestRequest
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			http.Error(w, "bad json", http.StatusBadRequest)
+		// org_id comes from the authenticated API key (auth middleware).
+		orgID := auth.OrgIDFromContext(r.Context())
+		if orgID == 0 {
+			writeJSON(w, http.StatusUnauthorized, map[string]any{"error": "unauthenticated"})
 			return
-		}
-
-		now := time.Now().UTC()
-		if req.EmailID == 0 {
-			// time.Now().UnixNano()/1000 ⇒ collision-resistant int64 that fits
-			// in BIGINT and stays roughly monotonic. UUIDv7 migration pending.
-			req.EmailID = now.UnixNano() / 1000
-		}
-		if req.OrgID == 0 {
-			req.OrgID = stubOrgID
-		}
-		if req.SourceAdapter == "" {
-			req.SourceAdapter = "http-stub"
 		}
 
 		ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
 		defer cancel()
+
+		if allowed, err := allowRequest(ctx, vk, orgID); err != nil {
+			log.Warn().Err(err).Int64("org_id", orgID).Msg("rate-limit check failed; allowing")
+		} else if !allowed {
+			writeJSON(w, http.StatusTooManyRequests, map[string]any{"error": "rate limit exceeded"})
+			return
+		}
+
+		req, err := parseIngest(r)
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]any{"error": err.Error()})
+			return
+		}
+		req.OrgID = orgID // authoritative; ignore any client-supplied org_id
+		now := time.Now().UTC()
+		if req.EmailID == 0 {
+			req.EmailID = now.UnixNano() / 1000
+		}
+		if req.SourceAdapter == "" {
+			req.SourceAdapter = "http"
+		}
+
+		// Dedup: a repeated (org, message_id) within the window is acknowledged
+		// but not re-published downstream.
+		if req.MessageID != "" {
+			dup, err := isDuplicate(ctx, vk, pool, orgID, req.MessageID, req.EmailID, now)
+			if err != nil {
+				log.Warn().Err(err).Msg("dedup check failed; treating as new")
+			} else if dup {
+				writeJSON(w, http.StatusOK, map[string]any{"status": "duplicate", "email_id": req.EmailID})
+				return
+			}
+		}
 
 		payload := contracts.EmailsRaw{
 			Meta:          contracts.NewMeta(req.EmailID, req.OrgID),
@@ -91,24 +128,116 @@ func ingestHandler(prod *kafkaproducer.Producer, log zerolog.Logger) http.Handle
 			RawMessageB64: req.RawMessageB64,
 			Headers:       req.Headers,
 		}
-
 		body, err := json.Marshal(payload)
 		if err != nil {
-			http.Error(w, "marshal failed", http.StatusInternalServerError)
+			writeJSON(w, http.StatusInternalServerError, map[string]any{"error": "marshal failed"})
 			return
 		}
-
 		key := []byte(strconv.FormatInt(req.EmailID, 10))
-		// Publish last arg: extra kafka retries after first attempt.
 		if err := prod.Publish(ctx, key, body, 3); err != nil {
 			log.Error().Err(err).Int64("email_id", req.EmailID).Msg("publish emails.raw failed")
-			http.Error(w, "publish failed", http.StatusBadGateway)
+			writeJSON(w, http.StatusBadGateway, map[string]any{"error": "publish failed"})
 			return
 		}
 
-		log.Info().Int64("email_id", req.EmailID).Msg("ingested email")
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusAccepted)
-		_ = json.NewEncoder(w).Encode(map[string]any{"status": "accepted", "email_id": req.EmailID})
+		log.Info().Int64("email_id", req.EmailID).Int64("org_id", orgID).Msg("ingested email")
+		writeJSON(w, http.StatusAccepted, map[string]any{"status": "accepted", "email_id": req.EmailID})
+	})
+}
+
+// parseIngest reads an ingest request from either a JSON body or a
+// multipart/form-data upload (file field "email"; optional message_id /
+// source_adapter form fields).
+func parseIngest(r *http.Request) (ingestRequest, error) {
+	ct := r.Header.Get("Content-Type")
+	if len(ct) >= 19 && ct[:19] == "multipart/form-data" {
+		if err := r.ParseMultipartForm(maxUploadBytes); err != nil {
+			return ingestRequest{}, fmt.Errorf("parse multipart: %w", err)
+		}
+		file, _, err := r.FormFile("email")
+		if err != nil {
+			return ingestRequest{}, errors.New("multipart: missing 'email' file field")
+		}
+		defer func() { _ = file.Close() }()
+		raw, err := io.ReadAll(io.LimitReader(file, maxUploadBytes))
+		if err != nil {
+			return ingestRequest{}, fmt.Errorf("read upload: %w", err)
+		}
+		return ingestRequest{
+			MessageID:     r.FormValue("message_id"),
+			SourceAdapter: r.FormValue("source_adapter"),
+			RawMessageB64: base64.StdEncoding.EncodeToString(raw),
+		}, nil
 	}
+
+	var req ingestRequest
+	if err := json.NewDecoder(io.LimitReader(r.Body, maxUploadBytes)).Decode(&req); err != nil {
+		return ingestRequest{}, errors.New("bad json")
+	}
+	return req, nil
+}
+
+// allowRequest enforces a fixed-window per-org rate limit in Valkey. It fails
+// open (returns true) on a cache error so a Redis blip doesn't drop ingestion.
+func allowRequest(ctx context.Context, vk valkeygo.Client, orgID int64) (bool, error) {
+	if vk == nil {
+		return true, nil
+	}
+	key := fmt.Sprintf("ratelimit:{%d}:%d", orgID, time.Now().Unix()/60)
+	count, err := vk.Do(ctx, vk.B().Incr().Key(key).Build()).ToInt64()
+	if err != nil {
+		return true, fmt.Errorf("ratelimit incr: %w", err)
+	}
+	if count == 1 {
+		_ = vk.Do(ctx, vk.B().Expire().Key(key).Seconds(60).Build()).Error()
+	}
+	return count <= reqPerMin, nil
+}
+
+// isDuplicate reports whether (orgID, messageID) was already ingested. It uses a
+// Valkey SET NX fast path and falls back to the email_identities table when
+// Valkey is unavailable.
+func isDuplicate(
+	ctx context.Context, vk valkeygo.Client, pool *pgxpool.Pool,
+	orgID int64, messageID string, emailID int64, fetchedAt time.Time,
+) (bool, error) {
+	if vk != nil {
+		key := fmt.Sprintf("dedup:{%d}:%s", orgID, messageID)
+		err := vk.Do(ctx, vk.B().Set().Key(key).Value("1").Nx().ExSeconds(dedupTTLSeconds).Build()).Error()
+		if err == nil {
+			return false, nil // key set ⇒ first time seen
+		}
+		if valkeygo.IsValkeyNil(err) {
+			return true, nil // NX failed ⇒ already present
+		}
+		// Valkey error → fall through to the DB.
+	}
+	return registerIdentity(ctx, pool, orgID, messageID, emailID, fetchedAt)
+}
+
+// registerIdentity records the (org, message_id) identity in email_identities
+// and reports whether it already existed (duplicate). It is the durable dedup
+// of record (migration 015).
+func registerIdentity(
+	ctx context.Context, pool *pgxpool.Pool,
+	orgID int64, messageID string, emailID int64, fetchedAt time.Time,
+) (bool, error) {
+	if pool == nil {
+		return false, errors.New("svc-01: no DB pool for dedup fallback")
+	}
+	const q = `
+INSERT INTO email_identities (org_id, message_id, internal_id, fetched_at)
+VALUES ($1, $2, $3, $4)
+ON CONFLICT (org_id, message_id) DO NOTHING`
+	tag, err := pool.Exec(ctx, q, orgID, messageID, emailID, fetchedAt)
+	if err != nil {
+		return false, fmt.Errorf("svc-01: register email identity: %w", err)
+	}
+	return tag.RowsAffected() == 0, nil // 0 rows ⇒ conflict ⇒ duplicate
+}
+
+func writeJSON(w http.ResponseWriter, status int, body map[string]any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
 }

--- a/services/svc-01-ingestion/cmd/ingestion/main.go
+++ b/services/svc-01-ingestion/cmd/ingestion/main.go
@@ -1,31 +1,23 @@
-// STUB: replace with real implementation. Accepts a synthetic ingest request
-// over HTTP, INSERTs the row into the partitioned `emails` table, and emits
-// emails.raw. NO Gmail/Outlook/IMAP adapters.
+// svc-01-ingestion accepts an ingest request over HTTP and emits emails.raw.
+// It no longer INSERTs the `emails` row — SVC-02 (the parser) is the
+// authoritative writer of the row + its junction tables. The row SVC-01 used to
+// write here would collide with SVC-02's insert (same (internal_id, fetched_at)
+// key) and make SVC-02 skip all of its writes, so ingestion now only
+// authenticates, mints the logical email_id, and publishes. NO Gmail/Outlook/
+// IMAP adapters yet.
 //
-// The `emails` insert is what binds the logical email_id used on Kafka to
-// the (internal_id, fetched_at) partition key downstream services persist
-// against (svc-04 rule_hits, svc-08 verdict + emails score update). Without
-// it, svc-08's UPDATE matches 0 rows and the pipeline never emits a verdict.
-//
-// In v0 the email_id and org_id are int64 BIGINT values (matching
-// emails.internal_id / orgs.id), generated from the request when not
-// supplied — once the real ingestion path lands the BIGSERIAL emails.id
-// from this INSERT will be the authoritative source.
+// email_id / org_id remain int64 BIGINT values for now (the UUIDv7 migration is
+// tracked separately).
 package main
 
 import (
 	"context"
 	"encoding/json"
-	"errors"
-	"fmt"
 	"net/http"
 	"os"
 	"strconv"
 	"time"
 
-	"github.com/jackc/pgx/v5/pgconn"
-	"github.com/jackc/pgx/v5/pgtype"
-	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/rs/zerolog"
 
 	contracts "github.com/saif/cybersiren/shared/contracts/kafka"
@@ -34,6 +26,8 @@ import (
 )
 
 const serviceName = "svc-01-ingestion"
+
+const stubOrgID int64 = 1
 
 type ingestRequest struct {
 	EmailID       int64             `json:"email_id,omitempty"`
@@ -44,8 +38,6 @@ type ingestRequest struct {
 	Headers       map[string]string `json:"headers,omitempty"`
 }
 
-const stubOrgID int64 = 1
-
 func main() {
 	if err := svckit.Run(svckit.Spec{
 		Name:           serviceName,
@@ -53,7 +45,7 @@ func main() {
 		ProducerTopics: []string{contracts.TopicEmailsRaw},
 		HTTPPort:       8081,
 		HTTPRoutes: func(mux *http.ServeMux, deps svckit.Deps) {
-			mux.HandleFunc("/ingest", ingestHandler(deps.Pool, deps.Producers[contracts.TopicEmailsRaw], deps.Log))
+			mux.HandleFunc("/ingest", ingestHandler(deps.Producers[contracts.TopicEmailsRaw], deps.Log))
 		},
 	}); err != nil {
 		l := zerolog.New(os.Stderr)
@@ -62,7 +54,7 @@ func main() {
 	}
 }
 
-func ingestHandler(pool *pgxpool.Pool, prod *kafkaproducer.Producer, log zerolog.Logger) http.HandlerFunc {
+func ingestHandler(prod *kafkaproducer.Producer, log zerolog.Logger) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			http.Error(w, "POST required", http.StatusMethodNotAllowed)
@@ -77,9 +69,8 @@ func ingestHandler(pool *pgxpool.Pool, prod *kafkaproducer.Producer, log zerolog
 
 		now := time.Now().UTC()
 		if req.EmailID == 0 {
-			// time.Now().UnixNano() / 1000 ⇒ collision-resistant int64 that
-			// fits comfortably in BIGINT and stays roughly monotonic for
-			// log-grep scanning. Real ingestion will use BIGSERIAL.
+			// time.Now().UnixNano()/1000 ⇒ collision-resistant int64 that fits
+			// in BIGINT and stays roughly monotonic. UUIDv7 migration pending.
 			req.EmailID = now.UnixNano() / 1000
 		}
 		if req.OrgID == 0 {
@@ -91,18 +82,6 @@ func ingestHandler(pool *pgxpool.Pool, prod *kafkaproducer.Producer, log zerolog
 
 		ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
 		defer cancel()
-
-		// Insert the row into the partitioned `emails` table BEFORE publishing
-		// emails.raw. Downstream services persist against (internal_id,
-		// fetched_at) — svc-04 rule_hits FK, svc-08 emails UPDATE + verdict
-		// FK — so the row must exist by the time their messages arrive. The
-		// publish only fans out after the INSERT commits so we can't ship a
-		// Kafka event that points at a non-existent partition row.
-		if err := insertEmailRow(ctx, pool, req, now); err != nil {
-			log.Error().Err(err).Int64("email_id", req.EmailID).Msg("insert emails row failed")
-			http.Error(w, "persist failed", http.StatusInternalServerError)
-			return
-		}
 
 		payload := contracts.EmailsRaw{
 			Meta:          contracts.NewMeta(req.EmailID, req.OrgID),
@@ -120,48 +99,16 @@ func ingestHandler(pool *pgxpool.Pool, prod *kafkaproducer.Producer, log zerolog
 		}
 
 		key := []byte(strconv.FormatInt(req.EmailID, 10))
-		// Publish last arg: extra kafka retries after first attempt (see kafka/producer).
+		// Publish last arg: extra kafka retries after first attempt.
 		if err := prod.Publish(ctx, key, body, 3); err != nil {
 			log.Error().Err(err).Int64("email_id", req.EmailID).Msg("publish emails.raw failed")
 			http.Error(w, "publish failed", http.StatusBadGateway)
 			return
 		}
 
-		log.Info().Int64("email_id", req.EmailID).Msg("ingested fake email")
+		log.Info().Int64("email_id", req.EmailID).Msg("ingested email")
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusAccepted)
-		_ = json.NewEncoder(w).Encode(map[string]any{
-			"status":   "accepted",
-			"email_id": req.EmailID,
-		})
+		_ = json.NewEncoder(w).Encode(map[string]any{"status": "accepted", "email_id": req.EmailID})
 	}
-}
-
-// insertEmailRow writes a minimal emails row keyed by (internal_id, fetched_at).
-// Idempotent: 23505 (unique violation, e.g. retried POST with the same
-// EMAIL_ID) is treated as success.
-func insertEmailRow(ctx context.Context, pool *pgxpool.Pool, req ingestRequest, fetchedAt time.Time) error {
-	if pool == nil {
-		return errors.New("svc-01: postgres pool unavailable")
-	}
-	const q = `
-INSERT INTO emails (internal_id, fetched_at, org_id, message_id)
-VALUES ($1, $2::timestamptz, $3, $4)
-ON CONFLICT (internal_id, fetched_at) DO NOTHING
-`
-	_, err := pool.Exec(ctx, q,
-		req.EmailID,
-		pgtype.Timestamptz{Time: fetchedAt, Valid: true},
-		pgtype.Int8{Int64: req.OrgID, Valid: req.OrgID > 0},
-		pgtype.Text{String: req.MessageID, Valid: req.MessageID != ""},
-	)
-	if err == nil {
-		return nil
-	}
-	var pe *pgconn.PgError
-	if errors.As(err, &pe) && pe.Code == "23505" {
-		// Concurrent retry won the insert race — treat as success.
-		return nil
-	}
-	return fmt.Errorf("svc-01: insert emails row: %w", err)
 }

--- a/services/svc-01-ingestion/cmd/ingestion/main_test.go
+++ b/services/svc-01-ingestion/cmd/ingestion/main_test.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"fmt"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/saif/cybersiren/shared/config"
+)
+
+func TestParseIngestJSON(t *testing.T) {
+	t.Parallel()
+	body := `{"message_id":"<a@x>","raw_message_b64":"Zm9v","source_adapter":"test"}`
+	r := httptest.NewRequest(http.MethodPost, "/ingest", strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/json")
+
+	req, err := parseIngest(r)
+	if err != nil {
+		t.Fatalf("parseIngest: %v", err)
+	}
+	if req.MessageID != "<a@x>" || req.RawMessageB64 != "Zm9v" || req.SourceAdapter != "test" {
+		t.Errorf("parsed = %+v", req)
+	}
+}
+
+func TestParseIngestMultipart(t *testing.T) {
+	t.Parallel()
+	raw := []byte("From: a@example.com\r\nSubject: hi\r\n\r\nbody")
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	fw, _ := mw.CreateFormFile("email", "msg.eml")
+	_, _ = fw.Write(raw)
+	_ = mw.WriteField("message_id", "<m1@x>")
+	_ = mw.WriteField("source_adapter", "upload")
+	_ = mw.Close()
+
+	r := httptest.NewRequest(http.MethodPost, "/ingest", &buf)
+	r.Header.Set("Content-Type", mw.FormDataContentType())
+
+	req, err := parseIngest(r)
+	if err != nil {
+		t.Fatalf("parseIngest multipart: %v", err)
+	}
+	if req.MessageID != "<m1@x>" || req.SourceAdapter != "upload" {
+		t.Errorf("form fields = %+v", req)
+	}
+	if got, _ := base64.StdEncoding.DecodeString(req.RawMessageB64); !bytes.Equal(got, raw) {
+		t.Errorf("decoded upload = %q, want %q", got, raw)
+	}
+}
+
+func TestParseIngestMultipartMissingFile(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	_ = mw.WriteField("message_id", "<m@x>")
+	_ = mw.Close()
+	r := httptest.NewRequest(http.MethodPost, "/ingest", &buf)
+	r.Header.Set("Content-Type", mw.FormDataContentType())
+
+	if _, err := parseIngest(r); err == nil {
+		t.Fatal("expected error for missing email file field")
+	}
+}
+
+// TestRegisterIdentityDedup verifies the DB dedup fallback: the first
+// (org, message_id) is new, the second is a duplicate. Skipped in -short/no-DB;
+// runs in CI Integration.
+func TestRegisterIdentityDedup(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping DB integration test in -short mode")
+	}
+	cfg, err := config.Load()
+	if err != nil {
+		t.Skipf("config load failed: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	pool, err := pgxpool.New(ctx, cfg.DB.DSN())
+	if err != nil {
+		t.Skipf("no DB pool: %v", err)
+	}
+	defer pool.Close()
+	if err := pool.Ping(ctx); err != nil {
+		t.Skipf("DB not reachable: %v", err)
+	}
+
+	uniq := time.Now().UnixNano()
+	var orgID int64
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO organisations (name, slug) VALUES ($1,$2) RETURNING id`,
+		fmt.Sprintf("dedup-test-%d", uniq), fmt.Sprintf("dedup-test-%d", uniq)).Scan(&orgID); err != nil {
+		t.Fatalf("seed org: %v", err)
+	}
+	defer pool.Exec(context.Background(), `DELETE FROM organisations WHERE id=$1`, orgID) //nolint:errcheck
+
+	msgID := fmt.Sprintf("<dedup-%d@x>", uniq)
+	now := time.Now().UTC()
+
+	dup, err := registerIdentity(ctx, pool, orgID, msgID, uniq, now)
+	if err != nil || dup {
+		t.Fatalf("first call: dup=%v err=%v, want new", dup, err)
+	}
+	dup, err = registerIdentity(ctx, pool, orgID, msgID, uniq, now)
+	if err != nil || !dup {
+		t.Fatalf("second call: dup=%v err=%v, want duplicate", dup, err)
+	}
+}


### PR DESCRIPTION
## Why

Spine-v0 SVC-01 hardcoded `org_id = 1`, had no auth, no dedup, no rate limit, JSON-only ingest — and **pre-inserted the `emails` row**, which (once SVC-02's persistence PR #165 lands) collides with SVC-02's authoritative insert and makes SVC-02 silently skip every junction write. This hardens ingestion and removes that collision.

Addresses **#142** (UUIDv7 `email_id` and the Kafka dead-letter topic are deferred — see below).

> Stacked on **#168** (`shared/auth`); PR base is `feat/shared-auth`. **Merge order: #165 + #168 → this.** It must land after #165 so SVC-02 owns the `emails` insert.

## What it does

1. **Stops inserting the `emails` row** — SVC-02 is the sole writer now (the latent-bug fix). `commit 1`.
2. **API-key auth** via `shared/auth.RequireAPIKey` on `/ingest`; **`org_id` comes from the authenticated key** (deletes `stubOrgID`; any client-supplied `org_id` is ignored).
3. **Per-org rate limit** — Valkey fixed-window, 100 req/min, fail-open on cache error → 429.
4. **Dedup** — `(org, message_id)` via Valkey `SET NX` (7d) with an **`email_identities` DB fallback** (migration 015); a repeat returns `200 {"status":"duplicate"}` without re-publishing.
5. **Multipart upload** — `/ingest` now accepts `multipart/form-data` (file field `email`) in addition to JSON+base64.

## Commits (bisectable)
1. `fix(svc-01): stop inserting the emails row (SVC-02 owns it)` — isolated, the collision fix.
2. `feat(svc-01): harden ingestion — API-key auth, org_id, dedup, rate limit, multipart`.

## Verification
- `go mod verify`, `go build ./...`, `go vet ./...`, `go test -short -race ./services/svc-01-ingestion/...` green; golangci-lint clean.
- Unit: JSON + multipart parsing (incl. missing-file error). DB-gated (CI Integration): `email_identities` dedup — first call new, second duplicate.
- Auth itself is covered by the shared/auth package tests (#168).

## Acceptance criteria status (#142)
- [x] Missing/revoked/expired API key → 401 (shared/auth)
- [x] `org_id` flows from key → `emails.raw`
- [x] Duplicate `(org, message_id)` acknowledged without re-publish
- [x] Rate limit at >100/min/org
- [x] Multipart `/ingest`
- [ ] **Deferred:** `email_id` = UUIDv7 (contract-wide change; int64 interim retained — own follow-up)
- [ ] **Deferred:** Kafka dead-letter topic on publish-retry exhaustion

🤖 Generated with [Claude Code](https://claude.com/claude-code)
