### PR TITLE
fix(sidecars): harden HTTP input handling; apply tuned NLP threshold

### DIFF
--- a/fusion_export/scripts/serve.py
+++ b/fusion_export/scripts/serve.py
@@ -366,6 +366,18 @@ class Scorer:
 
 _scorer: Scorer | None = None
 
+# Hard cap on the request body we are willing to buffer. The per-route item
+# guards (max 500 URLs / requests) only fire after the body is parsed, so this
+# bound is what actually protects the process from a memory-exhaustion DoS.
+_MAX_BODY_BYTES = 8 * 1024 * 1024  # 8 MiB
+
+
+class _BodyTooLargeSentinel:
+    """Marker returned by _read_json when Content-Length exceeds the cap."""
+
+
+_BodyTooLarge = _BodyTooLargeSentinel()
+
 
 class Handler(BaseHTTPRequestHandler):
     def log_message(self, format, *args):
@@ -380,8 +392,17 @@ class Handler(BaseHTTPRequestHandler):
         self.wfile.write(body)
 
     def _read_json(self) -> Any:
-        length = int(self.headers.get("Content-Length", 0))
-        return json.loads(self.rfile.read(length))
+        # Cap the declared body size before reading so a giant (or
+        # slow-trickled) payload can't exhaust process memory ahead of the
+        # downstream item-count guards. Signalled to the caller via the
+        # sentinel _BodyTooLarge so the dispatcher can reply 413.
+        try:
+            length = int(self.headers.get("Content-Length", 0))
+        except (TypeError, ValueError):
+            length = 0
+        if length > _MAX_BODY_BYTES:
+            return _BodyTooLarge
+        return json.loads(self.rfile.read(min(length, _MAX_BODY_BYTES)))
 
     def _route_label(self) -> str:
         # Bound label cardinality: only known endpoints are reported by name,
@@ -440,6 +461,10 @@ class Handler(BaseHTTPRequestHandler):
             self._send_json(400, {"error": "invalid JSON"})
             return
 
+        if body is _BodyTooLarge:
+            self._send_json(413, {"error": "request body too large"})
+            return
+
         # Guard non-object bodies (null, lists, scalars) before calling .get().
         if not isinstance(body, dict):
             self._send_json(400, {"error": "request body must be a JSON object"})
@@ -456,10 +481,15 @@ class Handler(BaseHTTPRequestHandler):
             if len(urls) > 500:
                 self._send_json(400, {"error": "max 500 URLs per request"})
                 return
+            if not all(isinstance(u, str) for u in urls):
+                self._send_json(400, {"error": "each url must be a string"})
+                return
             with _tracer.start_as_current_span("fusion.score") as sp:
                 sp.set_attribute("fusion.batch_size", len(urls))
                 sp.set_attribute("fusion.path", "score")
-                results = _scorer.score(urls)
+                results = self._run_scorer(sp, lambda: _scorer.score(urls))
+                if results is None:
+                    return
                 self._annotate_span_with_first_result(sp, results)
             self._count_verdicts("/score", results)
             self._send_json(200, {
@@ -470,13 +500,15 @@ class Handler(BaseHTTPRequestHandler):
 
         elif self.path == "/score_one":
             url = body.get("url", "")
-            if not url:
-                self._send_json(400, {"error": "'url' is required"})
+            if not isinstance(url, str) or not url:
+                self._send_json(400, {"error": "'url' must be a non-empty string"})
                 return
             with _tracer.start_as_current_span("fusion.score_one") as sp:
                 sp.set_attribute("fusion.path", "score_one")
                 sp.set_attribute("fusion.url", url)
-                results = _scorer.score([url])
+                results = self._run_scorer(sp, lambda: _scorer.score([url]))
+                if results is None:
+                    return
                 self._annotate_span_with_first_result(sp, results)
             self._count_verdicts("/score_one", results)
             self._send_json(200, results[0] if results else {})
@@ -489,10 +521,15 @@ class Handler(BaseHTTPRequestHandler):
             if len(reqs) > 500:
                 self._send_json(400, {"error": "max 500 requests per call"})
                 return
+            if not all(isinstance(r, dict) for r in reqs):
+                self._send_json(400, {"error": "each request must be a JSON object"})
+                return
             with _tracer.start_as_current_span("fusion.score_features") as sp:
                 sp.set_attribute("fusion.batch_size", len(reqs))
                 sp.set_attribute("fusion.path", "score-features")
-                results = _scorer.score_features(reqs)
+                results = self._run_scorer(sp, lambda: _scorer.score_features(reqs))
+                if results is None:
+                    return
                 self._annotate_span_with_first_result(sp, results)
             self._count_verdicts("/score-features", results)
             self._send_json(200, {
@@ -503,6 +540,18 @@ class Handler(BaseHTTPRequestHandler):
 
         else:
             self._send_json(404, {"error": "not found"})
+
+    def _run_scorer(self, sp, call):
+        """Invoke a scorer callable, converting any failure into a 500 JSON
+        reply instead of letting the exception unwind out of do_POST and drop
+        the connection. Returns the results list, or None when it already
+        emitted an error response."""
+        try:
+            return call()
+        except Exception as exc:  # noqa: BLE001 - boundary: must always reply
+            sp.record_exception(exc)
+            self._send_json(500, {"error": "scoring failed"})
+            return None
 
     @staticmethod
     def _annotate_span_with_first_result(sp, results) -> None:

--- a/fusion_export/tests/test_serve_handler.py
+++ b/fusion_export/tests/test_serve_handler.py
@@ -1,0 +1,185 @@
+"""Regression tests for the L2 fusion HTTP sidecar request handler.
+
+These drive a real ThreadingHTTPServer on loopback with a stub Scorer so we
+can assert that malformed input and scorer failures produce a proper HTTP
+status (4xx/5xx) instead of an unhandled exception that drops the connection.
+"""
+from __future__ import annotations
+
+import http.client
+import json
+import sys
+import threading
+import unittest
+from http.server import ThreadingHTTPServer
+from pathlib import Path
+
+# scripts/serve.py is not an installable package; put it on the path.
+_SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+import serve  # noqa: E402
+
+
+class _StubScorer:
+    """Minimal stand-in for Scorer.
+
+    score()/score_features() either echo a benign verdict or raise, depending
+    on `boom`, so we can exercise both the happy path and the error boundary
+    without loading any ML model.
+    """
+
+    threshold = 0.5
+    fusion_mode = "mean"
+
+    def __init__(self, boom: bool = False):
+        self.boom = boom
+
+    def score(self, urls):
+        if self.boom:
+            raise RuntimeError("synthetic scorer failure")
+        return [{"url": u, "verdict": "benign", "url_p": 0.0,
+                 "op_p": 0.0, "deploy_p": 0.0} for u in urls]
+
+    def score_features(self, reqs):
+        if self.boom:
+            raise RuntimeError("synthetic scorer failure")
+        return [{"url": r.get("normalized_url", ""), "verdict": "benign",
+                 "url_p": 0.0, "op_p": 0.0, "deploy_p": 0.0} for r in reqs]
+
+
+class _ServerFixture:
+    """Spin up the real Handler on an ephemeral loopback port."""
+
+    def __init__(self, scorer):
+        self._prev = serve._scorer
+        serve._scorer = scorer
+        self.httpd = ThreadingHTTPServer(("127.0.0.1", 0), serve.Handler)
+        self.port = self.httpd.server_address[1]
+        self.thread = threading.Thread(target=self.httpd.serve_forever, daemon=True)
+        self.thread.start()
+
+    def close(self):
+        self.httpd.shutdown()
+        self.httpd.server_close()
+        self.thread.join(timeout=5)
+        serve._scorer = self._prev
+
+    def post(self, path, body, raw=False, headers=None):
+        conn = http.client.HTTPConnection("127.0.0.1", self.port, timeout=5)
+        payload = body if raw else json.dumps(body)
+        hdrs = {"Content-Type": "application/json"}
+        if headers:
+            hdrs.update(headers)
+        conn.request("POST", path, payload, hdrs)
+        resp = conn.getresponse()
+        data = resp.read()
+        conn.close()
+        return resp.status, data
+
+
+class TestHandlerErrorBoundaries(unittest.TestCase):
+    def _server(self, boom=False):
+        fx = _ServerFixture(_StubScorer(boom=boom))
+        self.addCleanup(fx.close)
+        return fx
+
+    # ── Finding: scorer exceptions must become a 500, not a dropped socket ──
+    def test_scorer_failure_returns_500_not_dropped_connection(self):
+        fx = self._server(boom=True)
+        status, body = fx.post("/score", {"urls": ["http://example.com"]})
+        self.assertEqual(status, 500)
+        self.assertIn(b"scoring failed", body)
+
+    def test_score_one_scorer_failure_returns_500(self):
+        fx = self._server(boom=True)
+        status, body = fx.post("/score_one", {"url": "http://example.com"})
+        self.assertEqual(status, 500)
+        self.assertIn(b"scoring failed", body)
+
+    def test_score_features_scorer_failure_returns_500(self):
+        fx = self._server(boom=True)
+        status, body = fx.post("/score-features",
+                               {"requests": [{"normalized_url": "http://x"}]})
+        self.assertEqual(status, 500)
+        self.assertIn(b"scoring failed", body)
+
+    # ── Finding: non-string url elements must be rejected with 400 ──────────
+    def test_score_rejects_non_string_url_elements(self):
+        fx = self._server()
+        for bad in ([123], [None], [["nested"]], [True]):
+            with self.subTest(bad=bad):
+                status, body = fx.post("/score", {"urls": bad})
+                self.assertEqual(status, 400)
+                self.assertIn(b"string", body)
+
+    def test_score_accepts_string_urls(self):
+        fx = self._server()
+        status, _ = fx.post("/score", {"urls": ["http://example.com"]})
+        self.assertEqual(status, 200)
+
+    # ── Finding: /score_one must require a non-empty string ─────────────────
+    def test_score_one_rejects_non_string_url(self):
+        fx = self._server()
+        for bad in (123, True, ["http://x"], {"u": 1}):
+            with self.subTest(bad=bad):
+                status, body = fx.post("/score_one", {"url": bad})
+                self.assertEqual(status, 400)
+                self.assertIn(b"non-empty string", body)
+
+    def test_score_one_rejects_empty_url(self):
+        fx = self._server()
+        status, _ = fx.post("/score_one", {"url": ""})
+        self.assertEqual(status, 400)
+
+    # ── Finding: /score-features must reject non-dict elements ──────────────
+    def test_score_features_rejects_non_dict_elements(self):
+        fx = self._server()
+        status, body = fx.post("/score-features",
+                               {"requests": [{"normalized_url": "http://x"}, 1, None]})
+        self.assertEqual(status, 400)
+        self.assertIn(b"JSON object", body)
+
+    # ── Finding: oversized Content-Length must be rejected with 413 ─────────
+    def test_oversized_body_returns_413(self):
+        fx = self._server()
+        # Declare an over-cap Content-Length but send only a small body, so the
+        # handler rejects on the header before reading. (A truly multi-GB body
+        # would be capped the same way; we don't allocate it here.)
+        big = serve._MAX_BODY_BYTES + 1
+        conn = http.client.HTTPConnection("127.0.0.1", fx.port, timeout=5)
+        conn.putrequest("POST", "/score")
+        conn.putheader("Content-Type", "application/json")
+        conn.putheader("Content-Length", str(big))
+        conn.endheaders()
+        # Send far less than declared; the server must not block waiting for the
+        # full Content-Length and must answer 413.
+        conn.send(b'{"urls": []}')
+        resp = conn.getresponse()
+        status = resp.status
+        resp.read()
+        conn.close()
+        self.assertEqual(status, 413)
+
+    def test_read_json_caps_oversized_content_length(self):
+        # Unit-level guard: _read_json returns the too-large sentinel without
+        # reading the body when Content-Length exceeds the cap.
+        handler = serve.Handler.__new__(serve.Handler)
+        handler.headers = {"Content-Length": str(serve._MAX_BODY_BYTES + 1)}
+
+        class _ExplodingReader:
+            def read(self, *_a):
+                raise AssertionError("body must not be read once over the cap")
+
+        handler.rfile = _ExplodingReader()
+        self.assertIs(handler._read_json(), serve._BodyTooLarge)
+
+    def test_within_cap_body_is_processed(self):
+        fx = self._server()
+        status, _ = fx.post("/score", {"urls": ["http://example.com"]})
+        self.assertEqual(status, 200)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/services/svc-06-nlp/nlp/inference.py
+++ b/services/svc-06-nlp/nlp/inference.py
@@ -471,8 +471,11 @@ class NLPInferenceEngine:
         # the model weights are unchanged.
         threat_prob = float(probs[1]) + float(probs[2])
 
-        # 5. Two-class decision: legitimate vs phishing.
-        if threat_prob > leg_prob:
+        # 5. Two-class decision: legitimate vs phishing. Apply the tuned
+        #    operating point from config (spec §5.4: phish_threshold fitted for
+        #    recall >= 0.96 at minimum FPR) rather than an implicit 0.5 argmax,
+        #    so the published verdict tracks the documented threshold.
+        if threat_prob > self.phish_threshold:
             classification = "phishing"
             confidence = threat_prob
         else:

--- a/services/svc-06-nlp/nlp/test_inference.py
+++ b/services/svc-06-nlp/nlp/test_inference.py
@@ -487,6 +487,29 @@ class TestPredict:
         # Higher temperature → phishing probability is lower
         assert r1["phishing_probability"] > r2["phishing_probability"]
 
+    def test_threshold_applied_between_half_and_config(self):
+        """The tuned phish_threshold (spec §5.4) must gate the verdict, not an
+        implicit 0.5 argmax. logits [0.0, 0.5, 0.0] yield threat_prob≈0.726:
+        above 0.5 (so the old `threat_prob > leg_prob` rule said "phishing")
+        but below the configured 0.8 operating point, so the verdict is now
+        "legitimate"."""
+        engine = _engine_with_logits([0.0, 0.5, 0.0])  # default phish_threshold=0.8
+        result = engine.predict("s", "b")
+        assert 0.5 < result["phishing_probability"] < 0.8
+        assert result["classification"] == "legitimate"
+        # confidence reports the legitimate prob when below threshold
+        assert result["confidence"] < 0.5
+
+    def test_lower_threshold_flips_borderline_to_phishing(self):
+        """The same borderline logits classify as phishing once the threshold
+        is lowered below the phishing probability, proving the config knob is
+        live."""
+        engine = _engine_with_logits([0.0, 0.5, 0.0])
+        engine.phish_threshold = 0.6
+        result = engine.predict("s", "b")
+        assert result["classification"] == "phishing"
+        assert result["confidence"] == result["phishing_probability"]
+
 
 # ─────────────────────────────────────────────────────────────────────────────
 # 8. Config loading


### PR DESCRIPTION
From a whole-codebase review pass. No model changes.
- fusion serve.py: wrap scorer dispatch in try/except (return 4xx/5xx instead of dropping the connection); cap request body at 8 MiB before reading (unbounded-memory DoS); reject non-string/non-dict request payloads with 400.
- svc-06 nlp inference.py: apply the loaded phish_threshold (0.8, spec §5.4) instead of an implicit 0.5 argmax.
pytest green (svc-06 68 passed incl. 2 new; fusion 30 passed incl. 11 new handler tests).