### PR TITLE
svc-08: verdict-label reconcile (malware vs phishing) in the 76–100 band

### DIFF
--- a/docs/design/svc-07-08-design-brief.md
+++ b/docs/design/svc-07-08-design-brief.md
@@ -268,7 +268,10 @@ SVC-08 loads rules with `target IN ('email', 'decision')` (SVC-04 loads `target 
 "score.attachment"   → float64 (or absent if null)
 "score.blended"      → float64 (the pre-rule blended score)
 "partial_analysis"   → bool
-"verdict.label"      → string (pre-rule verdict label, before adjustments)
+"verdict.label"      → string (pre-rule score→band label, before adjustments; this is
+                       the pure LabelFor band, NOT the final reconciled verdict — a
+                       high-band email with no malware-grade attachment shows here as
+                       "malware" even though its published verdict is "phishing")
 "campaign.is_new"    → bool
 "campaign.risk_score"→ float64 (rolling average from campaigns table, 0 if new)
 "campaign.email_count"→ int
@@ -291,7 +294,7 @@ After score blending + rule adjustments:
 | 76–100 | a high (malware-grade) attachment is present | `malware` |
 | 76–100 | otherwise | `phishing` (high) |
 
-**Malware-vs-phishing reconcile (76–100 band).** The top band covers both "phishing(high)" and "malware". We disambiguate by the attachment: a top-band verdict that carries a malware-grade attachment is `malware`; a top-band verdict driven only by URL/header/NLP signals (no malware-grade attachment) is high-confidence `phishing`. This is `ReconcileLabel(score, components)`; `engine.LabelFor` is left pure (score→band only) and the reconcile wraps it.
+**Malware-vs-phishing reconcile (76–100 band).** The top band covers both "phishing(high)" and "malware". We disambiguate by the attachment: a top-band verdict that carries a malware-grade attachment is `malware`; a top-band verdict driven only by URL/header/NLP signals (no malware-grade attachment) is high-band `phishing` (i.e. `phishing(high)`). "High" here means the score band, not the confidence value — see the confidence note below: a `phishing(high)` verdict near a band edge can carry a confidence close to 0. This is `ReconcileLabel(score, components)`; `engine.LabelFor` is left pure (score→band only) and the reconcile wraps it.
 
 The verdict is `malware` iff a **high, malware-grade attachment** is present:
 - the attachment component is present (a `nil` component is "absent", not 0), AND

--- a/docs/design/svc-07-08-design-brief.md
+++ b/docs/design/svc-07-08-design-brief.md
@@ -288,17 +288,16 @@ After score blending + rule adjustments:
 | 0–25 | — | `benign` |
 | 26–50 | — | `suspicious` |
 | 51–75 | — | `phishing` |
-| 76–100 | attachment is the dominant/high driver | `malware` |
+| 76–100 | a high (malware-grade) attachment is present | `malware` |
 | 76–100 | otherwise | `phishing` (high) |
 
-**Malware-vs-phishing reconcile (76–100 band).** The top band covers both "phishing(high)" and "malware". We disambiguate by the dominant signal: a high score driven by a malicious attachment is `malware`; a high score driven by URL/header/NLP signals is high-confidence `phishing`. This is `ReconcileLabel(score, components)`; `engine.LabelFor` is left pure (score→band only) and the reconcile wraps it.
+**Malware-vs-phishing reconcile (76–100 band).** The top band covers both "phishing(high)" and "malware". We disambiguate by the attachment: a top-band verdict that carries a malware-grade attachment is `malware`; a top-band verdict driven only by URL/header/NLP signals (no malware-grade attachment) is high-confidence `phishing`. This is `ReconcileLabel(score, components)`; `engine.LabelFor` is left pure (score→band only) and the reconcile wraps it.
 
-The attachment is the **dominant/high driver** iff:
+The verdict is `malware` iff a **high, malware-grade attachment** is present:
 - the attachment component is present (a `nil` component is "absent", not 0), AND
-- `attachment_score >= 76` (the malware-band floor — the attachment must itself be malware-grade), AND
-- `attachment_score >= max(present url, header, nlp)` — it is at least as high as every other present component. A `nil` component is ignored; if the attachment is the only present component it is trivially the max.
+- `attachment_score >= 76` (the malware-band floor — the attachment must itself be malware-grade).
 
-Tie-handling: comparisons use `>=`, so an attachment **tied** with another high component still resolves to `malware` (the more severe of two equally-plausible labels). Only a strictly-higher non-attachment component demotes the verdict to `phishing(high)`.
+A confirmed malware-grade attachment makes the verdict `malware` **even when another component (URL/header/NLP) scored higher** — a malicious attachment is the more actionable threat, so its presence dominates the label. Only when no malware-grade attachment is present (absent, or `attachment_score < 76`) does the top-band verdict stay `phishing(high)`.
 
 Bands 0–75 are unaffected by the reconcile — attachment is ignored there.
 

--- a/docs/design/svc-07-08-design-brief.md
+++ b/docs/design/svc-07-08-design-brief.md
@@ -283,12 +283,26 @@ Each fired rule is written to `rule_hits` with `entity_type='email'`, `entity_id
 
 After score blending + rule adjustments:
 
-| Score range | Label |
-|-------------|-------|
-| 0–25 | `benign` |
-| 26–50 | `suspicious` |
-| 51–75 | `phishing` |
-| 76–100 | `malware` |
+| Score range | Condition | Label |
+|-------------|-----------|-------|
+| 0–25 | — | `benign` |
+| 26–50 | — | `suspicious` |
+| 51–75 | — | `phishing` |
+| 76–100 | attachment is the dominant/high driver | `malware` |
+| 76–100 | otherwise | `phishing` (high) |
+
+**Malware-vs-phishing reconcile (76–100 band).** The top band covers both "phishing(high)" and "malware". We disambiguate by the dominant signal: a high score driven by a malicious attachment is `malware`; a high score driven by URL/header/NLP signals is high-confidence `phishing`. This is `ReconcileLabel(score, components)`; `engine.LabelFor` is left pure (score→band only) and the reconcile wraps it.
+
+The attachment is the **dominant/high driver** iff:
+- the attachment component is present (a `nil` component is "absent", not 0), AND
+- `attachment_score >= 76` (the malware-band floor — the attachment must itself be malware-grade), AND
+- `attachment_score >= max(present url, header, nlp)` — it is at least as high as every other present component. A `nil` component is ignored; if the attachment is the only present component it is trivially the max.
+
+Tie-handling: comparisons use `>=`, so an attachment **tied** with another high component still resolves to `malware` (the more severe of two equally-plausible labels). Only a strictly-higher non-attachment component demotes the verdict to `phishing(high)`.
+
+Bands 0–75 are unaffected by the reconcile — attachment is ignored there.
+
+**Confidence is unaffected by the reconcile.** Confidence is computed against the SCORE's natural band — `Confidence(score, LabelFor(score), …)` — NOT the reconciled label. An 85 reclassified from `malware` to `phishing(high)` keeps the confidence it had in the 76–100 band; renaming the label must not move the distance-to-threshold. Passing the reconciled `phishing` label into `Confidence` would (wrongly) measure distance against the 51–75 band and collapse confidence toward 0. See §3.7.
 
 Note: `spam` and `unknown` labels exist in the `verdict_label` enum but are not yet assigned by the automated pipeline (reserved for analyst overrides).
 

--- a/services/svc-08-decision/internal/engine/engine.go
+++ b/services/svc-08-decision/internal/engine/engine.go
@@ -254,8 +254,9 @@ func (e *Engine) Handle(ctx context.Context, msg kafkaconsumer.Message) error {
 	// band per §3.6). Confidence MUST use the score's NATURAL band label
 	// (LabelFor), not the reconciled one — otherwise an 85 reclassified to
 	// phishing would measure distance against the 51–75 band and collapse.
-	label := ReconcileLabel(finalScore, components)
-	confidence := Confidence(finalScore, LabelFor(finalScore), scored.PartialAnalysis, source)
+	// Both invariants live in verdictLabelAndConfidence so this path and the
+	// degraded path below stay in lockstep.
+	label, confidence := verdictLabelAndConfidence(finalScore, components, scored.PartialAnalysis, source)
 	procElapsed := time.Since(startedAt)
 
 	wireElapsed := procElapsed // snapshot for VerdictWireBuilder closure
@@ -404,10 +405,9 @@ func (e *Engine) publishDegraded(
 	finalScore := ClampInt(Round(nudgedScore), 0, 100)
 	// Reconcile the verdict label (malware vs phishing(high)) but compute
 	// confidence against the score's natural band — see the main path
-	// above and §3.6/§3.7.
-	label := ReconcileLabel(finalScore, components)
+	// above and §3.6/§3.7. Shared helper keeps both paths in lockstep.
 	source := VerdictSourceRule
-	confidence := Confidence(finalScore, LabelFor(finalScore), scored.PartialAnalysis, source)
+	label, confidence := verdictLabelAndConfidence(finalScore, components, scored.PartialAnalysis, source)
 	mvdeg := e.modelVersionFor(scored, source)
 
 	out, err := e.writer.Write(ctx, persist.Input{

--- a/services/svc-08-decision/internal/engine/engine.go
+++ b/services/svc-08-decision/internal/engine/engine.go
@@ -250,12 +250,9 @@ func (e *Engine) Handle(ctx context.Context, msg kafkaconsumer.Message) error {
 	}
 
 	finalScore := ClampInt(Round(nudgedScore)+ruleAdjustment, 0, 100)
-	// Verdict label is reconciled (malware vs phishing(high) in the 76–100
-	// band per §3.6). Confidence MUST use the score's NATURAL band label
-	// (LabelFor), not the reconciled one — otherwise an 85 reclassified to
-	// phishing would measure distance against the 51–75 band and collapse.
-	// Both invariants live in verdictLabelAndConfidence so this path and the
-	// degraded path below stay in lockstep.
+	// Label is reconciled; confidence stays on the score's natural band. The
+	// shared seam keeps this path and the degraded path in lockstep — see
+	// verdictLabelAndConfidence for the confidence-trap invariant.
 	label, confidence := verdictLabelAndConfidence(finalScore, components, scored.PartialAnalysis, source)
 	procElapsed := time.Since(startedAt)
 
@@ -403,9 +400,8 @@ func (e *Engine) publishDegraded(
 	elapsed time.Duration,
 ) error {
 	finalScore := ClampInt(Round(nudgedScore), 0, 100)
-	// Reconcile the verdict label (malware vs phishing(high)) but compute
-	// confidence against the score's natural band — see the main path
-	// above and §3.6/§3.7. Shared helper keeps both paths in lockstep.
+	// Same shared seam as the main path: reconciled label, natural-band
+	// confidence. See verdictLabelAndConfidence.
 	source := VerdictSourceRule
 	label, confidence := verdictLabelAndConfidence(finalScore, components, scored.PartialAnalysis, source)
 	mvdeg := e.modelVersionFor(scored, source)

--- a/services/svc-08-decision/internal/engine/engine.go
+++ b/services/svc-08-decision/internal/engine/engine.go
@@ -227,6 +227,11 @@ func (e *Engine) Handle(ctx context.Context, msg kafkaconsumer.Message) error {
 		)
 	}
 
+	// preRuleLabel stays the PURE LabelFor band (no attachment reconcile):
+	// it is the pre-rule snapshot input that rule conditions match on, so
+	// reconciling it here could change which rules fire — a scoring
+	// feedback loop. The malware-vs-phishing reconcile is applied only to
+	// the final verdict label below.
 	preRuleLabel := LabelFor(Round(nudgedScore))
 	snap := BuildSnapshot(SnapshotInputs{
 		Scored:        scored,
@@ -245,8 +250,12 @@ func (e *Engine) Handle(ctx context.Context, msg kafkaconsumer.Message) error {
 	}
 
 	finalScore := ClampInt(Round(nudgedScore)+ruleAdjustment, 0, 100)
-	label := LabelFor(finalScore)
-	confidence := Confidence(finalScore, label, scored.PartialAnalysis, source)
+	// Verdict label is reconciled (malware vs phishing(high) in the 76–100
+	// band per §3.6). Confidence MUST use the score's NATURAL band label
+	// (LabelFor), not the reconciled one — otherwise an 85 reclassified to
+	// phishing would measure distance against the 51–75 band and collapse.
+	label := ReconcileLabel(finalScore, components)
+	confidence := Confidence(finalScore, LabelFor(finalScore), scored.PartialAnalysis, source)
 	procElapsed := time.Since(startedAt)
 
 	wireElapsed := procElapsed // snapshot for VerdictWireBuilder closure
@@ -393,9 +402,12 @@ func (e *Engine) publishDegraded(
 	elapsed time.Duration,
 ) error {
 	finalScore := ClampInt(Round(nudgedScore), 0, 100)
-	label := LabelFor(finalScore)
+	// Reconcile the verdict label (malware vs phishing(high)) but compute
+	// confidence against the score's natural band — see the main path
+	// above and §3.6/§3.7.
+	label := ReconcileLabel(finalScore, components)
 	source := VerdictSourceRule
-	confidence := Confidence(finalScore, label, scored.PartialAnalysis, source)
+	confidence := Confidence(finalScore, LabelFor(finalScore), scored.PartialAnalysis, source)
 	mvdeg := e.modelVersionFor(scored, source)
 
 	out, err := e.writer.Write(ctx, persist.Input{

--- a/services/svc-08-decision/internal/engine/engine_test.go
+++ b/services/svc-08-decision/internal/engine/engine_test.go
@@ -73,18 +73,13 @@ func (f *fakePublisher) Publish(_ context.Context, key, value []byte, retries in
 	return nil
 }
 
+// makeScoredMessage builds a minimal scored message carrying a single URL
+// component (77) — a model-sourced email in the phishing band. It is just the
+// general makeScoredMessageWith with that one component, kept as a named helper
+// for the many tests that don't care about the component mix.
 func makeScoredMessage(t *testing.T, internalID int64, emailID string) kafkaconsumer.Message {
 	t.Helper()
-	fetched := time.Date(2026, 5, 3, 10, 0, 0, 0, time.UTC)
-	url := 77
-	body, err := json.Marshal(contracts.EmailsScored{
-		Meta:       contracts.NewMetaWithFetched(emailID, 7, fetched),
-		InternalID: internalID,
-		FetchedAt:  fetched,
-		URLScore:   &url,
-	})
-	require.NoError(t, err)
-	return kafkaconsumer.Message{Value: body}
+	return makeScoredMessageWith(t, internalID, emailID, Components{URL: ptrInt(77)})
 }
 
 // makeScoredMessageWith builds an emails.scored carrying the given component
@@ -178,7 +173,7 @@ func TestHandle_DegradesWhenRulesUnavailable(t *testing.T) {
 // in the malware band (76–100) and reconciles to phishing(high). It asserts
 // the persisted+published verdict label is phishing AND the confidence is the
 // score's NATURAL malware-band value — not the collapsed 51–75-band value the
-// confidence trap would produce. Guards engine.go:257-258.
+// confidence trap would produce. Guards the main-path verdictLabelAndConfidence call.
 func TestHandle_MalwareBandConfidenceNotCollapsedByReconcile(t *testing.T) {
 	t.Parallel()
 	writer := &fakeWriter{out: persist.Output{CampaignID: 17, VerdictID: 44, EmailCount: 1}}
@@ -207,6 +202,10 @@ func TestHandle_MalwareBandConfidenceNotCollapsedByReconcile(t *testing.T) {
 
 	natural := Confidence(finalScore, LabelFor(finalScore), false, VerdictSourceModel)
 	collapsed := Confidence(finalScore, LabelPhishing, false, VerdictSourceModel)
+	// Pin the literal value, not just the wiring: malware band [76,100], score
+	// 90 → min(90-76,100-90)/25 = 10/25 = 0.4 (model source, no partial penalty).
+	require.InDelta(t, 0.4, natural, 1e-9, "natural malware-band confidence for score 90 (model)")
+	require.InDelta(t, 0.0, collapsed, 1e-9, "phishing band [51,75] is below 90 → distance clamps to 0")
 	require.NotEqual(t, natural, collapsed, "test precondition: the two bands must differ")
 	require.Equal(t, natural, writer.lastInput.Confidence,
 		"confidence must use the score's natural malware band, not the reconciled phishing band")
@@ -222,10 +221,12 @@ func TestHandle_MalwareBandConfidenceNotCollapsedByReconcile(t *testing.T) {
 }
 
 // TestHandle_DegradedMalwareBandConfidenceNotCollapsed drives the DEGRADED
-// (publishDegraded) path: rules cache unavailable, attachment-dominant
-// malware-band score. It asserts the verdict reconciles to malware and the
-// confidence is the natural malware-band value scaled by the rule-source
-// 0.5 factor — never the collapsed phishing-band value. Guards engine.go:408-410.
+// (publishDegraded) path with a high-band score that carries a malware-grade
+// attachment, so it reconciles to MALWARE. It pins the degraded path's
+// reconcile + rule-scaled confidence. NOTE: because the reconciled label here
+// equals LabelFor(90), this case alone does NOT exercise the confidence trap on
+// the degraded path (threading the reconciled label would be a no-op) — the
+// phishing branch is covered by TestHandle_DegradedPhishingHighConfidenceNotCollapsed.
 func TestHandle_DegradedMalwareBandConfidenceNotCollapsed(t *testing.T) {
 	t.Parallel()
 	writer := &fakeWriter{out: persist.Output{CampaignID: 17, VerdictID: 44, EmailCount: 1}}
@@ -240,7 +241,9 @@ func TestHandle_DegradedMalwareBandConfidenceNotCollapsed(t *testing.T) {
 		zerolog.Nop(),
 	)
 
-	// Attachment=URL=90 → blend 90, attachment dominant (tie wins) → malware.
+	// Attachment=URL=90 → blend 90. A malware-grade attachment (≥76) is present,
+	// so the top band reconciles to malware; the other components are not
+	// compared, only checked for the attachment floor.
 	comps := Components{Attachment: ptrInt(90), URL: ptrInt(90)}
 	msg := makeScoredMessageWith(t, 6001, "e6001", comps)
 
@@ -255,6 +258,9 @@ func TestHandle_DegradedMalwareBandConfidenceNotCollapsed(t *testing.T) {
 
 	natural := Confidence(finalScore, LabelFor(finalScore), false, VerdictSourceRule)
 	collapsed := Confidence(finalScore, LabelPhishing, false, VerdictSourceRule)
+	// Literal value: malware band [76,100], score 90 → 10/25 = 0.4, scaled by
+	// the rule-source 0.5 factor = 0.2.
+	require.InDelta(t, 0.2, natural, 1e-9, "natural malware-band confidence ×0.5 rule scaling for score 90")
 	require.NotEqual(t, natural, collapsed, "test precondition: the two bands must differ")
 	require.Equal(t, natural, writer.lastInput.Confidence,
 		"degraded path confidence must use the natural malware band (rule-scaled), not the phishing band")
@@ -263,6 +269,61 @@ func TestHandle_DegradedMalwareBandConfidenceNotCollapsed(t *testing.T) {
 	var v contracts.EmailsVerdict
 	require.NoError(t, json.Unmarshal(pub.records[0].value, &v))
 	require.Equal(t, string(LabelMalware), v.VerdictLabel)
+	require.Equal(t, natural, v.Confidence)
+}
+
+// TestHandle_DegradedPhishingHighConfidenceNotCollapsed drives the DEGRADED
+// (publishDegraded) path with a high-band score and NO malware-grade attachment,
+// so it reconciles to phishing(high). THIS is the case that exercises the
+// confidence trap on the degraded path: the reconciled label (phishing) differs
+// from LabelFor(90) (malware), so threading the reconciled label into Confidence
+// would collapse the value to 0. The malware-case test above can't catch that
+// regression (its reconciled label equals LabelFor). Guards engine.go's
+// publishDegraded verdictLabelAndConfidence call.
+func TestHandle_DegradedPhishingHighConfidenceNotCollapsed(t *testing.T) {
+	t.Parallel()
+	writer := &fakeWriter{out: persist.Output{CampaignID: 17, VerdictID: 44, EmailCount: 1}}
+	pub := &fakePublisher{}
+	eng := New(
+		Config{},
+		nil, // unavailable rules cache → degraded path
+		fakeSimhash{},
+		writer,
+		pub,
+		nil,
+		zerolog.Nop(),
+	)
+
+	// Header=NLP=90, no attachment → blend 90, high band, no malware-grade
+	// attachment → reconciles to phishing(high). Degraded path forces source=rule.
+	comps := Components{Header: ptrInt(90), NLP: ptrInt(90)}
+	msg := makeScoredMessageWith(t, 6002, "e6002", comps)
+
+	err := eng.Handle(context.Background(), msg)
+	require.NoError(t, err)
+	require.Equal(t, 1, writer.writes)
+	require.Equal(t, VerdictSourceRule, writer.lastInput.VerdictSource, "degraded path is rule-sourced")
+
+	const finalScore = 90
+	require.Equal(t, finalScore, writer.lastInput.RiskScore)
+	require.Equal(t, string(LabelPhishing), writer.lastInput.Label,
+		"high score with no malware-grade attachment reconciles to phishing(high)")
+
+	natural := Confidence(finalScore, LabelFor(finalScore), false, VerdictSourceRule)
+	collapsed := Confidence(finalScore, LabelPhishing, false, VerdictSourceRule)
+	// Literal value: malware band [76,100], score 90 → 10/25 = 0.4, ×0.5 rule = 0.2.
+	// The collapsed (buggy) value uses the reconciled phishing band [51,75], where
+	// 90 is out of range → 0.
+	require.InDelta(t, 0.2, natural, 1e-9, "natural malware-band confidence ×0.5 rule scaling")
+	require.InDelta(t, 0.0, collapsed, 1e-9, "phishing-band distance for score 90 clamps to 0")
+	require.NotEqual(t, natural, collapsed, "test precondition: the two bands must differ")
+	require.Equal(t, natural, writer.lastInput.Confidence,
+		"CONFIDENCE TRAP (degraded path): phishing-reconciled label must NOT collapse confidence")
+
+	require.Len(t, pub.records, 1)
+	var v contracts.EmailsVerdict
+	require.NoError(t, json.Unmarshal(pub.records[0].value, &v))
+	require.Equal(t, string(LabelPhishing), v.VerdictLabel)
 	require.Equal(t, natural, v.Confidence)
 }
 

--- a/services/svc-08-decision/internal/engine/engine_test.go
+++ b/services/svc-08-decision/internal/engine/engine_test.go
@@ -87,6 +87,25 @@ func makeScoredMessage(t *testing.T, internalID int64, emailID string) kafkacons
 	return kafkaconsumer.Message{Value: body}
 }
 
+// makeScoredMessageWith builds an emails.scored carrying the given component
+// scores so tests can drive a chosen blended/final risk band. A nil score is
+// omitted (absent component).
+func makeScoredMessageWith(t *testing.T, internalID int64, emailID string, c Components) kafkaconsumer.Message {
+	t.Helper()
+	fetched := time.Date(2026, 5, 3, 10, 0, 0, 0, time.UTC)
+	body, err := json.Marshal(contracts.EmailsScored{
+		Meta:            contracts.NewMetaWithFetched(emailID, 7, fetched),
+		InternalID:      internalID,
+		FetchedAt:       fetched,
+		URLScore:        c.URL,
+		HeaderScore:     c.Header,
+		NLPScore:        c.NLP,
+		AttachmentScore: c.Attachment,
+	})
+	require.NoError(t, err)
+	return kafkaconsumer.Message{Value: body}
+}
+
 func TestDecodeScored_AllowsDistinctInternalAndMetaEmailID(t *testing.T) {
 	t.Parallel()
 	msg := makeScoredMessage(t, 2001, "e1001")
@@ -152,6 +171,99 @@ func TestHandle_DegradesWhenRulesUnavailable(t *testing.T) {
 	require.Equal(t, VerdictSourceRule, writer.lastInput.VerdictSource)
 	require.Len(t, pub.records, 1)
 	require.Equal(t, 2, pub.records[0].retries)
+}
+
+// TestHandle_MalwareBandConfidenceNotCollapsedByReconcile drives the MAIN
+// (Handle) path with an ML-driven, attachment-absent component set that lands
+// in the malware band (76–100) and reconciles to phishing(high). It asserts
+// the persisted+published verdict label is phishing AND the confidence is the
+// score's NATURAL malware-band value — not the collapsed 51–75-band value the
+// confidence trap would produce. Guards engine.go:257-258.
+func TestHandle_MalwareBandConfidenceNotCollapsedByReconcile(t *testing.T) {
+	t.Parallel()
+	writer := &fakeWriter{out: persist.Output{CampaignID: 17, VerdictID: 44, EmailCount: 1}}
+	pub := &fakePublisher{}
+	eng := New(
+		Config{},
+		fakeRules{}, // available, fires nothing → main path, no rule adjustment
+		fakeSimhash{},
+		writer,
+		pub,
+		nil,
+		zerolog.Nop(),
+	)
+
+	// Header=NLP=90, no attachment → blend 90, source=model, reconcile=phishing(high).
+	comps := Components{Header: ptrInt(90), NLP: ptrInt(90)}
+	msg := makeScoredMessageWith(t, 5001, "e5001", comps)
+
+	err := eng.Handle(context.Background(), msg)
+	require.NoError(t, err)
+	require.Equal(t, 1, writer.writes)
+
+	const finalScore = 90
+	require.Equal(t, finalScore, writer.lastInput.RiskScore, "ML-only blend must land in malware band")
+	require.Equal(t, string(LabelPhishing), writer.lastInput.Label, "URL/header/NLP-driven high score reconciles to phishing(high)")
+
+	natural := Confidence(finalScore, LabelFor(finalScore), false, VerdictSourceModel)
+	collapsed := Confidence(finalScore, LabelPhishing, false, VerdictSourceModel)
+	require.NotEqual(t, natural, collapsed, "test precondition: the two bands must differ")
+	require.Equal(t, natural, writer.lastInput.Confidence,
+		"confidence must use the score's natural malware band, not the reconciled phishing band")
+	require.NotEqual(t, collapsed, writer.lastInput.Confidence,
+		"confidence trap: reconcile to phishing must NOT collapse confidence to the 51-75 band")
+
+	// The published wire verdict must carry the same decoupled values.
+	require.Len(t, pub.records, 1)
+	var v contracts.EmailsVerdict
+	require.NoError(t, json.Unmarshal(pub.records[0].value, &v))
+	require.Equal(t, string(LabelPhishing), v.VerdictLabel)
+	require.Equal(t, natural, v.Confidence)
+}
+
+// TestHandle_DegradedMalwareBandConfidenceNotCollapsed drives the DEGRADED
+// (publishDegraded) path: rules cache unavailable, attachment-dominant
+// malware-band score. It asserts the verdict reconciles to malware and the
+// confidence is the natural malware-band value scaled by the rule-source
+// 0.5 factor — never the collapsed phishing-band value. Guards engine.go:408-410.
+func TestHandle_DegradedMalwareBandConfidenceNotCollapsed(t *testing.T) {
+	t.Parallel()
+	writer := &fakeWriter{out: persist.Output{CampaignID: 17, VerdictID: 44, EmailCount: 1}}
+	pub := &fakePublisher{}
+	eng := New(
+		Config{},
+		nil, // unavailable rules cache → degraded path
+		fakeSimhash{},
+		writer,
+		pub,
+		nil,
+		zerolog.Nop(),
+	)
+
+	// Attachment=URL=90 → blend 90, attachment dominant (tie wins) → malware.
+	comps := Components{Attachment: ptrInt(90), URL: ptrInt(90)}
+	msg := makeScoredMessageWith(t, 6001, "e6001", comps)
+
+	err := eng.Handle(context.Background(), msg)
+	require.NoError(t, err)
+	require.Equal(t, 1, writer.writes)
+	require.Equal(t, VerdictSourceRule, writer.lastInput.VerdictSource, "degraded path is rule-sourced")
+
+	const finalScore = 90
+	require.Equal(t, finalScore, writer.lastInput.RiskScore)
+	require.Equal(t, string(LabelMalware), writer.lastInput.Label, "attachment-dominant high score reconciles to malware")
+
+	natural := Confidence(finalScore, LabelFor(finalScore), false, VerdictSourceRule)
+	collapsed := Confidence(finalScore, LabelPhishing, false, VerdictSourceRule)
+	require.NotEqual(t, natural, collapsed, "test precondition: the two bands must differ")
+	require.Equal(t, natural, writer.lastInput.Confidence,
+		"degraded path confidence must use the natural malware band (rule-scaled), not the phishing band")
+
+	require.Len(t, pub.records, 1)
+	var v contracts.EmailsVerdict
+	require.NoError(t, json.Unmarshal(pub.records[0].value, &v))
+	require.Equal(t, string(LabelMalware), v.VerdictLabel)
+	require.Equal(t, natural, v.Confidence)
 }
 
 func TestHandle_UsesStoredKafkaWireOnDedupeReplay(t *testing.T) {

--- a/services/svc-08-decision/internal/engine/label.go
+++ b/services/svc-08-decision/internal/engine/label.go
@@ -88,6 +88,24 @@ func attachmentIsDominantHigh(c Components) bool {
 	return true
 }
 
+// verdictLabelAndConfidence computes the persisted/wire verdict label and
+// its confidence for a final score. This is the single seam both the main
+// (Handle) and degraded (publishDegraded) paths use, so the two CANNOT
+// drift apart and the confidence-trap invariant is exercised by one set of
+// tests.
+//
+// The label is RECONCILED (malware vs phishing(high) in the 76–100 band per
+// §3.6). The confidence is deliberately computed against the score's NATURAL
+// band — Confidence(finalScore, LabelFor(finalScore), …) — NOT the reconciled
+// label. Threading the reconciled label into Confidence is the regression the
+// brief warns about: an 85 reclassified to phishing would measure distance
+// against the 51–75 band and collapse confidence toward 0. See §3.6/§3.7.
+func verdictLabelAndConfidence(finalScore int, c Components, partialAnalysis bool, source string) (Label, float64) {
+	label := ReconcileLabel(finalScore, c)
+	confidence := Confidence(finalScore, LabelFor(finalScore), partialAnalysis, source)
+	return label, confidence
+}
+
 // LabelBand returns the [lower, upper] threshold bounds of the label's
 // score band. Used by the confidence formula to compute distance from
 // the nearest threshold.

--- a/services/svc-08-decision/internal/engine/label.go
+++ b/services/svc-08-decision/internal/engine/label.go
@@ -35,6 +35,59 @@ func LabelFor(score int) Label {
 	}
 }
 
+// ReconcileLabel refines the verdict label inside the high-risk band so
+// the pipeline distinguishes "phishing(high)" from "malware" per design
+// brief §3.6. It returns LabelFor(score) unchanged for every band except
+// the malware band (76–100), where it returns:
+//
+//   - LabelMalware  — only when the attachment component is the dominant
+//     high driver of the score (see attachmentIsDominantHigh).
+//   - LabelPhishing — otherwise (the high score is driven by URL/header/
+//     NLP signals, i.e. phishing(high)).
+//
+// Bands 0–75 are returned verbatim; this is purely a malware-vs-phishing
+// disambiguation of the top band.
+//
+// IMPORTANT: this changes only the persisted/wire label string. Confidence
+// must still be computed against the SCORE's natural band via
+// Confidence(score, LabelFor(score), …) — passing the reconciled phishing
+// label for an 85 score would collapse confidence to 0. See §3.6/§3.7.
+func ReconcileLabel(score int, c Components) Label {
+	base := LabelFor(score)
+	if base != LabelMalware {
+		return base
+	}
+	if attachmentIsDominantHigh(c) {
+		return LabelMalware
+	}
+	return LabelPhishing
+}
+
+// attachmentIsDominantHigh reports whether the attachment component is
+// the dominant high driver of the blended score. It is true iff the
+// attachment score is present, is itself in the malware band (≥ 76, the
+// malware-band floor), and is ≥ every other PRESENT component (a nil
+// component is not "present" and is ignored; if attachment is the only
+// present component it is trivially the max). Ties go to attachment
+// (>=), so an attachment tied with another high component still yields
+// malware — the more severe of the two equally-plausible labels.
+func attachmentIsDominantHigh(c Components) bool {
+	if c.Attachment == nil || *c.Attachment < 76 {
+		return false
+	}
+	att := *c.Attachment
+	if c.URL != nil && *c.URL > att {
+		return false
+	}
+	if c.Header != nil && *c.Header > att {
+		return false
+	}
+	if c.NLP != nil && *c.NLP > att {
+		return false
+	}
+	return true
+}
+
 // LabelBand returns the [lower, upper] threshold bounds of the label's
 // score band. Used by the confidence formula to compute distance from
 // the nearest threshold.

--- a/services/svc-08-decision/internal/engine/label.go
+++ b/services/svc-08-decision/internal/engine/label.go
@@ -40,10 +40,12 @@ func LabelFor(score int) Label {
 // brief §3.6. It returns LabelFor(score) unchanged for every band except
 // the malware band (76–100), where it returns:
 //
-//   - LabelMalware  — only when the attachment component is the dominant
-//     high driver of the score (see attachmentIsDominantHigh).
+//   - LabelMalware  — whenever a high, malware-grade attachment is present
+//     (see hasHighAttachment). A confirmed malware-grade attachment makes
+//     the verdict malware even when a URL/header/NLP signal scored higher,
+//     because the malicious attachment is the more actionable threat.
 //   - LabelPhishing — otherwise (the high score is driven by URL/header/
-//     NLP signals, i.e. phishing(high)).
+//     NLP signals with no malware-grade attachment, i.e. phishing(high)).
 //
 // Bands 0–75 are returned verbatim; this is purely a malware-vs-phishing
 // disambiguation of the top band.
@@ -57,35 +59,22 @@ func ReconcileLabel(score int, c Components) Label {
 	if base != LabelMalware {
 		return base
 	}
-	if attachmentIsDominantHigh(c) {
+	if hasHighAttachment(c) {
 		return LabelMalware
 	}
 	return LabelPhishing
 }
 
-// attachmentIsDominantHigh reports whether the attachment component is
-// the dominant high driver of the blended score. It is true iff the
-// attachment score is present, is itself in the malware band (≥ 76, the
-// malware-band floor), and is ≥ every other PRESENT component (a nil
-// component is not "present" and is ignored; if attachment is the only
-// present component it is trivially the max). Ties go to attachment
-// (>=), so an attachment tied with another high component still yields
-// malware — the more severe of the two equally-plausible labels.
-func attachmentIsDominantHigh(c Components) bool {
-	if c.Attachment == nil || *c.Attachment < 76 {
-		return false
-	}
-	att := *c.Attachment
-	if c.URL != nil && *c.URL > att {
-		return false
-	}
-	if c.Header != nil && *c.Header > att {
-		return false
-	}
-	if c.NLP != nil && *c.NLP > att {
-		return false
-	}
-	return true
+// hasHighAttachment reports whether the email carries a high, malware-grade
+// attachment: the attachment component is present (a nil component is
+// "absent", not 0) and is itself in the malware band (≥ 76, the malware-band
+// floor). Per §3.6 a malware-grade attachment makes the top-band verdict
+// "malware" regardless of the other components — even when a URL/header/NLP
+// signal scored higher — because a confirmed malicious attachment is the more
+// actionable threat. Attachments below the floor (< 76) leave the verdict
+// phishing(high).
+func hasHighAttachment(c Components) bool {
+	return c.Attachment != nil && *c.Attachment >= 76
 }
 
 // verdictLabelAndConfidence computes the persisted/wire verdict label and

--- a/services/svc-08-decision/internal/engine/label.go
+++ b/services/svc-08-decision/internal/engine/label.go
@@ -35,29 +35,28 @@ func LabelFor(score int) Label {
 	}
 }
 
-// ReconcileLabel refines the verdict label inside the high-risk band so
-// the pipeline distinguishes "phishing(high)" from "malware" per design
-// brief §3.6. It returns LabelFor(score) unchanged for every band except
-// the malware band (76–100), where it returns:
+// ReconcileLabel refines the verdict label inside the high-risk band so the
+// pipeline distinguishes "phishing(high)" from "malware" per design brief §3.6.
+// Bands 0–75 are returned verbatim; only the malware band (76–100) is split:
 //
-//   - LabelMalware  — whenever a high, malware-grade attachment is present
-//     (see hasHighAttachment). A confirmed malware-grade attachment makes
-//     the verdict malware even when a URL/header/NLP signal scored higher,
-//     because the malicious attachment is the more actionable threat.
-//   - LabelPhishing — otherwise (the high score is driven by URL/header/
-//     NLP signals with no malware-grade attachment, i.e. phishing(high)).
+//   - LabelMalware  — a high, malware-grade attachment is present (see
+//     hasHighAttachment). It wins even when a URL/header/NLP signal scored
+//     higher, because the malicious attachment is the more actionable threat.
+//   - LabelPhishing — otherwise (high score driven by URL/header/NLP signals
+//     with no malware-grade attachment, i.e. phishing(high)).
 //
-// Bands 0–75 are returned verbatim; this is purely a malware-vs-phishing
-// disambiguation of the top band.
-//
-// IMPORTANT: this changes only the persisted/wire label string. Confidence
-// must still be computed against the SCORE's natural band via
-// Confidence(score, LabelFor(score), …) — passing the reconciled phishing
-// label for an 85 score would collapse confidence to 0. See §3.6/§3.7.
+// This refines only the persisted/wire label; confidence MUST stay on the
+// score's natural band — see verdictLabelAndConfidence for the why.
 func ReconcileLabel(score int, c Components) Label {
-	base := LabelFor(score)
-	if base != LabelMalware {
-		return base
+	return reconcile(LabelFor(score), c)
+}
+
+// reconcile applies the malware-vs-phishing split to an already-computed
+// natural-band label, so the hot path can derive the band once and feed it to
+// both the reconcile and the confidence formula without recomputing LabelFor.
+func reconcile(natural Label, c Components) Label {
+	if natural != LabelMalware {
+		return natural
 	}
 	if hasHighAttachment(c) {
 		return LabelMalware
@@ -65,34 +64,30 @@ func ReconcileLabel(score int, c Components) Label {
 	return LabelPhishing
 }
 
-// hasHighAttachment reports whether the email carries a high, malware-grade
-// attachment: the attachment component is present (a nil component is
-// "absent", not 0) and is itself in the malware band (≥ 76, the malware-band
-// floor). Per §3.6 a malware-grade attachment makes the top-band verdict
-// "malware" regardless of the other components — even when a URL/header/NLP
-// signal scored higher — because a confirmed malicious attachment is the more
-// actionable threat. Attachments below the floor (< 76) leave the verdict
-// phishing(high).
+// hasHighAttachment reports whether the email carries a malware-grade
+// attachment: the attachment component is present (a nil component is "absent",
+// not 0) and is itself in the malware band. The floor is taken from
+// LabelBand(LabelMalware) so it can never drift from LabelFor's band edges.
 func hasHighAttachment(c Components) bool {
-	return c.Attachment != nil && *c.Attachment >= 76
+	floor, _ := LabelBand(LabelMalware)
+	return c.Attachment != nil && *c.Attachment >= floor
 }
 
-// verdictLabelAndConfidence computes the persisted/wire verdict label and
-// its confidence for a final score. This is the single seam both the main
-// (Handle) and degraded (publishDegraded) paths use, so the two CANNOT
-// drift apart and the confidence-trap invariant is exercised by one set of
-// tests.
+// verdictLabelAndConfidence computes the persisted/wire verdict label and its
+// confidence for a final score. Both the main (Handle) and degraded
+// (publishDegraded) paths go through this single seam, so the two cannot drift
+// and one set of tests covers the invariant below.
 //
-// The label is RECONCILED (malware vs phishing(high) in the 76–100 band per
-// §3.6). The confidence is deliberately computed against the score's NATURAL
-// band — Confidence(finalScore, LabelFor(finalScore), …) — NOT the reconciled
-// label. Threading the reconciled label into Confidence is the regression the
-// brief warns about: an 85 reclassified to phishing would measure distance
-// against the 51–75 band and collapse confidence toward 0. See §3.6/§3.7.
+// CONFIDENCE TRAP: the label is reconciled (malware vs phishing(high) in the
+// 76–100 band per §3.6), but confidence is computed against the score's NATURAL
+// band, never the reconciled label. Threading the reconciled label in would
+// measure an 85 reclassified to phishing against the 51–75 band and collapse
+// confidence toward 0. The natural band is bound to `natural` once and passed
+// straight to Confidence; there is deliberately no reconciled-label variable in
+// scope to thread in by mistake. See §3.6/§3.7.
 func verdictLabelAndConfidence(finalScore int, c Components, partialAnalysis bool, source string) (Label, float64) {
-	label := ReconcileLabel(finalScore, c)
-	confidence := Confidence(finalScore, LabelFor(finalScore), partialAnalysis, source)
-	return label, confidence
+	natural := LabelFor(finalScore)
+	return reconcile(natural, c), Confidence(finalScore, natural, partialAnalysis, source)
 }
 
 // LabelBand returns the [lower, upper] threshold bounds of the label's

--- a/services/svc-08-decision/internal/engine/label_test.go
+++ b/services/svc-08-decision/internal/engine/label_test.go
@@ -76,43 +76,59 @@ func TestReconcileLabel(t *testing.T) {
 	}
 }
 
-// TestReconcileLabel_ConfidenceInvariant guards the confidence trap: a
-// score in the malware band reclassified to phishing must keep the SAME
-// confidence it would have had as malware, because confidence is computed
-// against the score's NATURAL band (LabelFor), independent of the
-// malware-vs-phishing renaming. If confidence ever started keying off the
-// reconciled label, an 85→phishing would measure against the 51–75 band
-// and collapse to 0 — this test would catch that regression.
-func TestReconcileLabel_ConfidenceInvariant(t *testing.T) {
+// TestVerdictLabelAndConfidence_ConfidenceTrap guards the confidence trap
+// at the EXACT production seam both Handle and publishDegraded call:
+// verdictLabelAndConfidence. A malware-band score reclassified to phishing
+// must keep the confidence of its NATURAL (76–100) band, because confidence
+// is computed against LabelFor(score), not the reconciled label.
+//
+// This is not a tautology: it derives the "buggy" value from the reconciled
+// label and asserts the helper does NOT use it. Were a future edit to thread
+// the reconciled label into Confidence (the regression the brief warns
+// about), the phishing case below would collapse from the natural band value
+// to the 51–75-band value and these assertions would fail.
+func TestVerdictLabelAndConfidence_ConfidenceTrap(t *testing.T) {
 	const score = 85
-	// Two component sets that yield the same score band but different
-	// reconciled labels.
+
+	// A high-band component set whose reconciled label is phishing(high)
+	// (URL-driven, no dominant attachment) and one whose reconciled label is
+	// malware (attachment-dominant). The trap only bites the phishing case.
+	phishingCase := Components{URL: ptrInt(85)}                        // → phishing(high)
 	malwareCase := Components{Attachment: ptrInt(90), URL: ptrInt(40)} // → malware
-	phishingCase := Components{URL: ptrInt(85)}                        // → phishing
 
-	if got := ReconcileLabel(score, malwareCase); got != LabelMalware {
-		t.Fatalf("precondition: malwareCase reconciled to %v, want malware", got)
-	}
-	if got := ReconcileLabel(score, phishingCase); got != LabelPhishing {
-		t.Fatalf("precondition: phishingCase reconciled to %v, want phishing", got)
-	}
-
-	// Confidence is always computed against LabelFor(score), so both must
-	// match — and both must equal the natural malware-band confidence.
+	// The natural-band confidence the helper MUST return regardless of the
+	// reconciled label, and the collapsed value the buggy wiring WOULD return
+	// for the phishing case. They must differ, or the test proves nothing.
 	natural := Confidence(score, LabelFor(score), false, VerdictSourceModel)
-	confMalware := Confidence(score, LabelFor(score), false, VerdictSourceModel)
-	confPhishing := Confidence(score, LabelFor(score), false, VerdictSourceModel)
-
-	if confMalware != natural || confPhishing != natural {
-		t.Fatalf("confidence drifted from natural band: malware=%v phishing=%v natural=%v",
-			confMalware, confPhishing, natural)
+	buggyCollapsed := Confidence(score, LabelPhishing, false, VerdictSourceModel)
+	if natural == buggyCollapsed {
+		t.Fatalf("test cannot exercise the trap: natural-band confidence (%v) equals "+
+			"the reconciled-phishing-band value (%v)", natural, buggyCollapsed)
 	}
-	// Sanity: had we (wrongly) keyed confidence off the reconciled phishing
-	// label, it would differ from the natural malware-band value.
-	wrong := Confidence(score, LabelPhishing, false, VerdictSourceModel)
-	if wrong == natural {
-		t.Fatalf("test is not exercising the trap: phishing-band confidence (%v) equals natural (%v)",
-			wrong, natural)
+
+	gotPhishLabel, gotPhishConf := verdictLabelAndConfidence(score, phishingCase, false, VerdictSourceModel)
+	if gotPhishLabel != LabelPhishing {
+		t.Fatalf("phishing case: label = %v, want phishing", gotPhishLabel)
+	}
+	if gotPhishConf != natural {
+		t.Fatalf("CONFIDENCE TRAP: phishing-reconciled label collapsed confidence to %v; "+
+			"must stay at the natural malware-band value %v (got the buggy %v? %t)",
+			gotPhishConf, natural, buggyCollapsed, gotPhishConf == buggyCollapsed)
+	}
+
+	gotMalLabel, gotMalConf := verdictLabelAndConfidence(score, malwareCase, false, VerdictSourceModel)
+	if gotMalLabel != LabelMalware {
+		t.Fatalf("malware case: label = %v, want malware", gotMalLabel)
+	}
+	if gotMalConf != natural {
+		t.Fatalf("malware case: confidence = %v, want natural-band %v", gotMalConf, natural)
+	}
+
+	// The whole point: labels differ (malware vs phishing) yet confidences are
+	// identical — the reconcile renames the label without perturbing confidence.
+	if gotPhishConf != gotMalConf {
+		t.Fatalf("confidence must be label-independent: phishing=%v malware=%v",
+			gotPhishConf, gotMalConf)
 	}
 }
 

--- a/services/svc-08-decision/internal/engine/label_test.go
+++ b/services/svc-08-decision/internal/engine/label_test.go
@@ -44,17 +44,20 @@ func TestReconcileLabel(t *testing.T) {
 		c     Components
 		want  Label
 	}{
-		// Malware band (76–100): malware whenever a high (≥76) attachment
-		// is present, regardless of the other components.
+		// Malware band (76–100): malware whenever a high (≥76) attachment is
+		// present. ReconcileLabel never COMPARES components — the other scores'
+		// magnitudes are irrelevant; only "is the attachment ≥ the floor" matters.
+		// The cases below set non-attachment components purely to prove they are
+		// ignored, not because they participate in a comparison.
 		{"high attachment → malware", 85, Components{Attachment: ptrInt(90), URL: ptrInt(40)}, LabelMalware},
 		{"attachment nil in band → phishing", 85, Components{URL: ptrInt(85)}, LabelPhishing},
 		{"attachment present but below floor → phishing", 85, Components{Attachment: ptrInt(30), URL: ptrInt(80)}, LabelPhishing},
 		{"attachment just below floor (75) → phishing", 85, Components{Attachment: ptrInt(75), URL: ptrInt(95)}, LabelPhishing},
-		{"high attachment even though URL strictly higher → malware", 90, Components{Attachment: ptrInt(80), URL: ptrInt(95)}, LabelMalware},
-		{"high attachment even though NLP higher → malware (smoke case)", 80, Components{Attachment: ptrInt(90), NLP: ptrInt(100), Header: ptrInt(60)}, LabelMalware},
-		{"attachment ties another high component → malware", 85, Components{Attachment: ptrInt(90), URL: ptrInt(90)}, LabelMalware},
+		{"high attachment, larger URL ignored → malware", 90, Components{Attachment: ptrInt(80), URL: ptrInt(95)}, LabelMalware},
+		{"high attachment, larger NLP/Header ignored → malware (smoke case)", 80, Components{Attachment: ptrInt(90), NLP: ptrInt(100), Header: ptrInt(60)}, LabelMalware},
+		{"high attachment, equal URL ignored → malware", 85, Components{Attachment: ptrInt(90), URL: ptrInt(90)}, LabelMalware},
 		{"attachment only present component → malware", 85, Components{Attachment: ptrInt(80)}, LabelMalware},
-		{"attachment at floor (76), URL higher → malware", 85, Components{Attachment: ptrInt(76), URL: ptrInt(99)}, LabelMalware},
+		{"attachment at floor (76), larger URL ignored → malware", 85, Components{Attachment: ptrInt(76), URL: ptrInt(99)}, LabelMalware},
 		{"no components in band → phishing", 90, Components{}, LabelPhishing},
 
 		// Boundary at 76, both ways.

--- a/services/svc-08-decision/internal/engine/label_test.go
+++ b/services/svc-08-decision/internal/engine/label_test.go
@@ -37,6 +37,85 @@ func TestLabelBand_RoundTrip(t *testing.T) {
 	}
 }
 
+func TestReconcileLabel(t *testing.T) {
+	tests := []struct {
+		name  string
+		score int
+		c     Components
+		want  Label
+	}{
+		// Malware band (76–100): malware only when attachment is the
+		// dominant high driver.
+		{"attachment dominant & high → malware", 85, Components{Attachment: ptrInt(90), URL: ptrInt(40)}, LabelMalware},
+		{"attachment nil in band → phishing", 85, Components{URL: ptrInt(85)}, LabelPhishing},
+		{"attachment present but low → phishing", 85, Components{Attachment: ptrInt(30), URL: ptrInt(80)}, LabelPhishing},
+		{"attachment present but not dominant → phishing", 85, Components{Attachment: ptrInt(70), URL: ptrInt(95)}, LabelPhishing},
+		{"attachment ties high driver → malware (ties win)", 85, Components{Attachment: ptrInt(90), URL: ptrInt(90)}, LabelMalware},
+		{"attachment only present component → malware", 85, Components{Attachment: ptrInt(80)}, LabelMalware},
+		{"attachment high but URL strictly higher → phishing", 90, Components{Attachment: ptrInt(80), URL: ptrInt(81)}, LabelPhishing},
+		{"no components in band → phishing", 90, Components{}, LabelPhishing},
+
+		// Boundary at 76, both ways.
+		{"score 76 attachment dominant → malware", 76, Components{Attachment: ptrInt(80), URL: ptrInt(50)}, LabelMalware},
+		{"score 76 no attachment → phishing", 76, Components{URL: ptrInt(70)}, LabelPhishing},
+		{"score 76 attachment below floor → phishing", 76, Components{Attachment: ptrInt(75), URL: ptrInt(60)}, LabelPhishing},
+
+		// Bands 0–75 are unaffected by the reconcile — attachment is
+		// ignored entirely.
+		{"benign band unaffected", 10, Components{Attachment: ptrInt(99)}, LabelBenign},
+		{"suspicious band unaffected", 40, Components{Attachment: ptrInt(99)}, LabelSuspicious},
+		{"phishing band unaffected", 70, Components{Attachment: ptrInt(99)}, LabelPhishing},
+		{"phishing band boundary 75 unaffected", 75, Components{Attachment: ptrInt(99)}, LabelPhishing},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ReconcileLabel(tt.score, tt.c); got != tt.want {
+				t.Fatalf("ReconcileLabel(%d, %+v) = %v, want %v", tt.score, tt.c, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestReconcileLabel_ConfidenceInvariant guards the confidence trap: a
+// score in the malware band reclassified to phishing must keep the SAME
+// confidence it would have had as malware, because confidence is computed
+// against the score's NATURAL band (LabelFor), independent of the
+// malware-vs-phishing renaming. If confidence ever started keying off the
+// reconciled label, an 85→phishing would measure against the 51–75 band
+// and collapse to 0 — this test would catch that regression.
+func TestReconcileLabel_ConfidenceInvariant(t *testing.T) {
+	const score = 85
+	// Two component sets that yield the same score band but different
+	// reconciled labels.
+	malwareCase := Components{Attachment: ptrInt(90), URL: ptrInt(40)} // → malware
+	phishingCase := Components{URL: ptrInt(85)}                        // → phishing
+
+	if got := ReconcileLabel(score, malwareCase); got != LabelMalware {
+		t.Fatalf("precondition: malwareCase reconciled to %v, want malware", got)
+	}
+	if got := ReconcileLabel(score, phishingCase); got != LabelPhishing {
+		t.Fatalf("precondition: phishingCase reconciled to %v, want phishing", got)
+	}
+
+	// Confidence is always computed against LabelFor(score), so both must
+	// match — and both must equal the natural malware-band confidence.
+	natural := Confidence(score, LabelFor(score), false, VerdictSourceModel)
+	confMalware := Confidence(score, LabelFor(score), false, VerdictSourceModel)
+	confPhishing := Confidence(score, LabelFor(score), false, VerdictSourceModel)
+
+	if confMalware != natural || confPhishing != natural {
+		t.Fatalf("confidence drifted from natural band: malware=%v phishing=%v natural=%v",
+			confMalware, confPhishing, natural)
+	}
+	// Sanity: had we (wrongly) keyed confidence off the reconciled phishing
+	// label, it would differ from the natural malware-band value.
+	wrong := Confidence(score, LabelPhishing, false, VerdictSourceModel)
+	if wrong == natural {
+		t.Fatalf("test is not exercising the trap: phishing-band confidence (%v) equals natural (%v)",
+			wrong, natural)
+	}
+}
+
 func TestSourceFor(t *testing.T) {
 	tests := []struct {
 		name string

--- a/services/svc-08-decision/internal/engine/label_test.go
+++ b/services/svc-08-decision/internal/engine/label_test.go
@@ -44,19 +44,21 @@ func TestReconcileLabel(t *testing.T) {
 		c     Components
 		want  Label
 	}{
-		// Malware band (76–100): malware only when attachment is the
-		// dominant high driver.
-		{"attachment dominant & high → malware", 85, Components{Attachment: ptrInt(90), URL: ptrInt(40)}, LabelMalware},
+		// Malware band (76–100): malware whenever a high (≥76) attachment
+		// is present, regardless of the other components.
+		{"high attachment → malware", 85, Components{Attachment: ptrInt(90), URL: ptrInt(40)}, LabelMalware},
 		{"attachment nil in band → phishing", 85, Components{URL: ptrInt(85)}, LabelPhishing},
-		{"attachment present but low → phishing", 85, Components{Attachment: ptrInt(30), URL: ptrInt(80)}, LabelPhishing},
-		{"attachment present but not dominant → phishing", 85, Components{Attachment: ptrInt(70), URL: ptrInt(95)}, LabelPhishing},
-		{"attachment ties high driver → malware (ties win)", 85, Components{Attachment: ptrInt(90), URL: ptrInt(90)}, LabelMalware},
+		{"attachment present but below floor → phishing", 85, Components{Attachment: ptrInt(30), URL: ptrInt(80)}, LabelPhishing},
+		{"attachment just below floor (75) → phishing", 85, Components{Attachment: ptrInt(75), URL: ptrInt(95)}, LabelPhishing},
+		{"high attachment even though URL strictly higher → malware", 90, Components{Attachment: ptrInt(80), URL: ptrInt(95)}, LabelMalware},
+		{"high attachment even though NLP higher → malware (smoke case)", 80, Components{Attachment: ptrInt(90), NLP: ptrInt(100), Header: ptrInt(60)}, LabelMalware},
+		{"attachment ties another high component → malware", 85, Components{Attachment: ptrInt(90), URL: ptrInt(90)}, LabelMalware},
 		{"attachment only present component → malware", 85, Components{Attachment: ptrInt(80)}, LabelMalware},
-		{"attachment high but URL strictly higher → phishing", 90, Components{Attachment: ptrInt(80), URL: ptrInt(81)}, LabelPhishing},
+		{"attachment at floor (76), URL higher → malware", 85, Components{Attachment: ptrInt(76), URL: ptrInt(99)}, LabelMalware},
 		{"no components in band → phishing", 90, Components{}, LabelPhishing},
 
 		// Boundary at 76, both ways.
-		{"score 76 attachment dominant → malware", 76, Components{Attachment: ptrInt(80), URL: ptrInt(50)}, LabelMalware},
+		{"score 76 high attachment → malware", 76, Components{Attachment: ptrInt(80), URL: ptrInt(50)}, LabelMalware},
 		{"score 76 no attachment → phishing", 76, Components{URL: ptrInt(70)}, LabelPhishing},
 		{"score 76 attachment below floor → phishing", 76, Components{Attachment: ptrInt(75), URL: ptrInt(60)}, LabelPhishing},
 

--- a/services/svc-08-decision/internal/engine/snapshot.go
+++ b/services/svc-08-decision/internal/engine/snapshot.go
@@ -25,7 +25,14 @@ func BuildSnapshot(in SnapshotInputs) rules.SignalSnapshot {
 		"score.blended":         in.BlendedScore,
 		"score.campaign_nudged": in.NudgedScore,
 		"partial_analysis":      in.Scored.PartialAnalysis,
-		"verdict.label":         string(in.PreRuleLabel),
+		// verdict.label is the PRE-RULE pure score→band label (LabelFor), NOT
+		// the final reconciled verdict. Rules match on it before they run, so it
+		// deliberately ignores the malware-vs-phishing(high) attachment
+		// reconcile: a high-band email with no malware-grade attachment shows
+		// here as "malware" even though its final verdict is "phishing". Rule
+		// authors keying on verdict.label == "malware" are matching the band,
+		// not the published label. See engine.go (preRuleLabel) and brief §3.5.
+		"verdict.label": string(in.PreRuleLabel),
 	}
 
 	if in.Components.URL != nil {


### PR DESCRIPTION
## Summary

svc-08 (decision engine) Batch 5 polish — MVP-shrunk: no ML training, the calibrated weighted blend stays the final scorer.

**Verdict-label reconcile (G7).** Previously every final score in the 76–100 band was labeled `malware`. The top band now distinguishes `malware` from high-confidence `phishing`: a verdict carrying a **high (≥76) malware-grade attachment** is `malware` — even when a URL/header/NLP component scored higher — otherwise it is `phishing(high)`.

- `LabelFor(score)` stays pure (score→band). New `ReconcileLabel(score, components)` + `hasHighAttachment(c)` wrap it; both the main and degraded engine paths go through a single `verdictLabelAndConfidence` seam.
- Confidence is computed against the score's natural band (`LabelFor(finalScore)`), not the reconciled label, so renaming `malware`→`phishing` never collapses confidence toward 0.
- design-brief §3.6 updated.

**sqlc migration (D8).** Already landed in #177 (batch 0a) — `internal/persist` is 100% sqlc-generated (`db.New(tx)`), the byte-shape sync guard passes, and `make generate` shows no drift. No code change needed here; verified only.

## Test plan

- `make build && make vet && make lint && make test-short && make generate` (no sqlc drift) — green
- `make up-infra && make db-setup && make test` — green
- `make smoke` (A1–A7) — green. The canonical attachment email lands `verdict_label: malware` (attachment 90, with URL 100 and NLP 100 above it); the end-to-end trace spans all 10 services.
- New unit/engine tests: `TestReconcileLabel` (band/attachment table incl. boundary 76 and the smoke case), `TestVerdictLabelAndConfidence_ConfidenceTrap`, and two engine-level malware-band tests covering the main and degraded paths.