### PR TITLE
fix(svc-08): carry sender_domain/subject/plain_text to campaign fingerprint

### DIFF
--- a/services/svc-04-header-analysis/internal/header/signals.go
+++ b/services/svc-04-header-analysis/internal/header/signals.go
@@ -85,6 +85,7 @@ type HeaderSignals struct {
 // can evolve the wire format independently of the in-memory shape.
 func (s HeaderSignals) AsContract() contractsk.HeaderSignals {
 	out := contractsk.HeaderSignals{
+		SenderDomain:        s.Reputation.SenderDomain,
 		SPFResult:           string(s.Auth.SPF),
 		DKIMResult:          string(s.Auth.DKIM),
 		DMARCResult:         string(s.Auth.DMARC),

--- a/services/svc-04-header-analysis/internal/header/signals_test.go
+++ b/services/svc-04-header-analysis/internal/header/signals_test.go
@@ -1,0 +1,48 @@
+package header
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestAsContract_CarriesSenderDomain guards the cross-service contract that
+// SVC-08's campaign fingerprint depends on: scores.header.signals must carry
+// sender_domain (ARCH-SPEC §8.1). The wire key is asserted explicitly because
+// SVC-08 reads it via the literal JSON path signals.sender_domain.
+func TestAsContract_CarriesSenderDomain(t *testing.T) {
+	in := HeaderSignals{
+		Reputation: ReputationSignals{SenderDomain: "evil.example.com"},
+	}
+
+	out := in.AsContract()
+	if out.SenderDomain != "evil.example.com" {
+		t.Fatalf("AsContract().SenderDomain = %q, want evil.example.com", out.SenderDomain)
+	}
+
+	raw, err := json.Marshal(out)
+	if err != nil {
+		t.Fatalf("marshal HeaderSignals: %v", err)
+	}
+	var probe struct {
+		SenderDomain string `json:"sender_domain"`
+	}
+	if err := json.Unmarshal(raw, &probe); err != nil {
+		t.Fatalf("unmarshal HeaderSignals: %v", err)
+	}
+	if probe.SenderDomain != "evil.example.com" {
+		t.Fatalf("signals.sender_domain on wire = %q, want evil.example.com (SVC-08 reads this key)", probe.SenderDomain)
+	}
+}
+
+// TestAsContract_EmptySenderDomainOmitted confirms the omitempty tag keeps the
+// wire clean when SVC-04 could not derive a sender domain.
+func TestAsContract_EmptySenderDomainOmitted(t *testing.T) {
+	raw, err := json.Marshal(HeaderSignals{}.AsContract())
+	if err != nil {
+		t.Fatalf("marshal HeaderSignals: %v", err)
+	}
+	if got := string(raw); strings.Contains(got, "sender_domain") {
+		t.Fatalf("empty sender_domain should be omitted, got %s", got)
+	}
+}

--- a/services/svc-06-nlp/cmd/nlp-pipeline/main.go
+++ b/services/svc-06-nlp/cmd/nlp-pipeline/main.go
@@ -98,6 +98,14 @@ func handle(ctx context.Context, msg kafkaconsumer.Message, deps svckit.Deps) er
 			"intent_labels":        resp.IntentLabels,
 			"urgency_score":        resp.UrgencyScore,
 			"obfuscation_detected": resp.ObfuscationDetected,
+			// subject + plain_text carry the content dimension SVC-08's
+			// campaign fingerprint and SimHash near-dedup read from
+			// component_details.nlp.details (ARCH-SPEC §8.1). Without them the
+			// fingerprint's subject dimension collapses to SHA256("") and
+			// SimHash never runs. Body is the HTML-stripped clean plain text
+			// (spec field: plain_text).
+			"subject":    input.Subject,
+			"plain_text": input.Body,
 		},
 	}
 

--- a/services/svc-08-decision/internal/campaign/fingerprint_test.go
+++ b/services/svc-08-decision/internal/campaign/fingerprint_test.go
@@ -49,11 +49,19 @@ func TestNormaliseSubject(t *testing.T) {
 	}
 }
 
+// TestExtractInputs_FromComponentDetails feeds the extractor the REAL wire
+// shapes its upstream producers emit — a marshalled ScoresHeaderMessage from
+// svc-04 and a ScoreEnvelope (the legacy scores.nlp shape) from svc-06 — so
+// the test fails if either producer stops carrying the fingerprint dimensions.
+// Building from synthetic maps with hand-invented keys would mask such drift.
 func TestExtractInputs_FromComponentDetails(t *testing.T) {
-	header := mustJSON(map[string]any{
-		"signals": map[string]any{
-			"sender_domain": "evil.example.com",
-			"subject":       "ALERT: invoice 12345",
+	// scores.header as svc-04 emits it: sender_domain lives on signals
+	// (HeaderSignals.SenderDomain), populated from ReputationSignals.
+	header := mustJSON(contracts.ScoresHeaderMessage{
+		EmailID:   1,
+		Component: contracts.ComponentHeader,
+		Signals: contracts.HeaderSignals{
+			SenderDomain: "evil.example.com",
 		},
 	})
 	urlMsg := mustJSON(map[string]any{
@@ -64,9 +72,13 @@ func TestExtractInputs_FromComponentDetails(t *testing.T) {
 			},
 		},
 	})
-	nlp := mustJSON(map[string]any{
-		"details": map[string]any{
+	// scores.nlp as svc-06 emits it: a ScoreEnvelope whose Details map carries
+	// subject + plain_text + intent_labels (nlp-pipeline/main.go).
+	nlp := mustJSON(contracts.ScoreEnvelope{
+		Component: contracts.ComponentNLP,
+		Details: map[string]interface{}{
 			"intent_labels": []string{"phishing", "urgency"},
+			"subject":       "ALERT: invoice 12345",
 			"plain_text":    "click here to verify",
 		},
 	})
@@ -92,9 +104,12 @@ func TestExtractInputs_FromComponentDetails(t *testing.T) {
 }
 
 func TestExtractBody(t *testing.T) {
+	// scores.nlp as svc-06 emits it (ScoreEnvelope.Details), carrying
+	// plain_text + subject.
 	d := contracts.ComponentDetails{
-		NLP: mustJSON(map[string]any{
-			"details": map[string]any{
+		NLP: mustJSON(contracts.ScoreEnvelope{
+			Component: contracts.ComponentNLP,
+			Details: map[string]interface{}{
 				"plain_text": "  Click HERE to confirm  ",
 				"subject":    "Reset password",
 			},

--- a/shared/contracts/kafka/header.go
+++ b/shared/contracts/kafka/header.go
@@ -171,6 +171,12 @@ type FiredRule struct {
 // HeaderSignals is the structured snapshot of every dimension SVC-04
 // inspects, attached to scores.header for downstream explainability.
 type HeaderSignals struct {
+	// SenderDomain is the From: domain SVC-04 derived (ReputationSignals.
+	// SenderDomain). It is the always-present carrier of the sender dimension
+	// for SVC-08's campaign fingerprint (ARCH-SPEC §8.1:
+	// SHA256(sender_domain|url_domain|subject_template|intent)); SVC-08 reads
+	// it via component_details.header.signals.sender_domain.
+	SenderDomain        string  `json:"sender_domain,omitempty"`
 	SPFResult           string  `json:"spf_result"`
 	DKIMResult          string  `json:"dkim_result"`
 	DMARCResult         string  `json:"dmarc_result"`


### PR DESCRIPTION
From a whole-codebase review pass. Cross-service contract change.

svc-08 campaign fingerprinting read sender_domain from scores.header and subject/plain_text from scores.nlp, but no producer emitted them — so the fingerprint lost its sender + subject dimensions and SimHash near-dedup never ran.
- shared/contracts: add sender_domain to scores.header HeaderSignals; subject/plain_text to scores.nlp Details.
- svc-04 emits sender_domain; svc-06 nlp-pipeline emits subject + body.
- fingerprint_test fixtures rewritten to the real contract shapes.

Note: touches shared/contracts + svc-04 — it overlaps batch/2a's contract work, so expect a trivial merge reconciliation if both land.