### PR TITLE
fix(svc-02): preserve NLP/auth/body signals in the MIME walk

### DIFF
--- a/services/svc-02-parser/cmd/parser/headers_test.go
+++ b/services/svc-02-parser/cmd/parser/headers_test.go
@@ -4,7 +4,55 @@ import (
 	"encoding/json"
 	"net/mail"
 	"testing"
+
+	"github.com/saif/cybersiren/services/svc-02-parser/internal/email"
+	contracts "github.com/saif/cybersiren/shared/contracts/kafka"
 )
+
+// newHeaderView must merge EVERY Authentication-Results header before parsing,
+// not just the first/topmost. Real mail carries one AR header per authenticating
+// hop; a DMARC result living in a non-first header was being reported as missing
+// to svc-04 (the old code used Header.Get = first occurrence only).
+func TestNewHeaderViewMergesAllAuthResults(t *testing.T) {
+	parsed := &email.ParsedEmail{
+		Header: mail.Header{
+			"From": []string{"a@b.example"},
+			"Authentication-Results": []string{
+				"mx1.corp.example; spf=pass smtp.mailfrom=acme.example",
+				"mx2.corp.example; dmarc=fail",
+			},
+		},
+	}
+
+	hv := newHeaderView(parsed)
+	if hv.auth["spf"] != "pass" {
+		t.Errorf("auth[spf] = %q, want pass (from first AR header)", hv.auth["spf"])
+	}
+	if hv.auth["dmarc"] != "fail" {
+		t.Errorf("auth[dmarc] = %q, want fail (from second AR header — must be merged, not dropped)", hv.auth["dmarc"])
+	}
+}
+
+// A subject-only (body-less) email must still declare the NLP topic in the plan
+// so svc-07 keeps the NLP score svc-06 produces for the subject; HasBody alone
+// would omit it and silently drop the signal from the fusion verdict.
+func TestBuildAnalysisPlanSubjectOnlyDeclaresNLP(t *testing.T) {
+	parsed := &email.ParsedEmail{Subject: "Your account is locked, call this number"}
+	plan := buildAnalysisPlan(contracts.MessageMeta{}, parsed)
+
+	hasNLP := false
+	for _, s := range plan.ExpectedScores {
+		if s == contracts.TopicScoresNLP {
+			hasNLP = true
+		}
+	}
+	if !hasNLP {
+		t.Errorf("ExpectedScores = %v, want it to include the NLP topic for a subject-only email", plan.ExpectedScores)
+	}
+	if plan.HasBody {
+		t.Error("plan.HasBody = true for a body-less email, want false")
+	}
+}
 
 // A two-hop Received chain: index 0 is the receiving MX (most recent), the last
 // entry is the originating sender. Proves received_chain is populated and that

--- a/services/svc-02-parser/cmd/parser/main.go
+++ b/services/svc-02-parser/cmd/parser/main.go
@@ -495,7 +495,10 @@ func buildAnalysisPlan(meta contracts.MessageMeta, parsed *email.ParsedEmail) co
 	if len(parsed.Attachments) > 0 {
 		expected = append(expected, contracts.TopicScoresAttachment)
 	}
-	if parsed.HasBody() {
+	if parsed.HasText() {
+		// SVC-06 scores Subject+Body and emits scores.nlp whenever either is
+		// present, so a subject-only (body-less) phish must still declare the NLP
+		// topic — otherwise svc-07 drops the produced NLP score from the verdict.
 		expected = append(expected, contracts.TopicScoresNLP)
 	}
 	return contracts.AnalysisPlan{
@@ -562,8 +565,14 @@ func newHeaderView(parsed *email.ParsedEmail) headerView {
 		fromAddr:     fromAddr,
 		fromName:     fromName,
 		senderDomain: domainOf(fromAddr),
-		auth:         email.ParseAuthResults(h.Get("Authentication-Results")),
-		headersJSON:  headerMapJSON(h),
+		// Real mail carries one Authentication-Results header per authenticating
+		// hop (receiving MX, downstream filter, ARC sealer); h.Get returns only
+		// the first/topmost. Merge every AR header before parsing so an SPF/DKIM/
+		// DMARC result living in a non-first header is not reported as missing —
+		// ParseAuthResults splits on ";" and is first-wins per mechanism, so
+		// joining the slice is safe.
+		auth:        email.ParseAuthResults(strings.Join(h["Authentication-Results"], "; ")),
+		headersJSON: headerMapJSON(h),
 	}
 }
 

--- a/services/svc-02-parser/internal/email/parser.go
+++ b/services/svc-02-parser/internal/email/parser.go
@@ -63,6 +63,15 @@ func (p *ParsedEmail) HasBody() bool {
 	return strings.TrimSpace(p.BodyPlain) != "" || strings.TrimSpace(p.BodyHTML) != ""
 }
 
+// HasText reports whether the parsed email carries any text SVC-06 will score —
+// the Subject as well as the body. SVC-06 always runs its classifier over
+// Subject+Body and emits scores.nlp, so the analysis plan must declare the NLP
+// topic whenever there is usable text, even for a subject-only (body-less)
+// message; otherwise the produced NLP score is dropped from the fusion verdict.
+func (p *ParsedEmail) HasText() bool {
+	return p.HasBody() || strings.TrimSpace(p.Subject) != ""
+}
+
 // Parse decodes a full RFC 822 message (raw bytes, already base64-decoded off
 // the wire) into a ParsedEmail. A nil error with empty bodies/URLs is a valid
 // result for a header-only message; Parse only errors when the top-level
@@ -140,6 +149,34 @@ func walkPart(mediaType string, params map[string]string, cte, disposition, cont
 
 	decoded := decodeBody(body, cte)
 
+	// A forwarded email (message/rfc822, e.g. "fwd this suspicious mail" sent as
+	// a .eml attachment) is a full RFC 822 message, not an opaque blob. Recurse
+	// so its inner body and URLs are extracted and scored instead of landing as
+	// an attachment row no URL/NLP scorer ever reads. The maxParts counter (above)
+	// bounds nesting depth. Inner attachments and recipients stay with the
+	// attachment; only the body text + URLs (the phishing signal) are merged up.
+	if mediaType == "message/rfc822" {
+		if inner, err := Parse(decoded); err == nil {
+			if inner.BodyHTML != "" {
+				if pe.htmlBuf.Len() > 0 {
+					pe.htmlBuf.WriteByte('\n')
+				}
+				pe.htmlBuf.WriteString(inner.BodyHTML)
+			}
+			if inner.BodyPlain != "" {
+				if pe.plainBuf.Len() > 0 {
+					pe.plainBuf.WriteByte('\n')
+				}
+				pe.plainBuf.WriteString(inner.BodyPlain)
+			}
+			pe.URLs = append(pe.URLs, inner.URLs...)
+			pe.Attachments = append(pe.Attachments, inner.Attachments...)
+			return
+		}
+		// Fall through to the attachment branches when the inner message cannot be
+		// parsed at all, so a malformed forward is preserved rather than dropped.
+	}
+
 	disp, dispParams := parseDisposition(disposition)
 	filename := dispParams["filename"]
 	if filename == "" {
@@ -157,8 +194,18 @@ func walkPart(mediaType string, params map[string]string, cte, disposition, cont
 
 	switch {
 	case mediaType == "text/html":
+		// Separate consecutive same-type leaves (e.g. multipart/mixed body +
+		// appended footer): Go's multipart reader strips the CRLF before each
+		// boundary, so without a delimiter the trailing token of one part and the
+		// leading token of the next are glued, corrupting URLs and word counts.
+		if pe.htmlBuf.Len() > 0 {
+			pe.htmlBuf.WriteByte('\n')
+		}
 		pe.htmlBuf.Write(decoded)
 	case mediaType == "text/plain", isText:
+		if pe.plainBuf.Len() > 0 {
+			pe.plainBuf.WriteByte('\n')
+		}
 		pe.plainBuf.Write(decoded)
 	default:
 		// Unknown non-text leaf with no disposition: keep as an attachment so

--- a/services/svc-02-parser/internal/email/parser_test.go
+++ b/services/svc-02-parser/internal/email/parser_test.go
@@ -160,6 +160,100 @@ func TestDecodeBodyMalformedBase64ReturnsOriginal(t *testing.T) {
 	}
 }
 
+// TestParseTwoTextPlainPartsSeparated guards the body-concatenation bug: two
+// text/plain leaves in one multipart/mixed container must be joined with a
+// delimiter so a URL ending one part and a token starting the next are not
+// glued into a fabricated URL (and the word count stays correct).
+func TestParseTwoTextPlainPartsSeparated(t *testing.T) {
+	var b strings.Builder
+	b.WriteString("From: a@b.example\r\n")
+	b.WriteString("Subject: hi\r\n")
+	b.WriteString("Content-Type: multipart/mixed; boundary=\"MIX\"\r\n\r\n")
+	b.WriteString("--MIX\r\n")
+	b.WriteString("Content-Type: text/plain; charset=\"utf-8\"\r\n\r\n")
+	b.WriteString("Hello visit https://good.example\r\n")
+	b.WriteString("--MIX\r\n")
+	b.WriteString("Content-Type: text/plain; charset=\"utf-8\"\r\n\r\n")
+	b.WriteString("Unsubscribe here\r\n")
+	b.WriteString("--MIX--\r\n")
+
+	pe, err := Parse([]byte(b.String()))
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	urls := map[string]struct{}{}
+	for _, u := range pe.URLs {
+		urls[u.URL] = struct{}{}
+	}
+	if _, ok := urls["https://good.example"]; !ok {
+		t.Errorf("legit URL not extracted intact, got URLs %+v", pe.URLs)
+	}
+	if _, ok := urls["https://good.exampleUnsubscribe"]; ok {
+		t.Errorf("parts glued into fabricated URL: %+v", pe.URLs)
+	}
+	if got, want := WordCount(pe.BodyPlain), 5; got != want {
+		t.Errorf("WordCount(body) = %d, want %d (body=%q)", got, want, pe.BodyPlain)
+	}
+}
+
+// TestParseForwardedRFC822ExtractsInnerURLs guards that a phishing email
+// forwarded as a message/rfc822 attachment has its inner body and URLs
+// extracted and scored, rather than landing as an opaque attachment blob.
+func TestParseForwardedRFC822ExtractsInnerURLs(t *testing.T) {
+	inner := "From: phish@evil.example\r\n" +
+		"Subject: account locked\r\n\r\n" +
+		"Click http://evil.example/login to unlock.\r\n"
+
+	var b strings.Builder
+	b.WriteString("From: friend@corp.example\r\n")
+	b.WriteString("Subject: Fwd: suspicious\r\n")
+	b.WriteString("Content-Type: multipart/mixed; boundary=\"MIX\"\r\n\r\n")
+	b.WriteString("--MIX\r\n")
+	b.WriteString("Content-Type: text/plain\r\n\r\n")
+	b.WriteString("Is this real?\r\n")
+	b.WriteString("--MIX\r\n")
+	b.WriteString("Content-Type: message/rfc822\r\n\r\n")
+	b.WriteString(inner)
+	b.WriteString("--MIX--\r\n")
+
+	pe, err := Parse([]byte(b.String()))
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	found := false
+	for _, u := range pe.URLs {
+		if u.URL == "http://evil.example/login" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("inner forwarded URL not extracted, got URLs %+v / attachments %d", pe.URLs, len(pe.Attachments))
+	}
+	if !strings.Contains(pe.BodyPlain, "Click") {
+		t.Errorf("inner forwarded body not merged: %q", pe.BodyPlain)
+	}
+}
+
+// TestHasTextSubjectOnly guards that a subject-only (body-less) message still
+// reports HasText() true so the analysis plan declares the NLP topic and the
+// subject-only NLP score is not dropped from the fusion verdict.
+func TestHasTextSubjectOnly(t *testing.T) {
+	subjOnly := &ParsedEmail{Subject: "Your account is locked, call this number"}
+	if subjOnly.HasBody() {
+		t.Error("HasBody() = true for body-less message, want false")
+	}
+	if !subjOnly.HasText() {
+		t.Error("HasText() = false for subject-only message, want true")
+	}
+
+	empty := &ParsedEmail{}
+	if empty.HasText() {
+		t.Error("HasText() = true for empty message, want false")
+	}
+}
+
 func TestParseAuthResults(t *testing.T) {
 	got := ParseAuthResults("mx.example; spf=pass smtp.mailfrom=x; dkim=fail; dmarc=softfail; arc=none")
 	want := map[string]string{"spf": "pass", "dkim": "fail", "dmarc": "softfail", "arc": "none"}


### PR DESCRIPTION
From a whole-codebase review pass.
- Declare scores.nlp on subject-only emails (plan gated on HasText, not HasBody) so a subject-only phish's NLP score isn't dropped by the aggregator.
- Merge all Authentication-Results headers before parsing (a DMARC/SPF result in a non-first AR header was reported missing to svc-04).
- Separate consecutive text body parts with a newline (no more glued tokens/URLs across part boundaries).
- Recurse into message/rfc822 parts so URLs/body inside a forwarded phishing email are extracted, not treated as an opaque attachment.
Each fix ships a red-before/green-after test.