### PR TITLE
fix(svc-03): pin envelope score on confirmed phish; honest persistence metadata

### DIFF
--- a/services/svc-03-url-analysis/cmd/url-pipeline/main.go
+++ b/services/svc-03-url-analysis/cmd/url-pipeline/main.go
@@ -460,6 +460,14 @@ func scanOne(ctx context.Context, raw string, log zerolog.Logger) urlScan {
 
 	out.Label = classifyLabel(mlScore, tiRes, routed, out.MLVerdict)
 
+	// A confirmed phishing verdict (TI RiskScore>=80 or the L2 fusion scorer)
+	// must carry a high numeric envelope score: svc-07 fuses env.Score
+	// numerically and never consults the label, so leaving Score at the raw L1
+	// XGBoost value (which can be low even for a TI/L2-confirmed phish) would
+	// under-weight the strongest URL signal downstream. Mirror the guard
+	// typosquat / brand-in-subdomain branches which already pin Score=100.
+	out.Score, out.Probability = phishingScore(out.Label, out.Score, out.Probability)
+
 	outcome := "fallback_legitimate"
 	switch {
 	case tiRes.Matched && tiRes.RiskScore >= 80:
@@ -500,6 +508,17 @@ func classifyLabel(mlScore int, ti url.TIResult, routed bool, mlVerdict string) 
 	default:
 		return "legitimate"
 	}
+}
+
+// phishingScore raises the numeric envelope score to a confirmed-phishing
+// envelope when the label is "phishing", so a TI/L2-confirmed verdict is not
+// under-weighted downstream (svc-07 fuses on the numeric score, not the label).
+// Non-phishing labels keep the L1-derived score/probability unchanged.
+func phishingScore(label string, score int, prob float64) (int, float64) {
+	if label == "phishing" {
+		return 100, 1.0
+	}
+	return score, prob
 }
 
 // worseLabel returns the more severe of two label values.

--- a/services/svc-03-url-analysis/cmd/url-pipeline/main_test.go
+++ b/services/svc-03-url-analysis/cmd/url-pipeline/main_test.go
@@ -77,6 +77,51 @@ func TestPipelineClassifyLabel(t *testing.T) {
 	}
 }
 
+func TestPhishingScore(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name      string
+		label     string
+		inScore   int
+		inProb    float64
+		wantScore int
+		wantProb  float64
+	}{
+		{
+			// The regression: a TI/L2-confirmed phish whose L1 XGBoost score is
+			// low must still publish a confirmed-phishing envelope score so it is
+			// not under-weighted in svc-07's numeric fusion.
+			name:  "phishing with low L1 score is raised to 100",
+			label: "phishing", inScore: 5, inProb: 0.05,
+			wantScore: 100, wantProb: 1.0,
+		},
+		{
+			name:  "phishing already high is pinned to 100",
+			label: "phishing", inScore: 80, inProb: 0.8,
+			wantScore: 100, wantProb: 1.0,
+		},
+		{
+			name:  "suspicious keeps the L1 score",
+			label: "suspicious", inScore: 55, inProb: 0.55,
+			wantScore: 55, wantProb: 0.55,
+		},
+		{
+			name:  "legitimate keeps the L1 score",
+			label: "legitimate", inScore: 10, inProb: 0.1,
+			wantScore: 10, wantProb: 0.1,
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			gotScore, gotProb := phishingScore(tc.label, tc.inScore, tc.inProb)
+			assert.Equal(t, tc.wantScore, gotScore)
+			assert.InDelta(t, tc.wantProb, gotProb, 1e-9)
+		})
+	}
+}
+
 func TestWorseLabel(t *testing.T) {
 	t.Parallel()
 	cases := []struct {

--- a/services/svc-03-url-analysis/internal/persist/persist.go
+++ b/services/svc-03-url-analysis/internal/persist/persist.go
@@ -113,9 +113,6 @@ type URLResult struct {
 	MLDeployP  float64
 	MLVerdict  string
 	MLCacheHit bool
-
-	// PriorEnrichmentReused is set by Persist when GetPriorEnrichedThreat hit.
-	PriorEnrichmentReused bool
 }
 
 // Email is the per-email persistence input the handler hands to Persist.
@@ -232,12 +229,16 @@ func (p *Persister) persistURL(
 	prior, priorErr := p.store.GetPriorEnrichedThreat(ctx, e.OrgID, u.Domain, threatID)
 	switch {
 	case priorErr == nil:
-		u.PriorEnrichmentReused = true
+		// A prior enriched row exists for this org+domain. The reuse it would
+		// enable (merging the prior WHOIS/geo/ASN/cert columns and skipping the
+		// fresh enrichment) is not yet implemented, so this is recorded as a
+		// hit metric/log only — no enrichment column from `prior` is consumed,
+		// and analysis_metadata must not claim a reuse that did not happen.
 		p.metrics.IncPrior("hit")
 		p.log.Debug().
 			Int64("prior_threat_id", prior.ID).
 			Str("domain", u.Domain).
-			Msg("reusing prior-email enrichment")
+			Msg("prior-email enrichment found (reuse not yet implemented)")
 	case errors.Is(priorErr, repository.ErrNoPriorEnrichment):
 		p.metrics.IncPrior("miss")
 	default:
@@ -376,12 +377,19 @@ func (p *Persister) buildEnrichmentResult(
 // jsonb blob. Returns nil on a marshal error so the COALESCE UPDATE leaves the
 // column unchanged rather than writing malformed JSON.
 func (u *URLResult) analysisMetadata() []byte {
+	// NOTE: prior_enrichment_reused is intentionally NOT persisted here. The
+	// prior-email lookup currently only records a hit metric/log — it does not
+	// actually merge the prior row's WHOIS/geo/ASN/cert columns or skip the
+	// fresh enrichment (that optimization is unimplemented). Writing the flag
+	// into the durable analysis_metadata audit blob would assert a reuse that
+	// never happened. The hit is still observable via the IncPrior("hit")
+	// metric and the debug log in persistURL; surface it in the lineage only
+	// once the reuse it claims is real.
 	meta := map[string]any{
-		"source":                  "svc-03-url-analysis",
-		"label":                   u.Label,
-		"score":                   u.Score,
-		"ti_match":                u.TIMatch,
-		"prior_enrichment_reused": u.PriorEnrichmentReused,
+		"source":   "svc-03-url-analysis",
+		"label":    u.Label,
+		"score":    u.Score,
+		"ti_match": u.TIMatch,
 	}
 	if u.Normalized != "" {
 		meta["normalized_url"] = u.Normalized
@@ -421,13 +429,16 @@ func threatTypeForLabel(label string) string {
 	}
 }
 
-// tiMatchType maps a URL scan to the email_url_ti_matches.match_type CHECK
-// vocabulary ('exact','domain','ip','cidr','hash'). SVC-03's TI feed match is a
-// domain/apex blocklist hit, so 'domain' is the accurate default; an exact-URL
-// indicator is reported as 'exact'.
-func tiMatchType(u *URLResult) string {
-	if u.TIThreatType == "url" {
-		return "exact"
-	}
+// tiMatchType reports the email_url_ti_matches.match_type CHECK value for an
+// SVC-03 TI feed match. SVC-03 only ever matches against the Valkey domain
+// cache, which is populated exclusively from ti_indicators WHERE
+// indicator_type = 'domain' (db/queries/ti_indicators.sql ListActiveDomainIndicators),
+// so every hit on this path is a 'domain' match. The indicator's *kind* is not
+// carried on URLResult — only its threat_type *classification* (phishing /
+// malware / ...), which is never the literal 'url' — so there is nothing to
+// distinguish an exact-URL indicator here and recording 'exact' would be
+// unreachable. Surface 'exact' only once an exact-URL indicator's
+// indicator_type is plumbed through the cache to this layer.
+func tiMatchType(_ *URLResult) string {
 	return "domain"
 }

--- a/services/svc-03-url-analysis/internal/persist/persist_test.go
+++ b/services/svc-03-url-analysis/internal/persist/persist_test.go
@@ -235,7 +235,11 @@ func TestPersist_RejectsMissingOrg(t *testing.T) {
 	}
 }
 
-func TestPersist_PriorEnrichmentReuse_SetsFlagAndMetadata(t *testing.T) {
+func TestPersist_PriorEnrichmentHit_DoesNotClaimReuse(t *testing.T) {
+	// A prior-enrichment lookup hit must NOT persist a prior_enrichment_reused
+	// claim into the durable analysis_metadata audit blob: the reuse it would
+	// assert (merging the prior row's enrichment columns / skipping the fresh
+	// run) is unimplemented, so writing the flag would record a false fact.
 	store := &fakeStore{
 		priorSet: true,
 		priorRow: db.EnrichedThreat{ID: 7, RiskScore: pgtype.Int4{Int32: 80, Valid: true}},
@@ -244,13 +248,12 @@ func TestPersist_PriorEnrichmentReuse_SetsFlagAndMetadata(t *testing.T) {
 	if err := p.Persist(context.Background(), sampleEmail()); err != nil {
 		t.Fatalf("Persist: %v", err)
 	}
-	// analysis_metadata should record the reuse.
 	var meta map[string]any
 	if err := json.Unmarshal(store.enrichCalls[0].Column30, &meta); err != nil {
 		t.Fatalf("unmarshal analysis_metadata: %v", err)
 	}
-	if meta["prior_enrichment_reused"] != true {
-		t.Errorf("prior_enrichment_reused = %v, want true", meta["prior_enrichment_reused"])
+	if _, ok := meta["prior_enrichment_reused"]; ok {
+		t.Errorf("analysis_metadata claims prior_enrichment_reused=%v, want the key absent", meta["prior_enrichment_reused"])
 	}
 }
 
@@ -394,11 +397,14 @@ func TestThreatTypeForLabel(t *testing.T) {
 }
 
 func TestTIMatchType(t *testing.T) {
-	if got := tiMatchType(&URLResult{TIThreatType: "url"}); got != "exact" {
-		t.Errorf("url indicator → %q, want exact", got)
-	}
-	if got := tiMatchType(&URLResult{TIThreatType: "phishing"}); got != "domain" {
-		t.Errorf("domain indicator → %q, want domain", got)
+	// SVC-03 only matches against the domain cache (indicator_type='domain'),
+	// so every TI feed match on this path records match_type='domain'. The
+	// threat_type classification ('phishing'/'malware'/...) does not change
+	// that — it is never the indicator's kind.
+	for _, threatType := range []string{"phishing", "malware", "url", ""} {
+		if got := tiMatchType(&URLResult{TIThreatType: threatType}); got != "domain" {
+			t.Errorf("tiMatchType(threat_type=%q) = %q, want domain", threatType, got)
+		}
 	}
 }
 


### PR DESCRIPTION
From a whole-codebase review pass. Does not change ML scoring.
- Raise the numeric envelope score to 100 for a confirmed TI/L2 phishing verdict (the strongest URL signals no longer leak a low raw L1 score into the aggregator's fusion).
- Stop writing prior_enrichment_reused=true in the audit blob (the reuse optimization is unimplemented) — honest metadata.
- Remove the statically-dead 'exact' tiMatchType branch (compared a threat classification against an indicator_type value).