### PR TITLE
fix(ti): reactivate re-seen indicators; widen domain cache TTL; drop dead hash cache

### DIFF
--- a/db/queries/ti_indicators.sql
+++ b/db/queries/ti_indicators.sql
@@ -1,7 +1,9 @@
 -- name: UpsertTIIndicator :one
 -- Upserts a single TI indicator. Use with batch loop from Go for chunk processing.
 -- ON CONFLICT (feed_id, indicator_type, indicator_value):
---   update last_seen, merge threat_tags (distinct), GREATEST risk_score.
+--   update last_seen, merge threat_tags (distinct), GREATEST risk_score,
+--   and reactivate (is_active = TRUE) so an indicator that fell out of the feed
+--   and was deactivated comes back the moment it reappears.
 --   Do NOT overwrite first_seen or created_at.
 -- Returns TRUE when the row was newly inserted, FALSE when an existing row was updated.
 INSERT INTO ti_indicators (
@@ -51,7 +53,8 @@ SET
             ORDER BY tag
         )
     ),
-    risk_score = GREATEST(ti_indicators.risk_score, EXCLUDED.risk_score)
+    risk_score = GREATEST(ti_indicators.risk_score, EXCLUDED.risk_score),
+    is_active = TRUE
 RETURNING (xmax = 0) AS inserted;
 
 -- name: DeactivateStaleFeedIndicators :execrows

--- a/db/sqlc/ti_indicators.sql.go
+++ b/db/sqlc/ti_indicators.sql.go
@@ -129,7 +129,8 @@ SET
             ORDER BY tag
         )
     ),
-    risk_score = GREATEST(ti_indicators.risk_score, EXCLUDED.risk_score)
+    risk_score = GREATEST(ti_indicators.risk_score, EXCLUDED.risk_score),
+    is_active = TRUE
 RETURNING (xmax = 0) AS inserted
 `
 
@@ -153,7 +154,9 @@ type UpsertTIIndicatorParams struct {
 // Upserts a single TI indicator. Use with batch loop from Go for chunk processing.
 // ON CONFLICT (feed_id, indicator_type, indicator_value):
 //
-//	update last_seen, merge threat_tags (distinct), GREATEST risk_score.
+//	update last_seen, merge threat_tags (distinct), GREATEST risk_score,
+//	and reactivate (is_active = TRUE) so an indicator that fell out of the feed
+//	and was deactivated comes back the moment it reappears.
 //	Do NOT overwrite first_seen or created_at.
 //
 // Returns TRUE when the row was newly inserted, FALSE when an existing row was updated.

--- a/services/svc-03-url-analysis/internal/url/ti_checker_test.go
+++ b/services/svc-03-url-analysis/internal/url/ti_checker_test.go
@@ -19,7 +19,6 @@ type fakeTICache struct {
 }
 
 func (f *fakeTICache) RefreshDomainCache(_ context.Context) error { return nil }
-func (f *fakeTICache) RefreshHashCache(_ context.Context) error   { return nil }
 
 func (f *fakeTICache) IsBlocklisted(_ context.Context, _ string) (bool, int, string, error) {
 	return f.lookup.Blocked, f.lookup.RiskScore, f.lookup.ThreatType, f.err

--- a/services/svc-11-ti-sync/cmd/ti-sync/main.go
+++ b/services/svc-11-ti-sync/cmd/ti-sync/main.go
@@ -83,7 +83,7 @@ func main() {
 	defer rdb.Close()
 
 	repo := repository.NewTIRepository(pool, log, reg)
-	cache := sharedvalkey.NewTICache(rdb, repo, log, reg, int64(cfg.TIHashCacheTTLSeconds))
+	cache := sharedvalkey.NewTICache(rdb, repo, log, reg, int64(cfg.TIDomainCacheTTLSeconds))
 
 	enabledFeeds, err := db.New(pool).GetEnabledFeeds(ctx)
 	if err != nil {

--- a/services/svc-11-ti-sync/internal/ti/sync.go
+++ b/services/svc-11-ti-sync/internal/ti/sync.go
@@ -242,12 +242,6 @@ func (r *Runner) SyncAll(ctx context.Context) (err error) {
 		r.log.Error().Err(cacheErr).Msg("failed to refresh TI domain cache")
 	}
 
-	if r.cache != nil {
-		if cacheErr := r.cache.RefreshHashCache(ctx); cacheErr != nil {
-			r.log.Error().Err(cacheErr).Msg("failed to refresh TI hash cache")
-		}
-	}
-
 	if refreshErr := r.repo.RefreshAllMaterializedViews(ctx); refreshErr != nil {
 		r.log.Error().Err(refreshErr).Msg("failed to refresh materialized views")
 		return fmt.Errorf("refresh materialized views: %w", refreshErr)

--- a/services/svc-11-ti-sync/tests/runner_test.go
+++ b/services/svc-11-ti-sync/tests/runner_test.go
@@ -28,7 +28,6 @@ func TestRunnerSyncAll_AllFeedsSucceed(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.True(t, cache.refreshCalled)
-	assert.True(t, cache.hashRefreshCalled)
 	assert.True(t, repo.refreshMVCalled)
 	assert.Len(t, repo.upsertCalls, 2)
 	assert.ElementsMatch(t, []int64{1, 2}, repo.upsertCalls)
@@ -51,7 +50,6 @@ func TestRunnerSyncAll_OneFeedFetchFailsPartialSuccess(t *testing.T) {
 	assert.Equal(t, int64(2), repo.upsertCalls[0])
 	assert.ElementsMatch(t, []int64{1, 2}, repo.updateFetchedCalls)
 	assert.True(t, cache.refreshCalled)
-	assert.True(t, cache.hashRefreshCalled)
 	assert.True(t, repo.refreshMVCalled)
 }
 
@@ -93,7 +91,6 @@ func TestRunnerSyncAll_UpsertErrorOnOneFeedContinues(t *testing.T) {
 	assert.ElementsMatch(t, []int64{1, 2}, repo.upsertCalls)
 	assert.ElementsMatch(t, []int64{1, 2}, repo.updateFetchedCalls)
 	assert.True(t, cache.refreshCalled)
-	assert.True(t, cache.hashRefreshCalled)
 	assert.True(t, repo.refreshMVCalled)
 }
 
@@ -109,7 +106,6 @@ func TestRunnerSyncAll_CacheRefreshErrorIsBestEffort(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.True(t, cache.refreshCalled)
-	assert.True(t, cache.hashRefreshCalled)
 	assert.True(t, repo.refreshMVCalled)
 }
 
@@ -127,7 +123,6 @@ func TestRunnerSyncAll_MaterializedViewRefreshErrorReturnsError(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorIs(t, err, mvErr)
 	assert.True(t, cache.refreshCalled)
-	assert.True(t, cache.hashRefreshCalled)
 	assert.True(t, repo.refreshMVCalled)
 }
 
@@ -152,7 +147,7 @@ func TestRunnerSyncAll_UpdateLastFetchedCalledForEveryFeed(t *testing.T) {
 	assert.ElementsMatch(t, []int64{1, 2, 3}, repo.updateFetchedCalls)
 }
 
-func TestRunnerSyncAll_HashIndicatorsBypassTIUpsertAndRefreshHashCache(t *testing.T) {
+func TestRunnerSyncAll_HashIndicatorsBypassTIUpsertAndPersistToHashLibrary(t *testing.T) {
 	repo := &mockRepo{}
 	cache := &mockCache{}
 	feeds := []ti.Feed{
@@ -177,13 +172,12 @@ func TestRunnerSyncAll_HashIndicatorsBypassTIUpsertAndRefreshHashCache(t *testin
 	require.Len(t, repo.malwareHashBatches[0], 1)
 	assert.Equal(t, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", repo.malwareHashBatches[0][0].SHA256)
 	assert.True(t, cache.refreshCalled)
-	assert.True(t, cache.hashRefreshCalled)
 	assert.True(t, repo.refreshMVCalled)
 }
 
-func TestRunnerSyncAll_HashUpsertAndHashCacheErrorsAreBestEffort(t *testing.T) {
+func TestRunnerSyncAll_HashOnlyFeedUpsertErrorIsFatal(t *testing.T) {
 	repo := &mockRepo{malwareHashErr: errors.New("hash upsert failed")}
-	cache := &mockCache{hashRefreshErr: errors.New("hash cache unavailable")}
+	cache := &mockCache{}
 	feeds := []ti.Feed{
 		&mockFeed{
 			name:       "malwarebazaar",
@@ -206,7 +200,6 @@ func TestRunnerSyncAll_HashUpsertAndHashCacheErrorsAreBestEffort(t *testing.T) {
 	assert.Empty(t, repo.deactivateCalls)
 	// Cache and MV refresh are skipped when all feeds fail.
 	assert.False(t, cache.refreshCalled)
-	assert.False(t, cache.hashRefreshCalled)
 	assert.False(t, repo.refreshMVCalled)
 }
 
@@ -234,7 +227,6 @@ func TestRunnerSyncAll_MixedFeedHashUpsertFailureIsBestEffort(t *testing.T) {
 	assert.Len(t, repo.upsertIndicatorBatches[0], 1, "only non-hash indicator should be upserted")
 	assert.Len(t, repo.malwareHashBatches, 1)
 	assert.True(t, cache.refreshCalled)
-	assert.True(t, cache.hashRefreshCalled)
 	assert.True(t, repo.refreshMVCalled)
 }
 
@@ -256,7 +248,6 @@ func TestRunnerSyncAll_HashOnlyFeedCallsDeactivateStaleIndicators(t *testing.T) 
 	// Hash-only feeds should still call DeactivateStaleIndicators.
 	require.Len(t, repo.deactivateCalls, 1)
 	assert.Equal(t, int64(8), repo.deactivateCalls[0])
-	assert.True(t, cache.hashRefreshCalled)
 }
 
 func TestRunnerSyncAll_ContextCancellationSkipsRemainingFeeds(t *testing.T) {
@@ -397,20 +388,13 @@ func (m *mockRepo) RefreshAllMaterializedViews(_ context.Context) error {
 }
 
 type mockCache struct {
-	refreshCalled     bool
-	refreshErr        error
-	hashRefreshCalled bool
-	hashRefreshErr    error
+	refreshCalled bool
+	refreshErr    error
 }
 
 func (m *mockCache) RefreshDomainCache(_ context.Context) error {
 	m.refreshCalled = true
 	return m.refreshErr
-}
-
-func (m *mockCache) RefreshHashCache(_ context.Context) error {
-	m.hashRefreshCalled = true
-	return m.hashRefreshErr
 }
 
 func (m *mockCache) IsBlocklisted(_ context.Context, _ string) (bool, int, string, error) {

--- a/shared/config/config.go
+++ b/shared/config/config.go
@@ -34,7 +34,7 @@ type Config struct {
 	FeedOpenPhishAPIKey     string `koanf:"feed_openphish_api_key"`
 	FeedMalwareBazaarAPIKey string `koanf:"feed_malwarebazaar_api_key"`
 	SyncIntervalSeconds     int    `koanf:"sync_interval_seconds"`
-	TIHashCacheTTLSeconds   int    `koanf:"ti_hash_cache_ttl_seconds"`
+	TIDomainCacheTTLSeconds int    `koanf:"ti_domain_cache_ttl_seconds"`
 
 	Valkey     ValkeyConfig     `koanf:"valkey"`
 	Kafka      KafkaConfig      `koanf:"kafka"`
@@ -313,10 +313,10 @@ func Load() (*Config, error) {
 			Level:  "info",
 			Pretty: false,
 		},
-		JaegerEndpoint:        "",
-		MetricsPort:           9090,
-		SyncIntervalSeconds:   3600,
-		TIHashCacheTTLSeconds: 7200,
+		JaegerEndpoint:          "",
+		MetricsPort:             9090,
+		SyncIntervalSeconds:     3600,
+		TIDomainCacheTTLSeconds: 7200,
 		Valkey: ValkeyConfig{
 			Addr: "localhost:6379",
 			DB:   0,
@@ -616,13 +616,16 @@ func (c *Config) Validate() error {
 	if c.SyncIntervalSeconds <= 30 {
 		return fmt.Errorf("sync_interval_seconds must be greater than 30, got %d", c.SyncIntervalSeconds)
 	}
-	if c.TIHashCacheTTLSeconds <= 0 {
-		return fmt.Errorf("ti_hash_cache_ttl_seconds must be greater than 0, got %d", c.TIHashCacheTTLSeconds)
+	if c.TIDomainCacheTTLSeconds <= 0 {
+		return fmt.Errorf("ti_domain_cache_ttl_seconds must be greater than 0, got %d", c.TIDomainCacheTTLSeconds)
 	}
-	if c.TIHashCacheTTLSeconds < c.SyncIntervalSeconds {
+	// The TI domain cache is rewritten at the end of each sync cycle, so its TTL
+	// must outlive the interval (plus feed-fetch time) or blocklisted domains
+	// expire from the cache between syncs and svc-03 lookups miss them.
+	if c.TIDomainCacheTTLSeconds < c.SyncIntervalSeconds {
 		return fmt.Errorf(
-			"ti_hash_cache_ttl_seconds (%d) should be >= sync_interval_seconds (%d) to avoid cache expiry between syncs",
-			c.TIHashCacheTTLSeconds, c.SyncIntervalSeconds,
+			"ti_domain_cache_ttl_seconds (%d) should be >= sync_interval_seconds (%d) to avoid cache expiry between syncs",
+			c.TIDomainCacheTTLSeconds, c.SyncIntervalSeconds,
 		)
 	}
 

--- a/shared/config/config_test.go
+++ b/shared/config/config_test.go
@@ -46,10 +46,10 @@ func validConfig() *Config {
 			Level:  "info",
 			Pretty: false,
 		},
-		MetricsPort:           9090,
-		FeedPhishTankAPIKey:   "test-phishtank-key",
-		SyncIntervalSeconds:   3600,
-		TIHashCacheTTLSeconds: 7200,
+		MetricsPort:             9090,
+		FeedPhishTankAPIKey:     "test-phishtank-key",
+		SyncIntervalSeconds:     3600,
+		TIDomainCacheTTLSeconds: 7200,
 		Enrichment: EnrichmentConfig{
 			WorkerCount: 10,
 			JobTimeout:  30 * time.Second,
@@ -295,6 +295,9 @@ func TestValidate_InvalidValues(t *testing.T) {
 		{"enrichment whois timeout 0", func(c *Config) { c.Enrichment.WHOIS.Timeout = 0 }, "enrichment.whois.timeout must be greater than 0"},
 		{"enrichment urlscan timeout 0", func(c *Config) { c.Enrichment.URLScan.Timeout = 0 }, "enrichment.urlscan.timeout must be greater than 0"},
 		{"enrichment screenshot timeout 0", func(c *Config) { c.Enrichment.Screenshot.Timeout = 0 }, "enrichment.screenshot.timeout must be greater than 0"},
+		// ti domain cache TTL — must be positive and have headroom over the sync interval.
+		{"ti domain cache ttl 0", func(c *Config) { c.TIDomainCacheTTLSeconds = 0 }, "ti_domain_cache_ttl_seconds must be greater than 0"},
+		{"ti domain cache ttl below interval", func(c *Config) { c.TIDomainCacheTTLSeconds = 1800 }, "ti_domain_cache_ttl_seconds (1800) should be >= sync_interval_seconds"},
 	}
 
 	for _, tt := range tests {
@@ -358,6 +361,14 @@ func TestLoad_Defaults(t *testing.T) {
 	}
 	if cfg.Embedding.Dimension != 1536 {
 		t.Errorf("default Embedding.Dimension = %d, want %d", cfg.Embedding.Dimension, 1536)
+	}
+	// Domain cache TTL defaults to twice the sync interval so blocklisted domains
+	// never expire from the cache in the window between two refreshes.
+	if cfg.TIDomainCacheTTLSeconds != 7200 {
+		t.Errorf("default TIDomainCacheTTLSeconds = %d, want %d", cfg.TIDomainCacheTTLSeconds, 7200)
+	}
+	if cfg.SyncIntervalSeconds != 3600 {
+		t.Errorf("default SyncIntervalSeconds = %d, want %d", cfg.SyncIntervalSeconds, 3600)
 	}
 }
 

--- a/shared/postgres/repository/ti_reactivation_integration_test.go
+++ b/shared/postgres/repository/ti_reactivation_integration_test.go
@@ -1,0 +1,131 @@
+//go:build integration
+
+// TI indicator reactivation regression test (finding #13).
+//
+// Guards the UpsertTIIndicator ON CONFLICT ... DO UPDATE path: a re-seen
+// indicator must be reactivated (is_active = TRUE), otherwise an indicator that
+// briefly dropped out of a feed and was deactivated by DeactivateStaleFeedIndicators
+// stays invisible to detection forever.
+//
+// Requires a migrated DB reachable via TI_DATABASE_URL (any role with write
+// access to feeds/ti_indicators — RLS is not exercised here). The test skips
+// when TI_DATABASE_URL is unset so it never runs against the wrong DB by accident.
+package repository
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/rs/zerolog"
+
+	db "github.com/saif/cybersiren/db/sqlc"
+)
+
+func tiPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	dsn := os.Getenv("TI_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("set TI_DATABASE_URL to a migrated DB DSN for TI reactivation tests")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("ti pool: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	return pool
+}
+
+// TestUpsertTIIndicator_ReactivatesDeactivatedIndicator drives the three-cycle
+// flap scenario through the real query: insert active, let it go stale and be
+// deactivated, then re-seen → it must come back active.
+func TestUpsertTIIndicator_ReactivatesDeactivatedIndicator(t *testing.T) {
+	pool := tiPool(t)
+	ctx := context.Background()
+
+	// Seed a throwaway feed; ti_indicators.feed_id REFERENCES feeds(id).
+	var feedID int64
+	err := pool.QueryRow(ctx, `
+INSERT INTO feeds (name, feed_type, enabled)
+VALUES ($1, 'threat_intel', TRUE)
+RETURNING id`, "ti-reactivation-test-"+time.Now().Format("150405.000000")).Scan(&feedID)
+	if err != nil {
+		t.Fatalf("seed feed: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(ctx, `DELETE FROM ti_indicators WHERE feed_id = $1`, feedID)
+		_, _ = pool.Exec(ctx, `DELETE FROM feeds WHERE id = $1`, feedID)
+	})
+
+	repo := NewTIRepository(pool, zerolog.Nop(), nil)
+
+	const flapping = "flapping.example.com"
+	const stable = "stable.example.com"
+
+	domainIndicator := func(value string) TIIndicator {
+		return TIIndicator{
+			FeedID:         feedID,
+			FeedName:       "ti-reactivation-test",
+			IndicatorType:  db.TiIndicatorTypeDomain,
+			IndicatorValue: value,
+			ThreatType:     "phishing",
+			ThreatTags:     []string{"test"},
+			RiskScore:      80,
+			SourceID:       "test",
+		}
+	}
+
+	isActive := func(value string) bool {
+		var active bool
+		qErr := pool.QueryRow(ctx, `
+SELECT is_active FROM ti_indicators
+WHERE feed_id = $1 AND indicator_type = 'domain' AND indicator_value = $2`, feedID, value).Scan(&active)
+		if qErr != nil {
+			t.Fatalf("query is_active for %q: %v", value, qErr)
+		}
+		return active
+	}
+
+	// Cycle 1: both domains present → both active.
+	if _, err := repo.BulkUpsertIndicators(ctx, []TIIndicator{
+		domainIndicator(flapping),
+		domainIndicator(stable),
+	}); err != nil {
+		t.Fatalf("cycle 1 upsert: %v", err)
+	}
+	if !isActive(flapping) {
+		t.Fatalf("cycle 1: flapping domain should be active")
+	}
+
+	// Allow the next cycle's startedAt to strictly exceed cycle 1's last_seen
+	// so the omitted row is older than the deactivation cutoff.
+	time.Sleep(10 * time.Millisecond)
+
+	// Cycle 2: feed omits the flapping domain (but still has the stable one, so
+	// the batch is non-empty and deactivation runs for this feed) → flapping is
+	// now stale and gets deactivated.
+	if _, err := repo.BulkUpsertIndicators(ctx, []TIIndicator{
+		domainIndicator(stable),
+	}); err != nil {
+		t.Fatalf("cycle 2 upsert: %v", err)
+	}
+	if isActive(flapping) {
+		t.Fatalf("cycle 2: flapping domain should have been deactivated")
+	}
+
+	// Cycle 3: the flapping domain reappears → ON CONFLICT DO UPDATE must
+	// reactivate it. Before the fix it stayed is_active = FALSE forever.
+	if _, err := repo.BulkUpsertIndicators(ctx, []TIIndicator{
+		domainIndicator(flapping),
+		domainIndicator(stable),
+	}); err != nil {
+		t.Fatalf("cycle 3 upsert: %v", err)
+	}
+	if !isActive(flapping) {
+		t.Fatalf("cycle 3: re-seen flapping domain must be reactivated (is_active = TRUE)")
+	}
+}

--- a/shared/valkey/ti_cache.go
+++ b/shared/valkey/ti_cache.go
@@ -20,10 +20,12 @@ import (
 )
 
 const (
-	tiDomainTTLSeconds    int64 = 3600
-	tiDomainRefreshBatch        = 200
-	tiHashRefreshBatch          = 200
-	tiHashCacheTypeSHA256       = "sha256"
+	// tiDomainTTLDefaultSeconds is used when NewTICache is given a non-positive
+	// TTL. It is twice the default sync interval so domain keys survive the gap
+	// between the end of one refresh and the next (see config.Validate, which
+	// guards ti_domain_cache_ttl_seconds >= sync_interval_seconds).
+	tiDomainTTLDefaultSeconds int64 = 7200
+	tiDomainRefreshBatch            = 200
 )
 
 var tiCacheTracer = tracing.Tracer("shared/valkey/ti_cache")
@@ -42,8 +44,6 @@ type DomainLookup struct {
 // TICache provides read and write access to the threat-intelligence caches.
 type TICache interface {
 	RefreshDomainCache(ctx context.Context) error
-	// RefreshHashCache rebuilds the ti_hash:{sha256} keys in Valkey from the attachment library.
-	RefreshHashCache(ctx context.Context) error
 	// IsBlocklisted checks whether the given domain appears in the TI domain cache.
 	IsBlocklisted(ctx context.Context, domain string) (bool, int, string, error)
 	// LookupDomain is the richer variant of IsBlocklisted: it returns the same
@@ -53,10 +53,10 @@ type TICache interface {
 }
 
 type ValkeyTICache struct {
-	client         valkeygo.Client
-	repo           repository.TIRepository
-	log            zerolog.Logger
-	hashTTLSeconds int64
+	client           valkeygo.Client
+	repo             repository.TIRepository
+	log              zerolog.Logger
+	domainTTLSeconds int64
 
 	refreshKeysTotal *prometheus.GaugeVec
 	refreshDuration  *prometheus.HistogramVec
@@ -70,7 +70,7 @@ func NewTICache(
 	repo repository.TIRepository,
 	log zerolog.Logger,
 	metrics *prometheus.Registry,
-	hashTTLSeconds int64,
+	domainTTLSeconds int64,
 ) *ValkeyTICache {
 	if metrics == nil {
 		metrics = prometheus.NewRegistry()
@@ -92,15 +92,15 @@ func NewTICache(
 		Help: "Total blocklist lookups against the TI domain cache.",
 	}, []string{"hit"}))
 
-	if hashTTLSeconds <= 0 {
-		hashTTLSeconds = 7200
+	if domainTTLSeconds <= 0 {
+		domainTTLSeconds = tiDomainTTLDefaultSeconds
 	}
 
 	return &ValkeyTICache{
 		client:           client,
 		repo:             repo,
 		log:              log,
-		hashTTLSeconds:   hashTTLSeconds,
+		domainTTLSeconds: domainTTLSeconds,
 		refreshKeysTotal: refreshKeysTotal,
 		refreshDuration:  refreshDuration,
 		blocklistLookups: blocklistLookups,
@@ -167,7 +167,7 @@ func (c *ValkeyTICache) RefreshDomainCache(ctx context.Context) (err error) {
 				FieldValue("risk_score", strconv.Itoa(indicator.RiskScore)).
 				FieldValue("threat_type", indicator.ThreatType).
 				Build()
-			expireCmd := c.client.B().Expire().Key(key).Seconds(tiDomainTTLSeconds).Build()
+			expireCmd := c.client.B().Expire().Key(key).Seconds(c.domainTTLSeconds).Build()
 
 			cmds = append(cmds, hsetCmd, expireCmd)
 			metas = append(metas,
@@ -235,144 +235,6 @@ func (c *ValkeyTICache) RefreshDomainCache(ctx context.Context) (err error) {
 	}
 
 	c.setRefreshKeys("domain", keysWritten)
-
-	return nil
-}
-
-// RefreshHashCache rebuilds the ti_hash:{sha256} keys in Valkey from the attachment library.
-func (c *ValkeyTICache) RefreshHashCache(ctx context.Context) (err error) {
-	startedAt := time.Now()
-	keysWritten := 0
-	commandErrors := 0
-
-	ctx, span := tiCacheTracer.Start(ctx, "ti_cache.RefreshHashCache")
-	defer func() {
-		duration := time.Since(startedAt)
-		span.SetAttributes(
-			attribute.Int("keys_written", keysWritten),
-			attribute.Int("command_errors", commandErrors),
-			attribute.Float64("duration_seconds", duration.Seconds()),
-		)
-
-		c.observeRefreshDuration("hash", duration)
-
-		if err != nil {
-			span.RecordError(err)
-			span.SetStatus(codes.Error, err.Error())
-		}
-		span.End()
-	}()
-
-	if err = c.ensureReady(); err != nil {
-		return err
-	}
-
-	hashes, listErr := c.repo.ListMaliciousHashes(ctx)
-	if listErr != nil {
-		return fmt.Errorf("list malicious hashes: %w", listErr)
-	}
-
-	for start := 0; start < len(hashes); start += tiHashRefreshBatch {
-		end := start + tiHashRefreshBatch
-		if end > len(hashes) {
-			end = len(hashes)
-		}
-
-		chunk := hashes[start:end]
-		cmds := make([]valkeygo.Completed, 0, len(chunk)*2)
-		metas := make([]cacheCommandMeta, 0, len(chunk)*2)
-		keyStates := make([]cacheKeyState, 0, len(chunk))
-
-		for _, h := range chunk {
-			sha := strings.TrimSpace(h.SHA256)
-			if sha == "" {
-				c.log.Warn().Int64("id", h.ID).Msg("skipping malicious hash with empty sha256")
-				continue
-			}
-
-			key := fmt.Sprintf("ti_hash:{%s}", strings.ToLower(sha))
-			tags := strings.Join(h.ThreatTags, ",")
-			updatedAt := ""
-			if !h.UpdatedAt.IsZero() {
-				updatedAt = h.UpdatedAt.UTC().Format(time.RFC3339)
-			}
-
-			hsetCmd := c.client.B().Hset().
-				Key(key).
-				FieldValue().
-				FieldValue("type", tiHashCacheTypeSHA256).
-				FieldValue("risk_score", strconv.Itoa(h.RiskScore)).
-				FieldValue("tags", tags).
-				FieldValue("updated_at", updatedAt).
-				Build()
-			expireCmd := c.client.B().Expire().Key(key).Seconds(c.hashTTLSeconds).Build()
-
-			cmds = append(cmds, hsetCmd, expireCmd)
-			metas = append(metas,
-				cacheCommandMeta{Key: key, Command: "HSET"},
-				cacheCommandMeta{Key: key, Command: "EXPIRE"},
-			)
-			keyStates = append(keyStates, cacheKeyState{})
-		}
-
-		if len(cmds) == 0 {
-			continue
-		}
-
-		results := c.client.DoMulti(ctx, cmds...)
-		if len(results) != len(metas) {
-			c.log.Error().
-				Int("cmd_count", len(metas)).
-				Int("result_count", len(results)).
-				Msg("valkey DoMulti returned unexpected result count")
-		}
-
-		limit := len(results)
-		if limit > len(metas) {
-			limit = len(metas)
-		}
-
-		for i := 0; i < limit; i++ {
-			resultErr := results[i].Error()
-			if resultErr != nil {
-				commandErrors++
-				meta := metas[i]
-				c.log.Error().
-					Err(resultErr).
-					Str("key", meta.Key).
-					Str("command", meta.Command).
-					Msg("failed TI hash cache command")
-				continue
-			}
-
-			keyIndex := i / 2
-			if keyIndex >= len(keyStates) {
-				continue
-			}
-			if i%2 == 0 {
-				keyStates[keyIndex].HSetOK = true
-			} else {
-				keyStates[keyIndex].ExpireOK = true
-			}
-		}
-
-		for i := limit; i < len(metas); i++ {
-			commandErrors++
-			meta := metas[i]
-			c.log.Error().
-				Str("key", meta.Key).
-				Str("command", meta.Command).
-				Msg("missing TI hash cache command result")
-		}
-
-		for _, keyState := range keyStates {
-			if keyState.HSetOK && keyState.ExpireOK {
-				keysWritten++
-			}
-		}
-	}
-
-	c.setRefreshKeys("hash", keysWritten)
 
 	return nil
 }


### PR DESCRIPTION
From a whole-codebase review pass.
- UpsertTIIndicator never reset is_active=TRUE, so a deactivated indicator that reappears in a feed stayed permanently inactive — now reactivated (sqlc regenerated).
- The domain cache TTL (3600s) equalled the sync interval but refresh runs at cycle end, so keys expired before the next write (detection gap) — now a configurable TTL defaulting to 2x interval.
- Remove the dead ti_hash:{sha256} write path (no consumer ever read it; svc-05 reads attachment verdicts from Postgres).