### PR TITLE
feat(svc-11): leader election + STIX feed parser (#154, #155)

### DIFF
--- a/services/svc-11-ti-sync/cmd/ti-sync/main.go
+++ b/services/svc-11-ti-sync/cmd/ti-sync/main.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/rs/zerolog"
 	db "github.com/saif/cybersiren/db/sqlc"
+	"github.com/saif/cybersiren/services/svc-11-ti-sync/internal/leader"
 	"github.com/saif/cybersiren/services/svc-11-ti-sync/internal/ti"
 	"github.com/saif/cybersiren/services/svc-11-ti-sync/internal/ti/feeds"
 	"github.com/saif/cybersiren/shared/config"
@@ -131,6 +132,8 @@ func main() {
 			feedImpl.URL = feedURL
 
 			feedImpls = append(feedImpls, feedImpl)
+		case "stix":
+			feedImpls = append(feedImpls, feeds.NewSTIXFeed(feedRow.ID, feedURL, httpClient, log))
 		case "threatfox":
 			feedImpl := feeds.NewThreatFoxFeed(feedRow.ID, cfg, httpClient, log)
 			feedImpl.URL = feedURL
@@ -169,7 +172,19 @@ func main() {
 	}
 
 	runner := ti.NewRunner(feedImpls, repo, cache, log, reg)
-	if err := runner.Start(ctx, time.Duration(cfg.SyncIntervalSeconds)*time.Second); err != nil {
+	interval := time.Duration(cfg.SyncIntervalSeconds) * time.Second
+
+	// Single-instance enforcement (ARCH-SPEC §11): only the leader runs the sync
+	// loop; replicas idle until they win the lease. TTL covers a worst-case sync.
+	leaseTTL := 2 * interval
+	if leaseTTL < time.Minute {
+		leaseTTL = time.Minute
+	}
+	lease := leader.New(rdb, "ti-sync:leader", leaseTTL, log)
+	err = lease.RunAsLeader(ctx, func(leaderCtx context.Context) error {
+		return runner.Start(leaderCtx, interval)
+	})
+	if err != nil && !errors.Is(err, context.Canceled) {
 		log.Fatal().Err(err).Msg("TI sync runner failed")
 	}
 

--- a/services/svc-11-ti-sync/internal/leader/leader.go
+++ b/services/svc-11-ti-sync/internal/leader/leader.go
@@ -1,0 +1,141 @@
+// Package leader provides single-instance enforcement for SVC-11 via a Valkey
+// lease. ARCH-SPEC §11 marks TI Sync as single-instance; today that relies on
+// operator discipline. Only the elected leader runs the sync loop; other
+// replicas idle, retrying acquisition, and take over within one TTL if the
+// leader dies.
+package leader
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"time"
+
+	"github.com/rs/zerolog"
+	valkeygo "github.com/valkey-io/valkey-go"
+)
+
+// renewOwnedScript refreshes the lease TTL only if we still own it (atomic).
+const renewOwnedScript = `if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('expire', KEYS[1], ARGV[2]) else return 0 end`
+
+// releaseOwnedScript deletes the lease only if we still own it (atomic).
+const releaseOwnedScript = `if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('del', KEYS[1]) else return 0 end`
+
+// Lease is a Valkey-backed leadership lock identified by a per-process token.
+type Lease struct {
+	vk  valkeygo.Client
+	key string
+	id  string
+	ttl time.Duration
+	log zerolog.Logger
+}
+
+// New creates a Lease. ttl must comfortably exceed the worst-case sync duration
+// so the leader doesn't lose the lease mid-sync.
+func New(vk valkeygo.Client, key string, ttl time.Duration, log zerolog.Logger) *Lease {
+	return &Lease{vk: vk, key: key, id: newToken(), ttl: ttl, log: log}
+}
+
+// acquire attempts to take the lease (SET NX EX). Returns true if acquired.
+func (l *Lease) acquire(ctx context.Context) (bool, error) {
+	cmd := l.vk.B().Set().Key(l.key).Value(l.id).Nx().ExSeconds(int64(l.ttl.Seconds())).Build()
+	err := l.vk.Do(ctx, cmd).Error()
+	if err == nil {
+		return true, nil
+	}
+	if valkeygo.IsValkeyNil(err) {
+		return false, nil // held by someone else
+	}
+	return false, fmt.Errorf("leader: acquire: %w", err)
+}
+
+// renew extends the lease iff we still own it. Returns false if ownership lost.
+func (l *Lease) renew(ctx context.Context) (bool, error) {
+	cmd := l.vk.B().Eval().Script(renewOwnedScript).Numkeys(1).
+		Key(l.key).Arg(l.id, fmt.Sprintf("%d", int64(l.ttl.Seconds()))).Build()
+	n, err := l.vk.Do(ctx, cmd).ToInt64()
+	if err != nil {
+		return false, fmt.Errorf("leader: renew: %w", err)
+	}
+	return n == 1, nil
+}
+
+// release relinquishes the lease if we still own it (best-effort).
+func (l *Lease) release(ctx context.Context) {
+	cmd := l.vk.B().Eval().Script(releaseOwnedScript).Numkeys(1).Key(l.key).Arg(l.id).Build()
+	_ = l.vk.Do(ctx, cmd).Error()
+}
+
+// RunAsLeader blocks until this instance wins the lease, then runs fn with a
+// context that is cancelled if leadership is lost (failed renewal) or the parent
+// ctx ends. Non-leaders poll every ttl/2 until they win or ctx ends. fn is the
+// leader-only work (the sync loop) and should return when its ctx is cancelled.
+func (l *Lease) RunAsLeader(ctx context.Context, fn func(ctx context.Context) error) error {
+	pollEvery := l.ttl / 2
+	if pollEvery <= 0 {
+		pollEvery = time.Second
+	}
+	for {
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("leader: %w", err)
+		}
+		won, err := l.acquire(ctx)
+		if err != nil {
+			l.log.Warn().Err(err).Msg("leader: acquire failed; retrying")
+		}
+		if won {
+			l.log.Info().Str("lease", l.key).Msg("acquired leadership")
+			return l.lead(ctx, fn)
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("leader: %w", ctx.Err())
+		case <-time.After(pollEvery):
+		}
+	}
+}
+
+// lead runs fn while holding the lease, renewing in the background. If a renewal
+// reports lost ownership, fn's context is cancelled so it stops promptly.
+func (l *Lease) lead(ctx context.Context, fn func(ctx context.Context) error) error {
+	leaderCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	defer l.release(context.WithoutCancel(ctx))
+
+	go l.renewLoop(leaderCtx, cancel)
+	return fn(leaderCtx)
+}
+
+// renewLoop refreshes the lease every ttl/3 and cancels leadership on loss.
+func (l *Lease) renewLoop(ctx context.Context, cancel context.CancelFunc) {
+	every := l.ttl / 3
+	if every <= 0 {
+		every = time.Second
+	}
+	t := time.NewTicker(every)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			ok, err := l.renew(ctx)
+			if err != nil {
+				l.log.Warn().Err(err).Msg("leader: renew error")
+				continue // transient; a later tick may succeed before TTL
+			}
+			if !ok {
+				l.log.Warn().Msg("leader: lost lease; stepping down")
+				cancel()
+				return
+			}
+		}
+	}
+}
+
+func newToken() string {
+	b := make([]byte, 16)
+	_, _ = rand.Read(b)
+	return hex.EncodeToString(b)
+}

--- a/services/svc-11-ti-sync/internal/ti/feeds/stix.go
+++ b/services/svc-11-ti-sync/internal/ti/feeds/stix.go
@@ -1,0 +1,134 @@
+package feeds
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"regexp"
+	"strings"
+
+	"github.com/rs/zerolog"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+
+	"github.com/saif/cybersiren/services/svc-11-ti-sync/internal/ti"
+	httputil "github.com/saif/cybersiren/shared/http"
+)
+
+// stixObjectTypeMap maps a STIX Cyber-observable object type (the token before
+// the colon in a pattern, e.g. "url" in `[url:value = '…']`) to our internal
+// ti_indicators indicator_type.
+var stixObjectTypeMap = map[string]string{
+	"url":         "url",
+	"domain-name": "domain",
+	"ipv4-addr":   "ip",
+	"ipv6-addr":   "ip",
+	"file":        "hash",
+	"email-addr":  "email_address",
+}
+
+// stixComparison matches one `object-type:path = 'value'` comparison inside a
+// STIX 2.x pattern. Patterns may contain several joined by AND/OR.
+var stixComparison = regexp.MustCompile(`([a-z0-9-]+):[^=<>!]*?=\s*'([^']+)'`)
+
+// stixBundle is the minimal STIX 2.x bundle shape we consume.
+type stixBundle struct {
+	Objects []stixObject `json:"objects"`
+}
+
+type stixObject struct {
+	Type       string   `json:"type"`
+	ID         string   `json:"id"`
+	Pattern    string   `json:"pattern"`
+	Name       string   `json:"name"`
+	Labels     []string `json:"labels"`
+	Confidence int      `json:"confidence"`
+}
+
+// ParseSTIXBundle extracts indicator rows from a STIX 2.x bundle. Each Indicator
+// object's pattern is decomposed into one or more (type, value) comparisons,
+// each mapped to a ti_indicators row. Unsupported object types are skipped.
+func ParseSTIXBundle(data []byte, feedID int64) ([]ti.TIIndicator, error) {
+	var bundle stixBundle
+	if err := json.Unmarshal(data, &bundle); err != nil {
+		return nil, fmt.Errorf("stix: decode bundle: %w", err)
+	}
+
+	var out []ti.TIIndicator
+	for _, obj := range bundle.Objects {
+		if obj.Type != "indicator" || obj.Pattern == "" {
+			continue
+		}
+		threatType := "stix"
+		if len(obj.Labels) > 0 {
+			threatType = obj.Labels[0]
+		}
+		for _, m := range stixComparison.FindAllStringSubmatch(obj.Pattern, -1) {
+			indType, ok := stixObjectTypeMap[strings.ToLower(m[1])]
+			if !ok {
+				continue
+			}
+			out = append(out, ti.TIIndicator{
+				FeedID:         feedID,
+				IndicatorType:  indType,
+				IndicatorValue: m[2],
+				ThreatType:     threatType,
+				ThreatTags:     obj.Labels,
+				Confidence:     float64(obj.Confidence) / 100.0,
+				RiskScore:      obj.Confidence,
+				SourceID:       obj.ID,
+			})
+		}
+	}
+	return out, nil
+}
+
+// STIXFeed fetches a STIX 2.x bundle from a URL and parses it into indicators.
+// It satisfies ti.Feed, so it plugs into the runner like any other feed.
+type STIXFeed struct {
+	feedID     int64
+	URL        string
+	httpClient httputil.Client
+	log        zerolog.Logger
+}
+
+// NewSTIXFeed constructs a STIX feed for the given feed row id and bundle URL.
+func NewSTIXFeed(feedID int64, url string, httpClient httputil.Client, log zerolog.Logger) *STIXFeed {
+	return &STIXFeed{feedID: feedID, URL: url, httpClient: httpClient, log: log}
+}
+
+// Name identifies the feed.
+func (f *STIXFeed) Name() string { return "stix" }
+
+// FeedID returns the feeds-table id.
+func (f *STIXFeed) FeedID() int64 { return f.feedID }
+
+// Fetch downloads and parses the configured STIX bundle.
+func (f *STIXFeed) Fetch(ctx context.Context) (indicators []ti.TIIndicator, err error) {
+	fetchCtx, cancel := context.WithTimeout(ctx, ti.FeedFetchTimeout)
+	defer cancel()
+	fetchCtx, span := ti.Tracer().Start(fetchCtx, "feeds.stix.Fetch")
+	defer func() {
+		span.SetAttributes(attribute.Int("indicator_count", len(indicators)))
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+		}
+		span.End()
+	}()
+
+	if f.httpClient == nil {
+		return nil, fmt.Errorf("stix: http client is nil")
+	}
+	url := strings.TrimSpace(f.URL)
+	if url == "" {
+		return nil, fmt.Errorf("stix: empty feed URL")
+	}
+
+	resp, reqErr := f.httpClient.Do(fetchCtx, httputil.NewClientRequest(http.MethodGet, url), nil)
+	if reqErr != nil {
+		return nil, fmt.Errorf("stix: fetch %s: %w", url, reqErr)
+	}
+	return ParseSTIXBundle(resp.Body, f.feedID)
+}

--- a/services/svc-11-ti-sync/internal/ti/feeds/stix_test.go
+++ b/services/svc-11-ti-sync/internal/ti/feeds/stix_test.go
@@ -1,0 +1,59 @@
+package feeds
+
+import "testing"
+
+const sampleBundle = `{
+  "type": "bundle",
+  "objects": [
+    {"type":"identity","id":"identity--1","name":"ACME"},
+    {"type":"indicator","id":"indicator--a","confidence":80,"labels":["malicious-activity"],
+     "pattern":"[url:value = 'http://evil.example.com/x']"},
+    {"type":"indicator","id":"indicator--b","confidence":50,
+     "pattern":"[domain-name:value = 'bad.example.org']"},
+    {"type":"indicator","id":"indicator--c",
+     "pattern":"[ipv4-addr:value = '203.0.113.7']"},
+    {"type":"indicator","id":"indicator--d",
+     "pattern":"[file:hashes.'SHA-256' = 'abc123']"},
+    {"type":"indicator","id":"indicator--e",
+     "pattern":"[url:value = 'http://a.test'] OR [domain-name:value = 'b.test']"},
+    {"type":"indicator","id":"indicator--f","pattern":"[mutex:name = 'x']"}
+  ]
+}`
+
+func TestParseSTIXBundle(t *testing.T) {
+	t.Parallel()
+	got, err := ParseSTIXBundle([]byte(sampleBundle), 42)
+	if err != nil {
+		t.Fatalf("ParseSTIXBundle: %v", err)
+	}
+	// a(url) + b(domain) + c(ip) + d(hash) + e(url+domain) = 6; mutex unsupported.
+	if len(got) != 6 {
+		t.Fatalf("got %d indicators, want 6: %+v", len(got), got)
+	}
+	first := got[0]
+	if first.FeedID != 42 || first.IndicatorType != "url" || first.IndicatorValue != "http://evil.example.com/x" {
+		t.Errorf("first indicator = %+v", first)
+	}
+	if first.RiskScore != 80 || first.Confidence != 0.8 {
+		t.Errorf("confidence mapping wrong: risk=%d conf=%v", first.RiskScore, first.Confidence)
+	}
+
+	types := map[string]int{}
+	for _, ind := range got {
+		types[ind.IndicatorType]++
+	}
+	if types["url"] != 2 || types["domain"] != 2 || types["ip"] != 1 || types["hash"] != 1 {
+		t.Errorf("type distribution = %v, want url=2 domain=2 ip=1 hash=1", types)
+	}
+}
+
+func TestParseSTIXBundleInvalid(t *testing.T) {
+	t.Parallel()
+	if _, err := ParseSTIXBundle([]byte("{not json"), 1); err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+	got, err := ParseSTIXBundle([]byte(`{"objects":[]}`), 1)
+	if err != nil || len(got) != 0 {
+		t.Fatalf("empty bundle: got %d err %v, want 0/nil", len(got), err)
+	}
+}


### PR DESCRIPTION
## Why
SVC-11 relied on operator discipline for single-instance (#154) and only handled CSV/JSON feeds (#155). Both are self-contained additions off `main`.

Closes **#154, #155**.

## What it does
- **Leader election (#154)** — `internal/leader`: a Valkey lease (`SET NX` + Lua-guarded renew/release with a per-process token). Only the leader runs the sync loop; replicas idle and take over within one TTL. Wired around `runner.Start`; TTL = 2× sync interval (≥1m).
- **STIX 2.x (#155)** — `feeds/stix.go`: `ParseSTIXBundle` decomposes Indicator `pattern`s into `ti_indicators` rows (url/domain/ip/hash/email), and `STIXFeed` (implements `ti.Feed`) fetches + parses a bundle URL; registered as the `stix` feed name in the loader.

## Verification
`go build/vet`, golangci-lint clean. Unit tests for the STIX parser (multi-comparison patterns, confidence mapping, unsupported types skipped, invalid JSON). Leader lease logic exercised via the live stack (Valkey-dependent).

## Follow-up
#156 (feed registry to drop the hardcoded name switch) is the remaining SVC-11 item — left as a separate PR to avoid refactoring the working feed wiring here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
Closes #154
Closes #155
