### PR TITLE
fix(svc-07): close aggregation-state TTL leak + complete-result drop

### DIFF
--- a/services/svc-07-aggregator/internal/aggregator/aggregator.go
+++ b/services/svc-07-aggregator/internal/aggregator/aggregator.go
@@ -133,7 +133,6 @@ func (a *Aggregator) Handle(ctx context.Context, msg kafkaconsumer.Message) erro
 		a.bumpPublishError("hsetnx")
 		return fmt.Errorf("hsetnx __started_at: %w", err)
 	}
-	_ = created // information only — no behavioural change today
 
 	if err := a.store.HSet(ctx, key,
 		field, string(msg.Value),
@@ -154,8 +153,19 @@ func (a *Aggregator) Handle(ctx context.Context, msg kafkaconsumer.Message) erro
 		return fmt.Errorf("partition internal_id: %w", err)
 	}
 	if err := a.store.Expire(ctx, key, a.cfg.HashTTLSecs); err != nil {
-		// TTL refresh failure is not fatal — the existing TTL still
-		// protects the bucket. Log and continue.
+		if created {
+			// First write for this bucket: Expire is the ONLY thing that
+			// ever applies a TTL, and it just failed — the hash was created
+			// TTL-less. Committing now would leak the key in Valkey forever
+			// (the sweeper's no-plan path only Dels the lock and relies on
+			// the hash TTLing out). NACK so the offset is not committed and
+			// the message redelivers, guaranteeing the bucket gets a TTL.
+			a.observeMessage(msg.Topic, "error")
+			a.bumpPublishError("expire")
+			return fmt.Errorf("expire %s on first write: %w", key, err)
+		}
+		// Subsequent write: a prior write already set the TTL, so a refresh
+		// failure is not fatal — the existing TTL still protects the bucket.
 		a.log.Debug().Err(err).Str("key", key).Msg("expire failed; continuing")
 	}
 
@@ -189,6 +199,25 @@ func (a *Aggregator) Handle(ctx context.Context, msg kafkaconsumer.Message) erro
 		return fmt.Errorf("publish lock setnx: %w", err)
 	}
 	if !got {
+		// Lost the publish lock — the sweeper (or another instance) holds it.
+		// If it captured a PARTIAL snapshot before this completing score was
+		// visible, committing now would silently DROP this arrived component:
+		// the sweeper publishes the partial, Dels the hash, and this score is
+		// gone with no re-emit path. Re-read the bucket: while it is still
+		// present AND complete, the holder has not yet published+deleted, so
+		// NACK to redeliver and re-contend for the lock. Once the bucket is
+		// gone (holder published+deleted) the complete result is unrecoverable
+		// (the plan field was deleted with the hash); at that point committing
+		// is correct — at-least-once is satisfied and there is nothing left to
+		// publish for this email_id.
+		if again, gerr := a.store.HGetAll(ctx, key); gerr == nil {
+			if stillComplete, hasPlan := completionStatus(again); hasPlan && stillComplete {
+				a.observeMessage(msg.Topic, "error")
+				a.bumpPublishError("wait_lock_complete")
+				span.SetAttributes(attribute.String("aggregator.status", "wait_lock_retry"))
+				return fmt.Errorf("publish lock held while bucket %s still complete; retrying", key)
+			}
+		}
 		a.observeMessage(msg.Topic, "wait")
 		span.SetAttributes(attribute.String("aggregator.status", "wait_lock"))
 		return nil

--- a/services/svc-07-aggregator/internal/aggregator/aggregator_test.go
+++ b/services/svc-07-aggregator/internal/aggregator/aggregator_test.go
@@ -193,6 +193,95 @@ func TestSweeper_TimeoutEmitsPartial(t *testing.T) {
 	assert.Equal(t, []string{contracts.TopicScoresHeader}, out.MissingComponents)
 }
 
+// On the FIRST write for a bucket, Expire is the only thing that ever sets a
+// TTL. If it fails the handler must NACK (return error) so the offset is not
+// committed and the message redelivers — otherwise the hash leaks TTL-less in
+// Valkey forever (the sweeper's no-plan path only Dels the lock).
+func TestHandle_FirstWriteExpireFailure_NACKs(t *testing.T) {
+	t.Parallel()
+
+	store := newFakeStore()
+	store.errOnExpire = func(string) error { return &fakeError{msg: "valkey hiccup"} }
+	pub := &recorderPublisher{}
+	a := newAgg(t, store, pub)
+	ctx := context.Background()
+
+	emailID, orgID := int64(555), int64(1)
+
+	// First message for this email → bucket created → Expire fails.
+	err := a.Handle(ctx, envelopeMsg(t, contracts.TopicScoresURL, emailID, orgID, 50))
+	require.Error(t, err, "first-write Expire failure must surface so the offset is not committed")
+	assert.Equal(t, 0, pub.count())
+
+	// Once Valkey recovers, the redelivered message succeeds and the bucket
+	// carries a TTL (Expire is invoked without error).
+	store.errOnExpire = nil
+	require.NoError(t, a.Handle(ctx, envelopeMsg(t, contracts.TopicScoresURL, emailID, orgID, 50)))
+}
+
+// A subsequent write (bucket already exists with a TTL) must TOLERATE a
+// transient Expire failure — a refresh failure is not fatal because a prior
+// write already set the TTL.
+func TestHandle_SubsequentWriteExpireFailure_Tolerated(t *testing.T) {
+	t.Parallel()
+
+	store := newFakeStore()
+	pub := &recorderPublisher{}
+	a := newAgg(t, store, pub)
+	ctx := context.Background()
+
+	emailID, orgID := int64(556), int64(1)
+
+	// First write succeeds and sets the TTL.
+	require.NoError(t, a.Handle(ctx, envelopeMsg(t, contracts.TopicScoresURL, emailID, orgID, 50)))
+
+	// Now Expire starts failing — a second write must still commit (nil).
+	store.errOnExpire = func(string) error { return &fakeError{msg: "valkey hiccup"} }
+	require.NoError(t, a.Handle(ctx, headerMsg(t, emailID, orgID, 60)),
+		"refresh Expire failure on an existing bucket must not block the offset")
+}
+
+// When the completing (Nth) score arrives but the publish lock is already held
+// (the sweeper grabbed it mid-emit of a partial), committing would silently
+// DROP this arrived component. While the bucket is still present AND complete
+// the handler must NACK so the message redelivers and re-contends for the lock.
+func TestHandle_CompleteLosesLockRace_NACKsWhileBucketComplete(t *testing.T) {
+	t.Parallel()
+
+	store := newFakeStore()
+	pub := &recorderPublisher{}
+	a := newAgg(t, store, pub)
+	ctx := context.Background()
+
+	emailID, orgID := int64(557), int64(1)
+
+	// Plan + first score arrive normally (incomplete: header still missing).
+	require.NoError(t, a.Handle(ctx, planMsg(t, emailID, orgID,
+		contracts.TopicScoresURL, contracts.TopicScoresHeader,
+	)))
+	require.NoError(t, a.Handle(ctx, envelopeMsg(t, contracts.TopicScoresURL, emailID, orgID, 50)))
+	require.Equal(t, 0, pub.count())
+
+	// Simulate the sweeper (or another instance) already holding the publish
+	// lock for this email_id when the completing header score arrives.
+	got, err := store.SetNXEX(ctx, publishLockKey(orgID, emailID), 180, "1")
+	require.NoError(t, err)
+	require.True(t, got)
+
+	// Completing score arrives — bucket becomes complete but the lock is held.
+	err = a.Handle(ctx, headerMsg(t, emailID, orgID, 60))
+	require.Error(t, err, "complete score that loses the lock race must NACK, not commit-and-drop")
+	assert.Equal(t, 0, pub.count(), "this handler must not publish; the lock holder owns the emit")
+
+	// Once the lock holder finishes (releases the lock and clears the bucket),
+	// the redelivered message hits an empty/no-plan bucket and commits cleanly
+	// without republishing — the at-least-once emit already happened upstream.
+	require.NoError(t, store.Del(ctx, keyForOrgEmail(orgID, emailID)))
+	require.NoError(t, store.Del(ctx, publishLockKey(orgID, emailID)))
+	require.NoError(t, a.Handle(ctx, headerMsg(t, emailID, orgID, 60)))
+	assert.Equal(t, 0, pub.count(), "redelivery after holder cleanup must not double-publish")
+}
+
 func TestPackager_FlatHeaderShapeForwardedRaw(t *testing.T) {
 	t.Parallel()
 

--- a/services/svc-07-aggregator/internal/aggregator/store_fake_test.go
+++ b/services/svc-07-aggregator/internal/aggregator/store_fake_test.go
@@ -20,6 +20,7 @@ type fakeStore struct {
 	// Optional injected errors so tests can simulate transient failure.
 	errOnHSetNX func(key, field string) error
 	errOnSetNX  func(key string) error
+	errOnExpire func(key string) error
 }
 
 func newFakeStore() *fakeStore {
@@ -118,7 +119,15 @@ func (f *fakeStore) HGetAll(_ context.Context, key string) (map[string]string, e
 	return out, nil
 }
 
-func (f *fakeStore) Expire(_ context.Context, _ string, _ int) error { return nil }
+func (f *fakeStore) Expire(_ context.Context, key string, _ int) error {
+	f.mu.Lock()
+	hook := f.errOnExpire
+	f.mu.Unlock()
+	if hook != nil {
+		return hook(key)
+	}
+	return nil
+}
 
 func (f *fakeStore) Del(_ context.Context, key string) error {
 	f.mu.Lock()


### PR DESCRIPTION
From a whole-codebase review pass.
- The bucket's only TTL came from the first-write Expire, whose failure was swallowed — a TTL-less Valkey key leaked forever. Now a first-write Expire failure NACKs so redelivery re-applies the TTL.
- A complete final score that lost the publish-lock race to the sweeper was committed and dropped (downgrading the email to a partial). Now, if the bucket is still present and complete, it NACKs to re-contend for the lock instead of dropping the result (gated to avoid a NACK loop / double-publish).
Adds a fake-store Expire hook + 3 regression tests.