### PR TITLE
fix(shared/kafka): prevent message loss on handler error (commit-only-successful + rewind)

### DIFF
--- a/shared/kafka/consumer/consumer.go
+++ b/shared/kafka/consumer/consumer.go
@@ -41,9 +41,12 @@ type Config struct {
 
 // Handler processes a single Kafka message and returns nil on success.
 //
-// On non-nil error the consumer logs the failure, increments error metrics,
-// and skips committing the offset for that record (the message will be
-// re-read on consumer restart or partition rebalance).
+// On a non-nil error the consumer logs the failure, increments error metrics,
+// and does NOT commit the record's offset: the partition is rewound to the
+// failed record so it (and the records after it) are re-fetched and retried on
+// the next poll (at-least-once). A permanently-failing record therefore stalls
+// its partition until it succeeds — the bounded-retry + dead-letter escape is a
+// deferred platform task (spec §16 D16 / P8 8a-v).
 type Handler func(ctx context.Context, msg Message) error
 
 // Message is the consumer's view of a Kafka record. The embedded
@@ -184,49 +187,80 @@ func (c *Consumer) Run(ctx context.Context, handler Handler) error {
 			continue
 		}
 
-		batchOK := true
-		fetches.EachRecord(func(rec *kgo.Record) {
-			recCtx, span := c.tracer.WithProcessSpan(rec)
-			start := time.Now()
-
-			recLog := c.log.With().
-				Str("topic", rec.Topic).
-				Int32("partition", rec.Partition).
-				Int64("offset", rec.Offset).
-				Str("email_id", string(rec.Key)).
-				Logger()
-			recCtx = recLog.WithContext(recCtx)
-
-			msg := Message{
-				Topic:       rec.Topic,
-				Partition:   int(rec.Partition),
-				Offset:      rec.Offset,
-				Key:         rec.Key,
-				Value:       rec.Value,
-				Headers:     toHeaders(rec.Headers),
-				Time:        rec.Timestamp,
-				SpanContext: trace.SpanFromContext(recCtx).SpanContext(),
-			}
-
-			if err := handler(recCtx, msg); err != nil {
-				c.observeError(c.cfg.Topic, c.cfg.GroupID, "handler")
-				c.observeMessages(c.cfg.Topic, c.cfg.GroupID, "error")
-				recLog.Error().Err(err).Msg("kafka handler error; offset will not be committed")
-				batchOK = false
-				span.RecordError(err)
-				span.End()
+		// Process records grouped by partition so a handler failure rewinds ONLY
+		// the offending partition. We commit the contiguous successful PREFIX of
+		// each partition; on the first handler error in a partition we rewind the
+		// consume position to that record (SetOffsets) and stop processing the
+		// partition, so the failed record — and everything after it — is re-fetched
+		// and retried rather than skipped. franz-go advances the fetch cursor to the
+		// batch tail at poll time, so the previous code (skip-commit-on-any-error +
+		// CommitUncommittedOffsets) silently DROPPED a failed offset the moment a
+		// later batch committed the cumulative head — i.e. every fail-secure NACK in
+		// the pipeline lost its message instead of redelivering. A permanently
+		// failing ("poison") record now stalls its partition until it succeeds; the
+		// bounded-retry + dead-letter escape is the deferred platform task (§16 D16
+		// / P8 8a-v).
+		var toCommit []*kgo.Record
+		fetches.EachPartition(func(ftp kgo.FetchTopicPartition) {
+			if ftp.Err != nil {
+				c.observeError(ftp.Topic, c.cfg.GroupID, "fetch")
+				c.log.Error().Err(ftp.Err).Str("topic", ftp.Topic).
+					Int32("partition", ftp.Partition).Msg("partition fetch error")
 				return
 			}
+			for _, rec := range ftp.Records {
+				recCtx, span := c.tracer.WithProcessSpan(rec)
+				start := time.Now()
 
-			sharedkafka.IncConsumed(c.cfg.GroupID, rec.Topic)
-			c.observeMessages(c.cfg.Topic, c.cfg.GroupID, "ok")
-			c.observeProcessingLatency(c.cfg.Topic, c.cfg.GroupID, time.Since(start))
-			span.End()
+				recLog := c.log.With().
+					Str("topic", rec.Topic).
+					Int32("partition", rec.Partition).
+					Int64("offset", rec.Offset).
+					Str("email_id", string(rec.Key)).
+					Logger()
+				recCtx = recLog.WithContext(recCtx)
+
+				msg := Message{
+					Topic:       rec.Topic,
+					Partition:   int(rec.Partition),
+					Offset:      rec.Offset,
+					Key:         rec.Key,
+					Value:       rec.Value,
+					Headers:     toHeaders(rec.Headers),
+					Time:        rec.Timestamp,
+					SpanContext: trace.SpanFromContext(recCtx).SpanContext(),
+				}
+
+				if err := handler(recCtx, msg); err != nil {
+					c.observeError(c.cfg.Topic, c.cfg.GroupID, "handler")
+					c.observeMessages(c.cfg.Topic, c.cfg.GroupID, "error")
+					recLog.Error().Err(err).Msg("kafka handler error; rewinding partition to retry (offset not committed)")
+					// Rewind this partition to the failed record (carrying the leader
+					// epoch so the reset is fenced) so it and the records after it are
+					// re-fetched on the next poll.
+					c.client.SetOffsets(map[string]map[int32]kgo.EpochOffset{
+						rec.Topic: {rec.Partition: {Epoch: rec.LeaderEpoch, Offset: rec.Offset}},
+					})
+					span.RecordError(err)
+					span.End()
+					return // stop this partition; records after the failure are not processed
+				}
+
+				sharedkafka.IncConsumed(c.cfg.GroupID, rec.Topic)
+				c.observeMessages(c.cfg.Topic, c.cfg.GroupID, "ok")
+				c.observeProcessingLatency(c.cfg.Topic, c.cfg.GroupID, time.Since(start))
+				toCommit = append(toCommit, rec)
+				span.End()
+			}
 		})
 
-		if batchOK {
-			commitCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-			if err := c.client.CommitUncommittedOffsets(commitCtx); err != nil {
+		if len(toCommit) > 0 {
+			// Commit only the successfully-processed records, on a shutdown-
+			// independent context so the final batch is not dropped when ctx is
+			// already cancelled by SIGTERM (a dropped commit reprocesses the batch on
+			// the next restart).
+			commitCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			if err := c.client.CommitRecords(commitCtx, toCommit...); err != nil {
 				c.observeError(c.cfg.Topic, c.cfg.GroupID, "commit")
 				c.log.Error().Err(err).Msg("commit offsets failed")
 			}

--- a/shared/kafka/producer/producer.go
+++ b/shared/kafka/producer/producer.go
@@ -42,9 +42,10 @@ type Config struct {
 
 // Producer publishes JSON-serialised messages to a fixed Kafka topic.
 type Producer struct {
-	client *kgo.Client
-	topic  string
-	log    zerolog.Logger
+	client  *kgo.Client
+	topic   string
+	service string
+	log     zerolog.Logger
 
 	publishedTotal *prometheus.CounterVec
 	errorsTotal    *prometheus.CounterVec
@@ -89,6 +90,7 @@ func New(cfg Config, log zerolog.Logger, reg *prometheus.Registry) (*Producer, e
 	p := &Producer{
 		client:       cli,
 		topic:        cfg.Topic,
+		service:      cfg.ClientID,
 		log:          log.With().Str("component", "kafka-producer").Str("topic", cfg.Topic).Logger(),
 		writeTimeout: cfg.WriteTimeout,
 	}
@@ -140,7 +142,7 @@ func (p *Producer) Publish(ctx context.Context, key, value []byte, retries int) 
 		if err == nil {
 			p.observePublishCount(p.topic, "ok")
 			p.observePublishLatency(p.topic, time.Since(start))
-			sharedkafka.IncProduced(p.topic, p.topic)
+			sharedkafka.IncProduced(p.service, p.topic)
 			return nil
 		}
 


### PR DESCRIPTION
From a whole-codebase review pass.

The shared consumer disabled autocommit and committed via `CommitUncommittedOffsets` gated on a per-batch all-OK flag. franz-go advances the fetch cursor to the batch tail at poll time, so a record whose handler errored was not redelivered in-session, and a later successful batch's commit advanced the committed offset past it — silently dropping it. Every fail-secure NACK in the pipeline (svc-04/05/09 transient errors) lost its message instead of redelivering.

- Process records per partition; commit only each partition's contiguous successful prefix via `CommitRecords`.
- On a handler error, rewind that partition to the failed record (`SetOffsets`) and stop processing it, so it (and the records after it) are re-fetched. A poison record now stalls its partition until it succeeds — the bounded-retry/dead-letter escape stays the tracked platform task (§16 D16 / 8a-v).
- Commit on a shutdown-independent context so the final batch isn't dropped on SIGTERM.
- producer: label messages_produced_total with the client id, not the topic.

Validated live: full pipeline (all 12 topics) flows end-to-end through the new consumer; smoke green.