### PR TITLE
fix(enricher): SSRF guards on shortener/TLS dials + bounded DNS/WHOIS caches

### DIFF
--- a/internal/phishing/enricher/dns.go
+++ b/internal/phishing/enricher/dns.go
@@ -3,31 +3,49 @@ package enricher
 import (
 	"context"
 	"net"
-	"sync"
 	"time"
 
+	lru "github.com/hashicorp/golang-lru/v2"
 	"go.opentelemetry.io/otel/attribute"
 )
 
+const (
+	// dnsCacheMaxEntries bounds the in-process DNS cache so attacker-controlled
+	// hostnames (one per URL in incoming email) cannot grow it without limit.
+	dnsCacheMaxEntries = 10_000
+	// dnsCacheTTL bounds staleness (DNS records change); dnsNegativeTTL keeps a
+	// transient resolution failure from being cached for the whole TTL.
+	dnsCacheTTL    = 10 * time.Minute
+	dnsNegativeTTL = 1 * time.Minute
+)
+
+type dnsEntry struct {
+	ip        string
+	expiresAt time.Time
+}
+
 type dnsCache struct {
-	mu    sync.RWMutex
-	cache map[string]string
+	lru *lru.Cache[string, dnsEntry]
+}
+
+func newDNSCache() *dnsCache {
+	l, _ := lru.New[string, dnsEntry](dnsCacheMaxEntries)
+	return &dnsCache{lru: l}
 }
 
 func (c *dnsCache) get(host string) (string, bool) {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	v, ok := c.cache[host]
-	return v, ok
+	e, ok := c.lru.Get(host)
+	if !ok || time.Now().After(e.expiresAt) {
+		return "", false
+	}
+	return e.ip, true
 }
 
-func (c *dnsCache) set(host, ip string) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.cache[host] = ip
+func (c *dnsCache) set(host, ip string, ttl time.Duration) {
+	c.lru.Add(host, dnsEntry{ip: ip, expiresAt: time.Now().Add(ttl)})
 }
 
-var globalDNSCache = &dnsCache{cache: make(map[string]string)}
+var globalDNSCache = newDNSCache()
 
 // ResolveIP resolves hostname to an IPv4 address (preferred) or IPv6 address.
 // Results are cached in-process for the binary lifetime. Returns empty string on failure.
@@ -50,7 +68,7 @@ func ResolveIP(ctx context.Context, hostname string) string {
 		if err != nil {
 			span.RecordError(err)
 		}
-		globalDNSCache.set(hostname, "")
+		globalDNSCache.set(hostname, "", dnsNegativeTTL)
 		return ""
 	}
 
@@ -69,7 +87,7 @@ func ResolveIP(ctx context.Context, hostname string) string {
 		}
 	}
 
-	globalDNSCache.set(hostname, result)
+	globalDNSCache.set(hostname, result, dnsCacheTTL)
 	span.SetAttributes(attribute.String("enricher.ip", result))
 	return result
 }

--- a/internal/phishing/enricher/dns_test.go
+++ b/internal/phishing/enricher/dns_test.go
@@ -22,7 +22,7 @@ func TestResolveIP_InvalidHost(t *testing.T) {
 func TestResolveIP_Cache(t *testing.T) {
 	t.Parallel()
 	// Prime the cache with a fake result.
-	globalDNSCache.set("cached-test.example", "1.2.3.4")
+	globalDNSCache.set("cached-test.example", "1.2.3.4", dnsCacheTTL)
 	ip := ResolveIP(context.Background(), "cached-test.example")
 	require.Equal(t, "1.2.3.4", ip)
 }

--- a/internal/phishing/enricher/http.go
+++ b/internal/phishing/enricher/http.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"regexp"
 	"strings"
+	"syscall"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -113,6 +114,24 @@ func isPublicIP(ip net.IP) bool {
 		return false
 	}
 	return true
+}
+
+// blockNonPublicControl is a net.Dialer.Control hook that rejects a connection
+// whose resolved destination is a non-public IP. It runs AFTER DNS resolution
+// with the concrete ip:port, so unlike a pre-dial host check it also defeats
+// DNS-rebinding. Use it on dialers that don't route through safeDialContext
+// (e.g. the TLS dialer), so a user-submitted hostname cannot SSRF-probe an
+// internal/cloud-metadata address.
+func blockNonPublicControl(_, address string, _ syscall.RawConn) error {
+	host, _, err := net.SplitHostPort(address)
+	if err != nil {
+		return fmt.Errorf("split host:port %q: %w", address, err)
+	}
+	ip := net.ParseIP(host)
+	if ip == nil || !isPublicIPFn(ip) {
+		return errBlockedAddress
+	}
+	return nil
 }
 
 const browserUA = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36"

--- a/internal/phishing/enricher/http_test.go
+++ b/internal/phishing/enricher/http_test.go
@@ -125,3 +125,24 @@ func TestIsPublicIP(t *testing.T) {
 		require.Equal(t, tc.want, isPublicIP(net.ParseIP(tc.ip)), tc.ip)
 	}
 }
+
+// TestBlockNonPublicControl exercises the net.Dialer.Control SSRF hook the TLS
+// dialer (GetTLSCert) uses — it must reject loopback/metadata/private resolved
+// IPs and allow public ones, since the dialed host comes from an email URL.
+func TestBlockNonPublicControl(t *testing.T) {
+	t.Parallel()
+	blocked := []string{
+		"127.0.0.1:443", "169.254.169.254:80", "10.0.0.5:443",
+		"192.168.1.1:443", "[::1]:443", "0.0.0.0:443",
+	}
+	for _, addr := range blocked {
+		if err := blockNonPublicControl("tcp", addr, nil); err == nil {
+			t.Errorf("blockNonPublicControl(%q) = nil, want blocked", addr)
+		}
+	}
+	for _, addr := range []string{"8.8.8.8:443", "1.1.1.1:80"} {
+		if err := blockNonPublicControl("tcp", addr, nil); err != nil {
+			t.Errorf("blockNonPublicControl(%q) = %v, want allowed", addr, err)
+		}
+	}
+}

--- a/internal/phishing/enricher/shortener.go
+++ b/internal/phishing/enricher/shortener.go
@@ -37,15 +37,26 @@ func ResolveShortURL(ctx context.Context, rawURL string) (string, error) {
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
+	// SSRF guard: rawURL is a shortener link from an incoming email and the
+	// resolver follows its redirect chain. Route the dial through safeDialContext
+	// (rejects non-public IPs, incl. 169.254.169.254 cloud metadata) and re-validate
+	// every redirect target's scheme, mirroring the FetchHTTP client — otherwise an
+	// attacker short link could redirect into an internal/metadata host.
 	client := &http.Client{
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			if len(via) >= 10 {
 				return http.ErrUseLastResponse
 			}
+			if req.URL == nil || (req.URL.Scheme != "http" && req.URL.Scheme != "https") {
+				return errBlockedAddress
+			}
 			return nil
 		},
-		Transport: &http.Transport{},
-		Timeout:   5 * time.Second,
+		Transport: &http.Transport{
+			DialContext:           safeDialContext,
+			ResponseHeaderTimeout: 5 * time.Second,
+		},
+		Timeout: 5 * time.Second,
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodHead, rawURL, nil)

--- a/internal/phishing/enricher/tls.go
+++ b/internal/phishing/enricher/tls.go
@@ -36,8 +36,13 @@ func GetTLSCert(ctx context.Context, hostname string, port int) TLSResult {
 	dialCtx, cancel := context.WithTimeout(ctx, 2500*time.Millisecond)
 	defer cancel()
 
+	// SSRF guard: hostname comes from a URL in an incoming email. InsecureSkipVerify
+	// is intentional (we want cert data even for expired/self-signed certs), but
+	// without an IP filter that lets an attacker dial internal/cloud-metadata hosts
+	// on :443 to blind-probe the network. Control rejects any non-public resolved IP
+	// before the TCP connect (mirrors safeDialContext; defeats DNS rebinding).
 	dialer := &tls.Dialer{
-		NetDialer: &net.Dialer{},
+		NetDialer: &net.Dialer{Control: blockNonPublicControl},
 		Config: &tls.Config{
 			InsecureSkipVerify: true, //nolint:gosec // intentional: we want cert data even for expired/self-signed
 			ServerName:         hostname,

--- a/internal/phishing/enricher/whois.go
+++ b/internal/phishing/enricher/whois.go
@@ -3,13 +3,32 @@ package enricher
 import (
 	"context"
 	"strings"
-	"sync"
 	"time"
 
+	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/likexian/whois"
 	whoisparser "github.com/likexian/whois-parser"
 	"go.opentelemetry.io/otel/attribute"
 )
+
+const (
+	// whoisCacheMaxEntries bounds the in-process WHOIS cache so attacker-controlled
+	// apex domains (one per email) cannot grow it without limit.
+	whoisCacheMaxEntries = 10_000
+	// whoisSuccessTTL caches a real lookup for a day; whoisNegativeTTL keeps a
+	// single timeout/error from poisoning the entry for the full day when a valid
+	// WHOIS was retrievable moments later.
+	whoisSuccessTTL  = 24 * time.Hour
+	whoisNegativeTTL = 5 * time.Minute
+	// whoisLookupTimeout bounds the underlying whois.Whois call so the lookup
+	// goroutine cannot outlive the caller's budget by the library's ~30s default.
+	whoisLookupTimeout = 5 * time.Second
+)
+
+// whoisClient is a shared client with a bounded timeout (#40: the library's
+// default is ~30s, which lets the lookup goroutine linger long after the 5s
+// caller context is done).
+var whoisClient = whois.NewClient().SetTimeout(whoisLookupTimeout)
 
 // WHOISResult holds parsed WHOIS data for a domain.
 type WHOISResult struct {
@@ -26,27 +45,27 @@ type whoisEntry struct {
 }
 
 type whoisCacheStore struct {
-	mu    sync.RWMutex
-	cache map[string]whoisEntry
+	lru *lru.Cache[string, whoisEntry]
+}
+
+func newWHOISCache() *whoisCacheStore {
+	l, _ := lru.New[string, whoisEntry](whoisCacheMaxEntries)
+	return &whoisCacheStore{lru: l}
 }
 
 func (c *whoisCacheStore) get(domain string) (WHOISResult, bool) {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	e, ok := c.cache[domain]
+	e, ok := c.lru.Get(domain)
 	if !ok || time.Now().After(e.expiresAt) {
 		return WHOISResult{}, false
 	}
 	return e.result, true
 }
 
-func (c *whoisCacheStore) set(domain string, result WHOISResult) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.cache[domain] = whoisEntry{result: result, expiresAt: time.Now().Add(24 * time.Hour)}
+func (c *whoisCacheStore) set(domain string, result WHOISResult, ttl time.Duration) {
+	c.lru.Add(domain, whoisEntry{result: result, expiresAt: time.Now().Add(ttl)})
 }
 
-var globalWHOISCache = &whoisCacheStore{cache: make(map[string]whoisEntry)}
+var globalWHOISCache = newWHOISCache()
 
 // LookupWHOIS performs a WHOIS lookup for domain.
 // Results are cached in-process with a 24h TTL.
@@ -71,7 +90,7 @@ func LookupWHOIS(ctx context.Context, domain string) WHOISResult {
 	}
 	ch := make(chan outcome, 1)
 	go func() {
-		raw, err := whois.Whois(domain)
+		raw, err := whoisClient.Whois(domain)
 		if err != nil {
 			ch <- outcome{err: err}
 			return
@@ -96,14 +115,16 @@ func LookupWHOIS(ctx context.Context, domain string) WHOISResult {
 
 	select {
 	case <-ctx.Done():
-		globalWHOISCache.set(domain, WHOISResult{})
+		// Timeout/cancel: cache the miss only briefly so one slow lookup doesn't
+		// poison the domain for a full day when WHOIS was retrievable.
+		globalWHOISCache.set(domain, WHOISResult{}, whoisNegativeTTL)
 		return WHOISResult{}
 	case res := <-ch:
 		if res.err != nil {
-			globalWHOISCache.set(domain, WHOISResult{})
+			globalWHOISCache.set(domain, WHOISResult{}, whoisNegativeTTL)
 			return WHOISResult{}
 		}
-		globalWHOISCache.set(domain, res.r)
+		globalWHOISCache.set(domain, res.r, whoisSuccessTTL)
 		return res.r
 	}
 }

--- a/internal/phishing/enricher/whois_test.go
+++ b/internal/phishing/enricher/whois_test.go
@@ -23,7 +23,7 @@ func TestLookupWHOIS_GarbageInput(t *testing.T) {
 func TestLookupWHOIS_Cache(t *testing.T) {
 	t.Parallel()
 	fake := WHOISResult{RegistrationDate: "2000-01-01", Registrar: "Test Registrar"}
-	globalWHOISCache.set("cached-whois.test", fake)
+	globalWHOISCache.set("cached-whois.test", fake, whoisSuccessTTL)
 	r := LookupWHOIS(context.Background(), "cached-whois.test")
 	require.Equal(t, fake, r)
 }


### PR DESCRIPTION
From a whole-codebase review pass. URLs/hostnames come from incoming-email links, so the enrichment dials are attacker-influenced.

- ResolveShortURL followed its redirect chain with an unguarded transport (could reach 169.254.169.254 / internal hosts) — now routes through safeDialContext + re-validates redirect schemes.
- GetTLSCert dialed hostname:443 with InsecureSkipVerify and no IP filter (blind internal port-probe) — now a net.Dialer.Control hook rejects non-public resolved IPs (also defeats DNS rebinding).
- The in-process DNS/WHOIS caches were unbounded maps keyed on attacker-controlled hosts — now bounded golang-lru + TTL; a WHOIS timeout caches for 5m (not 24h); the WHOIS client has a 5s timeout so the lookup goroutine can't outlive the caller.

Adds a unit test for the SSRF IP filter; live smoke confirms legit WHOIS/domain-age enrichment still works (no over-blocking).