### PR TITLE
fix: gate aggregator publish on internal_id + green-up lint/e2e/smoke reruns

### DIFF
--- a/scripts/dev/inject_fake_email.sh
+++ b/scripts/dev/inject_fake_email.sh
@@ -223,6 +223,14 @@ while :; do
   sleep 0.5
 done
 
+# Clear any stale per-campaign notification rate-limit keys (notif:<org>:<campaign>,
+# 1h TTL). Both smoke emails share a campaign fingerprint, so a previous run within
+# the hour would otherwise suppress this run's alert and fail A5/A6. Idempotent.
+echo "==> Clearing per-campaign notification rate-limit keys (notif:*)"
+docker exec "$VALKEY_CONTAINER" redis-cli --no-raw KEYS 'notif:*' 2>/dev/null \
+  | sed -E 's/^[0-9]+\) "?//; s/"?$//' | grep -E '^notif:' \
+  | xargs -r -I{} docker exec "$VALKEY_CONTAINER" redis-cli DEL {} >/dev/null 2>&1 || true
+
 match="$(inject_and_wait "$EMAIL_ID" "$EML_A_B64" \
   "PayPal Billing <billing@paypa1-secure.tk>" \
   "URGENT: Your PayPal account will be suspended in 24 hours")"

--- a/services/svc-03-url-analysis/tests/e2e/run.sh
+++ b/services/svc-03-url-analysis/tests/e2e/run.sh
@@ -17,9 +17,16 @@ REPO_ROOT="$(cd "$HERE/../../../.." && pwd)"
 FIXTURE_FILE="$HERE/fixtures/scan_cases.json"
 TI_FIXTURE="${TI_FIXTURE:-/tmp/cybersiren-e2e-ti-fixture.json}"
 SVC_BIN="${SVC_BIN:-/tmp/cybersiren-svc-03-e2e}"
-STUB_PORT="${STUB_PORT:-8765}"
-SVC_PORT="${SVC_PORT:-18083}"
-SVC_METRICS_PORT="${SVC_METRICS_PORT:-19090}"
+
+# Default to free loopback ports so the e2e never collides with a running
+# stack: Prometheus owns host :19090, the smoke pipeline owns 9101-9110, and
+# the fusion-sidecar container owns :8765. Override any of these via env.
+pick_free_port() {
+  python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()'
+}
+STUB_PORT="${STUB_PORT:-$(pick_free_port)}"
+SVC_PORT="${SVC_PORT:-$(pick_free_port)}"
+SVC_METRICS_PORT="${SVC_METRICS_PORT:-$(pick_free_port)}"
 SVC_BASE="http://127.0.0.1:${SVC_PORT}"
 STUB_BASE="http://127.0.0.1:${STUB_PORT}"
 STUB_PID=""

--- a/services/svc-07-aggregator/internal/aggregator/aggregator.go
+++ b/services/svc-07-aggregator/internal/aggregator/aggregator.go
@@ -187,6 +187,16 @@ func (a *Aggregator) Handle(ctx context.Context, msg kafkaconsumer.Message) erro
 		span.SetAttributes(attribute.String("aggregator.status", "wait_scores"))
 		return nil
 	}
+	// The bucket is complete, but a concurrent scores.header handler may not
+	// have merged __partition_internal_id yet (HSET field then HSETNX id are
+	// two ops). Publishing now would fall back to email_id and mis-key the
+	// verdict. Wait for the id to land — a later arrival or the scores.header
+	// handler itself re-triggers; the timeout sweeper is the backstop.
+	if internalIDPending(state) {
+		a.observeMessage(msg.Topic, "wait")
+		span.SetAttributes(attribute.String("aggregator.status", "wait_internal_id"))
+		return nil
+	}
 
 	// Separate Valkey key with short TTL — not a hash field — so a crash
 	// after publish cannot leave a permanent lock that blocks retry while

--- a/services/svc-07-aggregator/internal/aggregator/aggregator_test.go
+++ b/services/svc-07-aggregator/internal/aggregator/aggregator_test.go
@@ -348,6 +348,42 @@ func TestResolvePartitionKeys_PrefersForwardedInternalID(t *testing.T) {
 	assert.Equal(t, int64(999), out2.InternalID, "falls back to email_id when none forwarded")
 }
 
+// A message-driven publish must wait while scores.header is present with a real
+// internal_id but __partition_internal_id hasn't been merged yet (the HSET-field
+// then HSETNX-id race) — otherwise emails.scored mis-keys off email_id. A header
+// that carried internal_id==0 is never coming, so we must NOT wait.
+func TestInternalIDPending(t *testing.T) {
+	t.Parallel()
+
+	headerWithID, err := json.Marshal(contracts.ScoresHeaderMessage{
+		EmailID: 999, OrgID: 1, Component: contracts.ComponentHeader, InternalID: 42,
+	})
+	require.NoError(t, err)
+	headerNoID, err := json.Marshal(contracts.ScoresHeaderMessage{
+		EmailID: 999, OrgID: 1, Component: contracts.ComponentHeader, InternalID: 0,
+	})
+	require.NoError(t, err)
+
+	t.Run("partition id already merged -> not pending", func(t *testing.T) {
+		st := map[string]string{
+			contracts.TopicScoresHeader: string(headerWithID),
+			fieldPartitionInternalID:    "42",
+		}
+		assert.False(t, internalIDPending(st))
+	})
+	t.Run("scores.header not yet arrived -> not pending", func(t *testing.T) {
+		assert.False(t, internalIDPending(map[string]string{}))
+	})
+	t.Run("header present with real id, partition field lagging -> pending", func(t *testing.T) {
+		st := map[string]string{contracts.TopicScoresHeader: string(headerWithID)}
+		assert.True(t, internalIDPending(st))
+	})
+	t.Run("header carried id==0 (never coming) -> not pending", func(t *testing.T) {
+		st := map[string]string{contracts.TopicScoresHeader: string(headerNoID)}
+		assert.False(t, internalIDPending(st))
+	})
+}
+
 func TestExtractIDs_EnvelopeAndFlatShapes(t *testing.T) {
 	t.Parallel()
 

--- a/services/svc-07-aggregator/internal/aggregator/packager.go
+++ b/services/svc-07-aggregator/internal/aggregator/packager.go
@@ -136,6 +136,38 @@ func completionStatus(state map[string]string) (complete, hasPlan bool) {
 	return true, true
 }
 
+// internalIDPending reports whether a message-driven publish must briefly wait
+// for the DB internal_id to be merged before emitting emails.scored.
+//
+// scores.header forwards svc-02's BIGSERIAL internal_id; its handler writes the
+// scores.header field (HSET) and then merges __partition_internal_id (HSETNX) as
+// two separate Valkey ops. A concurrent handler for another component can read a
+// state snapshot in that window — scores.header field present (so the bucket
+// looks complete) but __partition_internal_id not yet visible — and would
+// publish with the email_id fallback, mis-keying the verdict off the parser row.
+//
+// We wait only when scores.header is present AND carried a non-zero internal_id
+// but the partition field is not yet set: the merge is just lagging and the
+// scores.header handler (or a #190 redelivery if it errored) will complete it.
+// A scores.header that carried internal_id==0 (degraded upstream) is "never
+// coming", so we do NOT wait — the email_id fallback stands. The globally-last
+// completing handler always observes the merged id, so this never deadlocks; the
+// timeout sweeper is the backstop regardless.
+func internalIDPending(state map[string]string) bool {
+	if state[fieldPartitionInternalID] != "" {
+		return false
+	}
+	headerRaw, ok := state[contracts.TopicScoresHeader]
+	if !ok {
+		return false
+	}
+	var h contracts.ScoresHeaderMessage
+	if err := json.Unmarshal([]byte(headerRaw), &h); err != nil {
+		return false
+	}
+	return h.InternalID != 0
+}
+
 // keyForOrgEmail returns the aggregation hash key scoped by tenant so two
 // orgs cannot clobber each other's buckets when email_id overlaps.
 func keyForOrgEmail(orgID, emailID int64) string {

--- a/services/svc-08-decision/internal/campaign/fingerprint_test.go
+++ b/services/svc-08-decision/internal/campaign/fingerprint_test.go
@@ -72,11 +72,13 @@ func TestExtractInputs_FromComponentDetails(t *testing.T) {
 			},
 		},
 	})
-	// scores.nlp as svc-06 emits it: a ScoreEnvelope whose Details map carries
-	// subject + plain_text + intent_labels (nlp-pipeline/main.go).
-	nlp := mustJSON(contracts.ScoreEnvelope{
-		Component: contracts.ComponentNLP,
-		Details: map[string]interface{}{
+	// scores.nlp as svc-06 emits it: a {component, details} envelope whose
+	// details map carries subject + plain_text + intent_labels
+	// (nlp-pipeline/main.go). Built as a raw map — the same wire shape the
+	// decoder consumes — rather than the deprecated contracts.ScoreEnvelope.
+	nlp := mustJSON(map[string]any{
+		"component": contracts.ComponentNLP,
+		"details": map[string]any{
 			"intent_labels": []string{"phishing", "urgency"},
 			"subject":       "ALERT: invoice 12345",
 			"plain_text":    "click here to verify",
@@ -104,12 +106,13 @@ func TestExtractInputs_FromComponentDetails(t *testing.T) {
 }
 
 func TestExtractBody(t *testing.T) {
-	// scores.nlp as svc-06 emits it (ScoreEnvelope.Details), carrying
-	// plain_text + subject.
+	// scores.nlp as svc-06 emits it (a {component, details} envelope),
+	// carrying plain_text + subject. Raw map = the wire shape the decoder
+	// consumes, without the deprecated contracts.ScoreEnvelope.
 	d := contracts.ComponentDetails{
-		NLP: mustJSON(contracts.ScoreEnvelope{
-			Component: contracts.ComponentNLP,
-			Details: map[string]interface{}{
+		NLP: mustJSON(map[string]any{
+			"component": contracts.ComponentNLP,
+			"details": map[string]any{
 				"plain_text": "  Click HERE to confirm  ",
 				"subject":    "Reset password",
 			},


### PR DESCRIPTION
Four fixes found while verifying the pipeline after the #189–197 / #190 merges. The first is a correctness fix in the aggregator; the rest unblock the lint gate and make the e2e/smoke harnesses re-runnable.

## svc-07 — wait for internal_id before message-driven emails.scored publish
The aggregator writes the `scores.header` field (HSET) and merges the DB `internal_id` (`__partition_internal_id`, HSETNX) as two separate Valkey ops. A concurrent handler for another component could observe the bucket as complete in that window — header field present but `internal_id` not yet visible — and publish `emails.scored` with the `email_id` fallback, mis-keying the verdict off the parser row. Intermittent, and #190's redelivery widened the window by actually re-running the publish-lock re-contention.

Gate the message-driven publish on `internalIDPending()`: wait while `scores.header` is present with a non-zero `internal_id` but the partition field hasn't merged yet. A header that carried `internal_id==0` is never coming, so we don't wait. The globally-last completing handler always observes the merged id (no deadlock); the timeout sweeper publishes regardless as the backstop.

## svc-08 — drop deprecated ScoreEnvelope in the campaign test
`fingerprint_test.go` built `scores.nlp` via the deprecated `contracts.ScoreEnvelope`, tripping two `SA1019` lint failures. Build it as a raw `{component, details}` map (the wire shape the decoder consumes) instead — same semantics, lint clean.

## e2e-svc-03 — default to free loopback ports
`run.sh` hard-coded the metrics port to `:19090`, which collides with a running Prometheus container; the stub/svc ports could likewise collide with the smoke pipeline (9101–9110) or the fusion sidecar (:8765). Default all three to free loopback ports (still overridable via env).

## smoke — clear stale notif rate-limit keys in preflight
The per-campaign notification rate limiter (`notif:<org>:<campaign>`, 1h TTL) correctly suppresses a repeat alert, but that made A5/A6 fail on any second smoke run within the hour. Clear `notif:*` in the inject preflight so reruns are deterministic.

## Test plan
- `make build && make vet && make lint && make generate-check` — clean
- `make test` (race + integration) — green, incl. new `TestInternalIDPending`
- `make e2e-svc-03` with no port override while Prometheus is up — 6/6
- `make smoke` 8 consecutive runs — all pass, correct internal_id, zero aggregator rewind storms