### PR TITLE
Pipeline hardening: poison resilience, svc-03 URL latency (10x), consumer commit fix

### DIFF
--- a/db/migrations/036_add_suspicious_threat_type.up.sql
+++ b/db/migrations/036_add_suspicious_threat_type.up.sql
@@ -1,0 +1,16 @@
+-- ============================================================
+--  036_add_suspicious_threat_type.sql
+--
+--  Adds the 'suspicious' threat_type emitted by svc-03
+--  (url-analysis) which was missing from the allowlist.  A row
+--  carrying threat_type='suspicious' was rejected by the
+--  trg_normalise_threat_type trigger, NACKing the consumer and
+--  stalling the partition (poison-message stall).
+--
+--  Idempotent: ON CONFLICT (value) DO NOTHING.
+-- ============================================================
+
+INSERT INTO threat_type_values (value)
+VALUES
+	('suspicious')
+ON CONFLICT (value) DO NOTHING;

--- a/internal/phishing/breaker.go
+++ b/internal/phishing/breaker.go
@@ -1,0 +1,129 @@
+package phishing
+
+import (
+	"sync"
+	"time"
+)
+
+// Circuit-breaker tuning. These bound how the detector reacts to a degraded
+// network window where the L2 enricher's per-leg timeouts would otherwise be
+// paid on every single URL.
+const (
+	// breakerWindow is the rolling window over which enrichment failures are
+	// counted.
+	breakerWindow = 30 * time.Second
+	// breakerFailureThreshold is the number of enrichment failures within
+	// breakerWindow that trips the breaker OPEN.
+	breakerFailureThreshold = 5
+	// breakerCooldown is how long the breaker stays OPEN (enrichment skipped,
+	// fail-open) before allowing a single half-open probe.
+	breakerCooldown = 15 * time.Second
+)
+
+// breakerState enumerates the circuit-breaker states.
+type breakerState int
+
+const (
+	breakerClosed   breakerState = iota // healthy: enrichment allowed
+	breakerOpen                         // tripped: enrichment skipped (fail-open)
+	breakerHalfOpen                     // probing: one request allowed through
+)
+
+// nowFunc is overridable in tests so the time-based transitions can be driven
+// deterministically without sleeping.
+var nowFunc = time.Now
+
+// circuitBreaker is a lightweight failure-rate breaker around the L2 network
+// enricher. It is safe for concurrent use (the per-email loop scans URLs in
+// parallel). When OPEN it short-circuits enrichment so each URL fails open
+// immediately instead of independently eating the per-leg timeouts during a
+// degraded-network window.
+type circuitBreaker struct {
+	mu sync.Mutex
+
+	state    breakerState
+	failures []time.Time // failure timestamps within the rolling window
+	openedAt time.Time   // when the breaker last tripped OPEN
+}
+
+func newCircuitBreaker() *circuitBreaker {
+	return &circuitBreaker{state: breakerClosed}
+}
+
+// Allow reports whether an enrichment attempt may proceed. When the breaker is
+// OPEN and the cooldown has elapsed it transitions to HALF-OPEN and lets a
+// single probe through; the caller MUST report the probe's outcome via
+// Success/Failure so the breaker can close or re-open.
+func (b *circuitBreaker) Allow() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	switch b.state {
+	case breakerOpen:
+		if nowFunc().Sub(b.openedAt) >= breakerCooldown {
+			// Cooldown elapsed: allow one probe.
+			b.state = breakerHalfOpen
+			return true
+		}
+		return false
+	case breakerHalfOpen:
+		// A probe is already in flight; hold others until it reports back.
+		return false
+	default: // breakerClosed
+		return true
+	}
+}
+
+// Success records a successful enrichment. From HALF-OPEN it closes the breaker
+// and clears the failure window.
+func (b *circuitBreaker) Success() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if b.state == breakerHalfOpen {
+		b.state = breakerClosed
+		b.failures = nil
+	}
+}
+
+// Failure records a failed/timed-out enrichment. A failure during the HALF-OPEN
+// probe re-opens the breaker immediately. Otherwise the failure is appended to
+// the rolling window and the breaker trips OPEN once the threshold is exceeded.
+func (b *circuitBreaker) Failure() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	now := nowFunc()
+	if b.state == breakerHalfOpen {
+		b.trip(now)
+		return
+	}
+
+	// Drop failures outside the window, then record this one.
+	cutoff := now.Add(-breakerWindow)
+	kept := b.failures[:0]
+	for _, t := range b.failures {
+		if t.After(cutoff) {
+			kept = append(kept, t)
+		}
+	}
+	b.failures = append(kept, now)
+
+	if len(b.failures) >= breakerFailureThreshold {
+		b.trip(now)
+	}
+}
+
+// trip moves the breaker to OPEN. Caller must hold b.mu.
+func (b *circuitBreaker) trip(now time.Time) {
+	b.state = breakerOpen
+	b.openedAt = now
+	b.failures = nil
+}
+
+// State returns the current breaker state (for tests / observability).
+func (b *circuitBreaker) State() breakerState {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.state
+}

--- a/internal/phishing/breaker_test.go
+++ b/internal/phishing/breaker_test.go
@@ -1,0 +1,93 @@
+package phishing
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// withFakeClock swaps nowFunc for a controllable clock and restores it.
+func withFakeClock(t *testing.T) *time.Time {
+	t.Helper()
+	now := time.Now()
+	nowFunc = func() time.Time { return now }
+	t.Cleanup(func() { nowFunc = time.Now })
+	return &now
+}
+
+func TestCircuitBreaker_TripsAfterThreshold(t *testing.T) {
+	clk := withFakeClock(t)
+	b := newCircuitBreaker()
+
+	require.True(t, b.Allow(), "starts closed")
+	require.Equal(t, breakerClosed, b.State())
+
+	// One short of the threshold: still closed and allowing.
+	for i := 0; i < breakerFailureThreshold-1; i++ {
+		b.Failure()
+	}
+	require.Equal(t, breakerClosed, b.State())
+	require.True(t, b.Allow())
+
+	// The threshold-th failure trips it OPEN.
+	b.Failure()
+	require.Equal(t, breakerOpen, b.State())
+	require.False(t, b.Allow(), "OPEN breaker blocks enrichment")
+
+	// Before cooldown elapses it stays OPEN.
+	*clk = clk.Add(breakerCooldown - time.Millisecond)
+	require.False(t, b.Allow())
+
+	// After cooldown it half-opens and allows exactly one probe.
+	*clk = clk.Add(2 * time.Millisecond)
+	require.True(t, b.Allow(), "first call after cooldown probes (half-open)")
+	require.Equal(t, breakerHalfOpen, b.State())
+	require.False(t, b.Allow(), "second concurrent call is held until probe reports")
+}
+
+func TestCircuitBreaker_HalfOpenSuccessCloses(t *testing.T) {
+	clk := withFakeClock(t)
+	b := newCircuitBreaker()
+	for i := 0; i < breakerFailureThreshold; i++ {
+		b.Failure()
+	}
+	require.Equal(t, breakerOpen, b.State())
+
+	*clk = clk.Add(breakerCooldown)
+	require.True(t, b.Allow()) // half-open probe
+	b.Success()
+	require.Equal(t, breakerClosed, b.State(), "successful probe closes the breaker")
+	require.True(t, b.Allow())
+}
+
+func TestCircuitBreaker_HalfOpenFailureReopens(t *testing.T) {
+	clk := withFakeClock(t)
+	b := newCircuitBreaker()
+	for i := 0; i < breakerFailureThreshold; i++ {
+		b.Failure()
+	}
+	*clk = clk.Add(breakerCooldown)
+	require.True(t, b.Allow()) // half-open probe
+	b.Failure()
+	require.Equal(t, breakerOpen, b.State(), "failed probe re-opens the breaker")
+	require.False(t, b.Allow())
+}
+
+func TestCircuitBreaker_OldFailuresAgeOutOfWindow(t *testing.T) {
+	clk := withFakeClock(t)
+	b := newCircuitBreaker()
+
+	// Record threshold-1 failures, then advance past the window so they age out.
+	for i := 0; i < breakerFailureThreshold-1; i++ {
+		b.Failure()
+	}
+	*clk = clk.Add(breakerWindow + time.Second)
+
+	// A fresh burst short of the threshold must NOT trip, because the earlier
+	// failures fell out of the rolling window.
+	for i := 0; i < breakerFailureThreshold-1; i++ {
+		b.Failure()
+	}
+	require.Equal(t, breakerClosed, b.State(), "aged-out failures don't count toward the threshold")
+}

--- a/internal/phishing/detector.go
+++ b/internal/phishing/detector.go
@@ -80,6 +80,7 @@ type Detector struct {
 	client   *phclient.Client
 	metrics  *phclient.Metrics
 	enricher *enricher.Enricher // nil when GeoIP unavailable; Score falls back to /score
+	breaker  *circuitBreaker    // guards the network enricher (fail-open when tripped)
 	log      zerolog.Logger
 }
 
@@ -100,7 +101,7 @@ func NewDetector(cfg Config) (*Detector, error) {
 	if logger.GetLevel() == zerolog.NoLevel {
 		logger = zerolog.Nop()
 	}
-	d := &Detector{cfg: cfg, client: c, metrics: cfg.Metrics, log: logger}
+	d := &Detector{cfg: cfg, client: c, metrics: cfg.Metrics, breaker: newCircuitBreaker(), log: logger}
 	if cfg.GeoIPDir != "" {
 		enr, enrErr := enricher.New(cfg.GeoIPDir)
 		if enrErr != nil {
@@ -150,6 +151,21 @@ func (d *Detector) Score(ctx context.Context, rawURL string) (Result, error) {
 
 	if d.enricher != nil {
 		path = "score-features"
+		// Circuit breaker: during a degraded-network window the enricher's
+		// per-leg timeouts would be paid on every URL. When the breaker is
+		// OPEN we skip enrichment entirely and fail open (benign/low), so a
+		// transient network problem can't stall the whole pipeline. The
+		// breaker is only consulted on the enricher path; the /score fallback
+		// path below already tolerates sidecar failures.
+		if d.breaker != nil && !d.breaker.Allow() {
+			d.metrics.IncScore("benign", "breaker_open")
+			span.SetAttributes(
+				attribute.String("phishing.path", "breaker-open-skip"),
+				attribute.Bool("phishing.breaker_open", true),
+				attribute.String("phishing.verdict", "benign"),
+			)
+			return Result{URL: rawURL, EffectiveURL: rawURL, Verdict: "benign"}, nil
+		}
 		scored, cacheHit, err = d.scoreViaFeatures(ctx, rawURL)
 	} else {
 		path = "score"
@@ -200,6 +216,17 @@ func (d *Detector) Score(ctx context.Context, rawURL string) (Result, error) {
 // transient enricher problem doesn't take down L2 entirely.
 func (d *Detector) scoreViaFeatures(ctx context.Context, rawURL string) (phclient.ScoreResult, bool, error) {
 	eu, enrichErr := d.enricher.Enrich(ctx, rawURL)
+	// Report the enrichment outcome to the breaker so repeated failures in a
+	// degraded-network window trip it OPEN (and a clean run closes a half-open
+	// probe). Done here, immediately after the call, so only the network leg's
+	// health drives the breaker — not the sidecar /score-features call.
+	if d.breaker != nil {
+		if enrichErr != nil {
+			d.breaker.Failure()
+		} else {
+			d.breaker.Success()
+		}
+	}
 	if enrichErr != nil {
 		d.log.Warn().Err(enrichErr).Str("url", rawURL).
 			Msg("Go enricher failed; falling back to /score for this request")

--- a/internal/phishing/enricher/dns_gate_test.go
+++ b/internal/phishing/enricher/dns_gate_test.go
@@ -1,0 +1,75 @@
+package enricher
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestEnrich_DNSGate_SkipsWHOISandHTTPForDeadHost asserts the DNS gate: when a
+// host does not resolve, the expensive WHOIS and HTTP legs must NOT run. We
+// detect "HTTP ran" by pointing the URL at a counting httptest server and
+// priming the DNS cache with a negative (empty) result for its host, so DNS
+// resolution returns "" without a real lookup.
+func TestEnrich_DNSGate_SkipsWHOISandHTTPForDeadHost(t *testing.T) {
+	var httpHits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&httpHits, 1)
+		_, _ = w.Write([]byte("<html><title>x</title></html>"))
+	}))
+	defer srv.Close()
+
+	host := hostOf(t, srv.URL)
+
+	// Prime the DNS cache with a negative result so the gate sees "does not
+	// resolve" without performing a real lookup. (No GeoIP needed: with no IP
+	// the enricher returns before any concurrent leg starts.)
+	globalDNSCache.set(host, "", dnsCacheTTL)
+	t.Cleanup(func() { globalDNSCache.lru.Remove(host) })
+
+	// enricher with a nil geo is fine here because the dead-host path returns
+	// before GeoIP is consulted.
+	e := &Enricher{}
+	eu, err := e.Enrich(context.Background(), srv.URL)
+	require.NoError(t, err)
+	require.Empty(t, eu.IP, "dead host must have no IP")
+	require.Equal(t, int32(0), atomic.LoadInt32(&httpHits), "HTTP leg must be skipped for a dead host")
+	require.Zero(t, eu.HTTP.StatusCode, "no HTTP status when host does not resolve")
+	require.Empty(t, eu.WHOIS.Registrar, "WHOIS leg must be skipped for a dead host")
+}
+
+// TestEnrich_DNSGate_RunsHTTPForLiveHost asserts the complementary case: a host
+// that resolves DOES get the HTTP leg. The full Enrich path needs a GeoIP db
+// (gated on GEOIP_DIR), so we exercise the post-gate legs directly here to
+// confirm a live host's HTTP fetch still runs and parses.
+func TestEnrich_DNSGate_RunsHTTPForLiveHost(t *testing.T) {
+	allowLoopbackForTest(t)
+
+	var httpHits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&httpHits, 1)
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte(`<html lang="en"><head><title>Live</title></head></html>`))
+	}))
+	defer srv.Close()
+
+	host := hostOf(t, srv.URL)
+	require.NotEmpty(t, ResolveIP(context.Background(), host), "loopback host resolves")
+
+	r := FetchHTTP(context.Background(), srv.URL)
+	require.Equal(t, 200, r.StatusCode)
+	require.Equal(t, "Live", r.Title)
+	require.GreaterOrEqual(t, atomic.LoadInt32(&httpHits), int32(1))
+}
+
+func hostOf(t *testing.T, raw string) string {
+	t.Helper()
+	u, err := url.Parse(raw)
+	require.NoError(t, err)
+	return u.Hostname()
+}

--- a/internal/phishing/enricher/enricher.go
+++ b/internal/phishing/enricher/enricher.go
@@ -48,14 +48,25 @@ func (e *Enricher) Close() {
 	}
 }
 
-// Enrich runs all enrichment steps concurrently for one URL.
-// The whole operation is bounded by an 8-second timeout.
+// enricherTimeout bounds the whole enrichment operation. Lowered from 8s: the
+// per-email URL loop now runs these concurrently with a tight per-URL budget,
+// and the two slow legs (WHOIS, HTTP) are themselves capped at ~1.5-2s, so a
+// 2s overall cap keeps the worst-case per-URL latency near that of the slowest
+// single leg rather than letting one host stall the whole email.
+const enricherTimeout = 2 * time.Second
+
+// Enrich runs enrichment for one URL. DNS resolution runs FIRST as a gate: if
+// the host does not resolve (NXDOMAIN / no A or AAAA), the expensive WHOIS and
+// HTTP-GET legs are skipped entirely — you can't fetch a dead host, and most
+// phishing domains are already taken down by the time the email is scored. The
+// remaining cheap legs (GeoIP needs the IP anyway; TLS) still run when there is
+// an IP. The whole operation is bounded by enricherTimeout.
 func (e *Enricher) Enrich(ctx context.Context, rawURL string) (EnrichedURL, error) {
 	ctx, span := enricherTracer.Start(ctx, "enricher.Enrich")
 	defer span.End()
 	span.SetAttributes(attribute.String("enricher.url", rawURL))
 
-	ctx, cancel := context.WithTimeout(ctx, 8*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, enricherTimeout)
 	defer cancel()
 
 	eu := EnrichedURL{OriginalURL: rawURL}
@@ -77,14 +88,32 @@ func (e *Enricher) Enrich(ctx context.Context, rawURL string) (EnrichedURL, erro
 	hostname := extractHostname(effectiveURL)
 	apex := apexDomain(hostname)
 
+	// DNS gate: resolve first. A dead host short-circuits the two 5s legs.
+	eu.IP = ResolveIP(ctx, hostname)
+	span.SetAttributes(attribute.Bool("enricher.resolved", eu.IP != ""))
+
+	if eu.IP == "" {
+		// Host does not resolve: skip WHOIS + HTTP (and TLS, which also needs a
+		// reachable host). Return with whatever cheap signal exists. Features
+		// computed from the zero-value WHOIS/HTTP/TLS correctly read as "unknown".
+		span.SetAttributes(attribute.Bool("enricher.dns_gate_skip", true))
+		eu.Features = ComputeFeatures(eu)
+		return eu, nil
+	}
+
 	g, gctx := errgroup.WithContext(ctx)
 
-	// DNS + GeoIP (sequential: GeoIP needs the IP)
-	ipCh := make(chan string, 1)
+	// GeoIP (DNS already delivered the IP). GeoIPLookup.Lookup has no ctx of its
+	// own, so wrap it in a span here for trace continuity.
 	g.Go(func() error {
-		ip := ResolveIP(gctx, hostname)
-		eu.IP = ip
-		ipCh <- ip
+		_, geoSpan := enricherTracer.Start(gctx, "enricher.geoip.Lookup")
+		geoSpan.SetAttributes(attribute.String("enricher.ip", eu.IP))
+		eu.Geo = e.geo.Lookup(eu.IP)
+		geoSpan.SetAttributes(
+			attribute.String("enricher.country", eu.Geo.Country),
+			attribute.Int64("enricher.asn", int64(eu.Geo.ASN)),
+		)
+		geoSpan.End()
 		return nil
 	})
 
@@ -103,26 +132,6 @@ func (e *Enricher) Enrich(ctx context.Context, rawURL string) (EnrichedURL, erro
 	// HTTP
 	g.Go(func() error {
 		eu.HTTP = FetchHTTP(gctx, effectiveURL)
-		return nil
-	})
-
-	// GeoIP (starts after DNS delivers the IP). GeoIPLookup.Lookup has no
-	// ctx of its own, so wrap it in a span here for trace continuity.
-	g.Go(func() error {
-		select {
-		case ip := <-ipCh:
-			if ip != "" {
-				_, geoSpan := enricherTracer.Start(gctx, "enricher.geoip.Lookup")
-				geoSpan.SetAttributes(attribute.String("enricher.ip", ip))
-				eu.Geo = e.geo.Lookup(ip)
-				geoSpan.SetAttributes(
-					attribute.String("enricher.country", eu.Geo.Country),
-					attribute.Int64("enricher.asn", int64(eu.Geo.ASN)),
-				)
-				geoSpan.End()
-			}
-		case <-gctx.Done():
-		}
 		return nil
 	})
 

--- a/internal/phishing/enricher/http.go
+++ b/internal/phishing/enricher/http.go
@@ -46,8 +46,11 @@ var (
 	// private, loopback, link-local, or otherwise non-public address.
 	errBlockedAddress = errors.New("blocked: non-public IP address")
 
+	// httpFetchTimeout caps the whole fetch (connect + headers + the capped body
+	// read). Lowered from 5s so the HTTP leg can't dominate the per-URL tail; the
+	// enricher's overall cap is ~2s.
 	httpClient = &http.Client{
-		Timeout: 5 * time.Second,
+		Timeout: 1500 * time.Millisecond,
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			if len(via) >= 10 {
 				return http.ErrUseLastResponse
@@ -61,7 +64,7 @@ var (
 			return nil
 		},
 		Transport: &http.Transport{
-			ResponseHeaderTimeout: 5 * time.Second,
+			ResponseHeaderTimeout: 1500 * time.Millisecond,
 			DialContext:           safeDialContext,
 		},
 	}
@@ -136,6 +139,12 @@ func blockNonPublicControl(_, address string, _ syscall.RawConn) error {
 
 const browserUA = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36"
 
+// httpBodyReadCap bounds how much of the response body FetchHTTP reads. The
+// lightweight HTML signals we extract live in the <head> and early body, so
+// 32 KB is enough while keeping the transfer (and thus the per-URL latency)
+// bounded.
+const httpBodyReadCap = 32 * 1024
+
 // FetchHTTP fetches rawURL and parses relevant fields from the HTML body.
 // Returns zero-value HTTPResult (StatusCode=0) on error, including refusal
 // to fetch non-http(s) schemes and non-public IPs (SSRF guard).
@@ -167,8 +176,14 @@ func FetchHTTP(ctx context.Context, rawURL string) HTTPResult {
 
 	finalURL := resp.Request.URL.String()
 
-	// Read at most 512 KB to avoid memory issues on large pages.
-	body, err := io.ReadAll(io.LimitReader(resp.Body, 512*1024))
+	// Read at most httpBodyReadCap. We keep a GET (not HEAD) so the lightweight
+	// HTML signals we actually use — <title>, <html lang>, the first <form
+	// action>, the favicon link, password-input and hidden-redirect markers —
+	// are still extractable; those all live in the document <head> and early
+	// body. Capping the read at 32 KB (down from 512 KB) bounds the transfer
+	// time so a large or slow-streaming page can't blow the per-URL latency
+	// budget, while still covering the head of essentially every real page.
+	body, err := io.ReadAll(io.LimitReader(resp.Body, httpBodyReadCap))
 	if err != nil {
 		return HTTPResult{StatusCode: resp.StatusCode, FinalURL: finalURL}
 	}

--- a/internal/phishing/enricher/tls.go
+++ b/internal/phishing/enricher/tls.go
@@ -33,7 +33,9 @@ func GetTLSCert(ctx context.Context, hostname string, port int) TLSResult {
 	defer span.End()
 	span.SetAttributes(attribute.String("enricher.hostname", hostname), attribute.Int("enricher.port", port))
 
-	dialCtx, cancel := context.WithTimeout(ctx, 2500*time.Millisecond)
+	// 1.5s: keep the TLS handshake off the per-URL critical-path tail; the
+	// enricher's overall cap is ~2s.
+	dialCtx, cancel := context.WithTimeout(ctx, 1500*time.Millisecond)
 	defer cancel()
 
 	// SSRF guard: hostname comes from a URL in an incoming email. InsecureSkipVerify

--- a/internal/phishing/enricher/whois.go
+++ b/internal/phishing/enricher/whois.go
@@ -22,7 +22,11 @@ const (
 	whoisNegativeTTL = 5 * time.Minute
 	// whoisLookupTimeout bounds the underlying whois.Whois call so the lookup
 	// goroutine cannot outlive the caller's budget by the library's ~30s default.
-	whoisLookupTimeout = 5 * time.Second
+	// Lowered from 5s to keep WHOIS off the per-URL critical-path tail.
+	whoisLookupTimeout = 2 * time.Second
+	// whoisCtxTimeout bounds the per-call wait. Matches whoisLookupTimeout so the
+	// caller doesn't wait longer than the underlying client can take.
+	whoisCtxTimeout = 2 * time.Second
 )
 
 // whoisClient is a shared client with a bounded timeout (#40: the library's
@@ -81,7 +85,7 @@ func LookupWHOIS(ctx context.Context, domain string) WHOISResult {
 	}
 	span.SetAttributes(attribute.Bool("enricher.cache_hit", false))
 
-	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, whoisCtxTimeout)
 	defer cancel()
 
 	type outcome struct {

--- a/services/svc-03-url-analysis/cmd/url-pipeline/main.go
+++ b/services/svc-03-url-analysis/cmd/url-pipeline/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/rs/zerolog"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/saif/cybersiren/internal/phishing"
 	phclient "github.com/saif/cybersiren/internal/phishing/client"
@@ -38,6 +39,34 @@ import (
 const (
 	serviceName    = "svc-03-url-analysis"
 	predictTimeout = 5 * time.Second
+
+	// maxURLsPerEmail caps how many distinct URLs we score per email. A single
+	// crafted email can carry dozens of URLs; without a cap one email could
+	// monopolise the consumer. After dedup we keep the first N in order.
+	maxURLsPerEmail = 15
+	// maxURLConcurrency bounds the number of URLs scanned in parallel for one
+	// email. It also sets the default L1 model pool size so concurrent L1 calls
+	// don't serialise. 8 keeps the worst-case per-email wall-clock at roughly
+	// the per-URL latency (a few seconds) rather than N×per-URL.
+	maxURLConcurrency = 8
+
+	// l2Timeout bounds a single Layer-2 enrichment call. Lowered from 15s: the
+	// enricher's own cap is ~2s, and we want a confirmed worst-case per-URL of
+	// ~1.5-2s rather than letting one slow host stall the whole email.
+	l2Timeout = 1500 * time.Millisecond
+
+	// L2 early-exit thresholds. The expensive L2 network enricher only adds
+	// value in the genuinely-uncertain band; when L1 is already confident we
+	// skip it entirely (the biggest latency win — most URLs never touch the
+	// network). A domain-guard hit already returns before L2 is considered.
+	//
+	//   l1ConfidentPhishingScore: L1 XGBoost score at/above which we trust the
+	//     phishing call without L2 corroboration (mirrors classifyLabel's >=70
+	//     phishing cut, with margin).
+	//   l1ConfidentBenignScore: L1 score at/below which we trust the benign call
+	//     without L2 (well under classifyLabel's 40 suspicious cut).
+	l1ConfidentPhishingScore = 85
+	l1ConfidentBenignScore   = 20
 )
 
 var (
@@ -61,7 +90,9 @@ func main() {
 			scriptPath := deps.Cfg.ML.URLModelPath
 			poolSize := deps.Cfg.ML.URLModelPoolSize
 			if poolSize <= 0 {
-				poolSize = 2
+				// Match the per-email URL scan concurrency so concurrent L1
+				// predictions don't serialize on a smaller worker pool.
+				poolSize = maxURLConcurrency
 			}
 			log := deps.Log
 			m, err := url.NewURLModel(scriptPath, poolSize, func(msg string, e error) {
@@ -165,15 +196,46 @@ func handle(ctx context.Context, msg kafkaconsumer.Message, deps svckit.Deps) er
 
 	log := zerolog.Ctx(ctx).With().Str("email_id", input.Meta.EmailID).Logger()
 
-	scans := make([]urlScan, 0, len(input.URLs))
+	// Dedup by normalized form and cap the count per email before scoring.
+	// Each scan does live network I/O (DNS/TLS/HTTP), so deduping repeated
+	// links and capping a URL-stuffed email is what keeps a single email's
+	// wall-clock bounded. We keep the FIRST occurrence (preserving order) and
+	// note when we truncated.
+	kept, deduped, truncated := dedupAndCapURLs(input.URLs)
+	if deduped > 0 || truncated > 0 {
+		log.Info().
+			Int("urls_in", len(input.URLs)).
+			Int("urls_scanned", len(kept)).
+			Int("deduped", deduped).
+			Int("truncated", truncated).
+			Msg("URL list deduped/capped before scoring")
+	}
+
+	// Scan the kept URLs concurrently with a bounded semaphore. Results are
+	// written to a position-indexed slice (no shared-state race), then the
+	// email aggregate is folded serially below — identical output to the old
+	// serial loop, just computed in parallel.
+	scans := make([]urlScan, len(kept))
+	sem := make(chan struct{}, maxURLConcurrency)
+	g, gctx := errgroup.WithContext(ctx)
+	for i, raw := range kept {
+		i, raw := i, raw
+		g.Go(func() error {
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			scans[i] = scanOne(gctx, raw, log)
+			return nil
+		})
+	}
+	// scanOne never returns an error (it degrades internally), so Wait is only
+	// for the barrier; we ignore the (always-nil) error.
+	_ = g.Wait()
+
 	maxScore := 0
 	maxProb := 0.0
 	maxTIRisk := 0
 	worstLabel := "legitimate"
-
-	for _, raw := range input.URLs {
-		s := scanOne(ctx, raw.URL, log)
-		scans = append(scans, s)
+	for _, s := range scans {
 		if s.Score > maxScore {
 			maxScore = s.Score
 			maxProb = s.Probability
@@ -432,8 +494,23 @@ func scanOne(ctx context.Context, raw string, log zerolog.Logger) urlScan {
 	// Layer 2: ML phishing check fires when TI didn't match OR when TI
 	// matched with low confidence (< 80 risk). classifyLabel ignores
 	// low-confidence TI matches, so we still want L2 to weigh in.
+	//
+	// Staged early-exit (latency): the L2 enricher does live network I/O, so we
+	// only invoke it for the genuinely-uncertain band. When L1 is already
+	// confident (clearly phishing >= l1ConfidentPhishingScore or clearly benign
+	// <= l1ConfidentBenignScore) AND there's no low-confidence TI hint pulling
+	// the verdict the other way, we trust the cheap verdict and skip the network
+	// entirely. A low-confidence TI match (Matched but <80) keeps us in the
+	// uncertain band so L2 can corroborate. This is the biggest latency win —
+	// most URLs never touch the network.
 	ranL2 := false
-	if (!tiRes.Matched || tiRes.RiskScore < 80) && phishingDetector != nil {
+	l2Candidate := (!tiRes.Matched || tiRes.RiskScore < 80) && phishingDetector != nil
+	if l2Candidate && l1Confident(mlScore, routed, tiRes) {
+		scanMetrics.IncOutcome("l2_skipped_confident")
+		span.SetAttributes(attribute.Bool("scan.l2_skipped_confident", true))
+		l2Candidate = false
+	}
+	if l2Candidate {
 		reasonLabel := "ti_miss"
 		if tiRes.Matched {
 			reasonLabel = "ti_low_confidence"
@@ -441,7 +518,7 @@ func scanOne(ctx context.Context, raw string, log zerolog.Logger) urlScan {
 		scanMetrics.IncL2(reasonLabel)
 		ranL2 = true
 
-		mlCtx, mlCancel := context.WithTimeout(ctx, 15*time.Second)
+		mlCtx, mlCancel := context.WithTimeout(ctx, l2Timeout)
 		defer mlCancel()
 		if phishResult, phishErr := phishingDetector.Score(mlCtx, normalized); phishErr != nil {
 			scanMetrics.IncStageError("l2")
@@ -515,6 +592,45 @@ func phishingScore(label string, score int, prob float64) (int, float64) {
 		return 100, 1.0
 	}
 	return score, prob
+}
+
+// l1Confident reports whether the cheap signals (L1 XGBoost score + routing
+// flag, no TI match) already place a URL clearly in the phishing or benign band,
+// so the L2 network enricher can be skipped. A URL routed-to-enrichment or with
+// any TI hit is NOT confident — those stay in the uncertain band so L2 weighs in.
+func l1Confident(mlScore int, routed bool, ti url.TIResult) bool {
+	if ti.Matched || routed {
+		return false
+	}
+	return mlScore >= l1ConfidentPhishingScore || mlScore <= l1ConfidentBenignScore
+}
+
+// dedupAndCapURLs normalises each raw URL, drops duplicates that share a
+// normalized form (keeping the first raw occurrence), and caps the result at
+// maxURLsPerEmail. It returns the kept raw URLs (in first-seen order), the
+// number dropped as duplicates, and the number dropped by the cap.
+//
+// URLs that fail normalisation are kept (deduped on their raw form) so scanOne
+// can still record the normalisation failure rather than silently dropping them.
+func dedupAndCapURLs(urls []contracts.ExtractedURL) (kept []string, deduped, truncated int) {
+	seen := make(map[string]struct{}, len(urls))
+	for _, u := range urls {
+		key := u.URL
+		if n, err := normalization.NormalizeURL(u.URL); err == nil {
+			key = n
+		}
+		if _, dup := seen[key]; dup {
+			deduped++
+			continue
+		}
+		seen[key] = struct{}{}
+		if len(kept) >= maxURLsPerEmail {
+			truncated++
+			continue
+		}
+		kept = append(kept, u.URL)
+	}
+	return kept, deduped, truncated
 }
 
 // worseLabel returns the more severe of two label values.

--- a/services/svc-03-url-analysis/cmd/url-pipeline/main_test.go
+++ b/services/svc-03-url-analysis/cmd/url-pipeline/main_test.go
@@ -4,11 +4,13 @@ package main
 // These run without any external services.
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	urlpkg "github.com/saif/cybersiren/services/svc-03-url-analysis/internal/url"
+	contracts "github.com/saif/cybersiren/shared/contracts/kafka"
 )
 
 func TestPipelineClassifyLabel(t *testing.T) {
@@ -118,6 +120,90 @@ func TestPhishingScore(t *testing.T) {
 			gotScore, gotProb := phishingScore(tc.label, tc.inScore, tc.inProb)
 			assert.Equal(t, tc.wantScore, gotScore)
 			assert.InDelta(t, tc.wantProb, gotProb, 1e-9)
+		})
+	}
+}
+
+func extractedURLs(urls ...string) []contracts.ExtractedURL {
+	out := make([]contracts.ExtractedURL, len(urls))
+	for i, u := range urls {
+		out[i] = contracts.ExtractedURL{URL: u}
+	}
+	return out
+}
+
+func TestDedupAndCapURLs(t *testing.T) {
+	t.Parallel()
+
+	t.Run("dedups by normalized form, keeps first occurrence", func(t *testing.T) {
+		t.Parallel()
+		// These normalize to the same canonical form (trailing slash / case).
+		in := extractedURLs(
+			"https://example.com",
+			"https://example.com/",
+			"https://EXAMPLE.com",
+			"https://other.com/path",
+		)
+		kept, deduped, truncated := dedupAndCapURLs(in)
+		assert.Equal(t, []string{"https://example.com", "https://other.com/path"}, kept)
+		assert.Equal(t, 2, deduped)
+		assert.Equal(t, 0, truncated)
+	})
+
+	t.Run("caps at maxURLsPerEmail after dedup", func(t *testing.T) {
+		t.Parallel()
+		var urls []string
+		for i := 0; i < maxURLsPerEmail+5; i++ {
+			urls = append(urls, fmt.Sprintf("https://distinct-%d.example.com/", i))
+		}
+		kept, deduped, truncated := dedupAndCapURLs(extractedURLs(urls...))
+		assert.Len(t, kept, maxURLsPerEmail)
+		assert.Equal(t, 0, deduped)
+		assert.Equal(t, 5, truncated)
+		// Cap keeps the FIRST N in order.
+		assert.Equal(t, "https://distinct-0.example.com/", kept[0])
+	})
+
+	t.Run("unnormalizable URLs are kept and deduped on raw form", func(t *testing.T) {
+		t.Parallel()
+		in := extractedURLs("not a url", "not a url", "also::bad")
+		kept, deduped, _ := dedupAndCapURLs(in)
+		// "not a url" appears twice → one drop; the distinct bad one survives.
+		assert.Equal(t, 1, deduped)
+		assert.Contains(t, kept, "not a url")
+	})
+
+	t.Run("empty input", func(t *testing.T) {
+		t.Parallel()
+		kept, deduped, truncated := dedupAndCapURLs(nil)
+		assert.Empty(t, kept)
+		assert.Zero(t, deduped)
+		assert.Zero(t, truncated)
+	})
+}
+
+func TestL1Confident(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name   string
+		score  int
+		routed bool
+		ti     urlpkg.TIResult
+		want   bool
+	}{
+		{"clearly phishing → confident, skip L2", l1ConfidentPhishingScore, false, urlpkg.TIResult{}, true},
+		{"clearly benign → confident, skip L2", l1ConfidentBenignScore, false, urlpkg.TIResult{}, true},
+		{"just below phishing cut → uncertain", l1ConfidentPhishingScore - 1, false, urlpkg.TIResult{}, false},
+		{"just above benign cut → uncertain", l1ConfidentBenignScore + 1, false, urlpkg.TIResult{}, false},
+		{"mid-band → uncertain, run L2", 50, false, urlpkg.TIResult{}, false},
+		{"routed always uncertain even if benign-scored", l1ConfidentBenignScore, true, urlpkg.TIResult{}, false},
+		{"any TI match keeps it uncertain", l1ConfidentPhishingScore, false, urlpkg.TIResult{Matched: true, RiskScore: 50}, false},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, l1Confident(tc.score, tc.routed, tc.ti))
 		})
 	}
 }

--- a/services/svc-03-url-analysis/internal/url/model.go
+++ b/services/svc-03-url-analysis/internal/url/model.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	defaultPoolSize    = 3
+	defaultPoolSize    = 8
 	inferenceTimeout   = 5 * time.Second
 	neutralScore       = 50
 	neutralProbability = 0.5

--- a/services/svc-07-aggregator/cmd/aggregator/main.go
+++ b/services/svc-07-aggregator/cmd/aggregator/main.go
@@ -17,6 +17,8 @@ package main
 import (
 	"context"
 	"os"
+	"strconv"
+	"strings"
 
 	"github.com/rs/zerolog"
 	"golang.org/x/sync/errgroup"
@@ -57,7 +59,7 @@ func main() {
 				return errProducerMissing
 			}
 
-			agg = aggregator.New(aggregator.Config{}, store, producer, m, deps.Log)
+			agg = aggregator.New(loadConfig(), store, producer, m, deps.Log)
 			sweeper = aggregator.NewSweeper(agg)
 
 			// Start the sweeper in its own goroutine. Its lifetime is
@@ -86,6 +88,44 @@ func main() {
 		l.Error().Err(err).Send()
 		os.Exit(1)
 	}
+}
+
+// loadConfig builds the aggregator runtime config from optional env overrides.
+// Defaults are unchanged (timeout 30 s, hash TTL 120 s, tombstone gate ON);
+// these knobs let ops raise the sweep window above svc-03's URL-scan latency
+// without a rebuild. Invalid/absent values fall through to aggregator.New's
+// defaults (a non-positive value there is treated as "use default").
+//
+//   - CYBERSIREN_AGGREGATOR__TIMEOUT_SECS  partial-emit threshold (default 30)
+//   - CYBERSIREN_AGGREGATOR__HASH_TTL_SECS bucket/tombstone TTL  (default 120)
+//   - CYBERSIREN_AGGREGATOR__TOMBSTONE     "false"/"0"/"off" disables P1 gate
+func loadConfig() aggregator.Config {
+	var cfg aggregator.Config
+	cfg.TimeoutSecs = envInt("CYBERSIREN_AGGREGATOR__TIMEOUT_SECS")
+	cfg.HashTTLSecs = envInt("CYBERSIREN_AGGREGATOR__HASH_TTL_SECS")
+	if v, ok := os.LookupEnv("CYBERSIREN_AGGREGATOR__TOMBSTONE"); ok {
+		switch strings.ToLower(strings.TrimSpace(v)) {
+		case "false", "0", "off", "no":
+			cfg.SetTombstoneFinalized(false)
+		default:
+			cfg.SetTombstoneFinalized(true)
+		}
+	}
+	return cfg
+}
+
+// envInt parses a non-negative int env var; returns 0 (→ use default) when
+// unset, empty, or unparseable.
+func envInt(key string) int {
+	raw, ok := os.LookupEnv(key)
+	if !ok {
+		return 0
+	}
+	n, err := strconv.Atoi(strings.TrimSpace(raw))
+	if err != nil || n < 0 {
+		return 0
+	}
+	return n
 }
 
 // errors as package-level vars so `go vet` and the linter don't complain

--- a/services/svc-07-aggregator/internal/aggregator/aggregator.go
+++ b/services/svc-07-aggregator/internal/aggregator/aggregator.go
@@ -33,6 +33,21 @@ type Config struct {
 	SweepInterval      time.Duration // How often the sweeper polls (default 5 s)
 	PublishRetries     int           // Inner-loop publish retry budget (default 1)
 	PublishLockTTLSecs int           // Valkey NX lock TTL for emissions (default 180 s)
+	// TombstoneFinalized, when true (default), writes a short-TTL tombstone on
+	// finalization so late component scores are dropped instead of resurrecting
+	// a plan-less bucket (P1). Exposed so ops can disable the gate if needed.
+	// Set it via SetTombstoneFinalized so New can tell "left at zero value"
+	// (→ default ON) from an explicit disable.
+	TombstoneFinalized bool
+	tombstoneSet       bool // true once SetTombstoneFinalized was called
+}
+
+// SetTombstoneFinalized explicitly sets the P1 tombstone gate, marking the
+// field as deliberately configured so New does not override it with the
+// default-ON value. Used by main.go (env override) and tests.
+func (c *Config) SetTombstoneFinalized(v bool) {
+	c.TombstoneFinalized = v
+	c.tombstoneSet = true
 }
 
 // Aggregator is the per-message orchestrator. One instance is shared by
@@ -71,6 +86,12 @@ func New(
 	if cfg.PublishLockTTLSecs <= 0 {
 		// Longer than default producer stall window (writes + retries + backoff).
 		cfg.PublishLockTTLSecs = 180
+	}
+	// Tombstone gate defaults ON; main.go reads CYBERSIREN_AGGREGATOR__TOMBSTONE
+	// to disable it explicitly. The zero value of Config (used by some tests)
+	// thus gets the P1 protection by default — matching production wiring.
+	if !cfg.tombstoneSet {
+		cfg.TombstoneFinalized = true
 	}
 	return &Aggregator{
 		cfg:       cfg,
@@ -122,6 +143,34 @@ func (a *Aggregator) Handle(ctx context.Context, msg kafkaconsumer.Message) erro
 	field := msg.Topic
 	if msg.Topic == contracts.TopicAnalysisPlans {
 		field = fieldPlan
+	}
+
+	// P1 — Tombstone gate. If this email_id was already finalized (emails.scored
+	// emitted and the bucket Del'd), a tombstone with the bucket TTL is present.
+	// A score arriving now is "late": its plan field is gone forever (Kafka
+	// offset committed, never redelivered), so (re)creating a bucket here would
+	// produce a plan-less zombie that the sweeper re-logs every tick until TTL.
+	// Drop the late score cleanly instead. We deliberately DISCARD rather than
+	// re-emit a corrected partial: svc-08 keys idempotency on (internal_id,
+	// fetched_at) and dedupe-skips a second emails.scored for an already-written
+	// verdict (persist/writer.go FindExistingVerdictForEmail → DedupeSkip), so a
+	// re-emit would not update the verdict — it would be silently swallowed.
+	// Correcting late scores is a follow-up that needs svc-08 to recompute on
+	// replay; see the audit's svc-03 P0 for the real fix (land URL scores in time).
+	if a.cfg.TombstoneFinalized {
+		if done, terr := a.store.Exists(ctx, tombstoneKey(orgID, emailID)); terr != nil {
+			// Treat a tombstone-probe failure as "unknown" and fall through:
+			// at worst we recreate a bucket the sweeper will age out, which is
+			// the pre-tombstone behaviour — never NACK on this best-effort gate.
+			a.log.Debug().Err(terr).Str("email_id", emailID).Msg("tombstone probe failed; continuing")
+		} else if done {
+			a.observeMessage(msg.Topic, "late_drop")
+			a.bumpLateDrop("after_finalization")
+			a.log.Debug().Str("topic", msg.Topic).Str("email_id", emailID).Int64("org_id", orgID).
+				Msg("dropping late score: email_id already finalized (tombstoned)")
+			span.SetAttributes(attribute.String("aggregator.status", "late_drop_tombstoned"))
+			return nil
+		}
 	}
 
 	// Persist the message verbatim under the appropriate field. Set
@@ -286,6 +335,10 @@ func (a *Aggregator) publishAndCleanup(
 			Str("email_id", emailID).Int64("org_id", orgID).Int64("internal_id", out.InternalID).
 			Msg("cannot emit emails.scored: internal_id unresolved — dropping; verdict cannot be addressed")
 		a.bumpPublishError("internal_id_unresolved")
+		a.bumpLateDrop("internal_id_unresolved")
+		// Tombstone first: this email_id is finalized-as-dropped, so any late
+		// score must not resurrect a (plan-less) zombie bucket either.
+		a.writeTombstone(ctx, orgID, emailID)
 		_ = a.store.Del(ctx, publishLockKey(orgID, emailID))
 		if err := a.store.Del(ctx, keyForOrgEmail(orgID, emailID)); err != nil {
 			a.log.Debug().Err(err).Str("email_id", emailID).Msg("aggregator del failed; relying on TTL")
@@ -304,6 +357,11 @@ func (a *Aggregator) publishAndCleanup(
 	if err := a.publisher.Publish(ctx, key, body, a.cfg.PublishRetries); err != nil {
 		return fmt.Errorf("publish emails.scored: %w", err)
 	}
+
+	// Tombstone this email_id BEFORE deleting the bucket so a late score that
+	// races in between cannot recreate a plan-less zombie (P1). Best-effort:
+	// on tombstone failure the worst case is the pre-fix behaviour.
+	a.writeTombstone(ctx, orgID, emailID)
 
 	_ = a.store.Del(ctx, publishLockKey(orgID, emailID))
 
@@ -333,6 +391,28 @@ func (a *Aggregator) bumpPublishError(kind string) {
 		return
 	}
 	a.metrics.PublishErrors.WithLabelValues(kind).Inc()
+}
+
+// writeTombstone marks an email_id as finalized so Handle's tombstone gate
+// drops late scores instead of resurrecting a plan-less bucket. TTL matches
+// the bucket TTL: late scores can only arrive within that window (their own
+// bucket would otherwise have TTL'd out), and a longer-lived tombstone would
+// needlessly suppress a legitimately-new same-email_id (which cannot happen
+// for UUIDv7 ids anyway). Best-effort: a write failure is logged, not fatal.
+func (a *Aggregator) writeTombstone(ctx context.Context, orgID int64, emailID string) {
+	if !a.cfg.TombstoneFinalized {
+		return
+	}
+	if err := a.store.SetEX(ctx, tombstoneKey(orgID, emailID), a.cfg.HashTTLSecs, "1"); err != nil {
+		a.log.Debug().Err(err).Str("email_id", emailID).Msg("tombstone write failed; late scores may recreate a bucket")
+	}
+}
+
+func (a *Aggregator) bumpLateDrop(reason string) {
+	if a == nil || a.metrics == nil || a.metrics.LateDrops == nil {
+		return
+	}
+	a.metrics.LateDrops.WithLabelValues(reason).Inc()
 }
 
 func parseStartedAt(s string) time.Time {

--- a/services/svc-07-aggregator/internal/aggregator/aggregator_test.go
+++ b/services/svc-07-aggregator/internal/aggregator/aggregator_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -488,6 +489,122 @@ func TestParseAggregatorBucketKey(t *testing.T) {
 	_, _, lock := parseAggregatorBucketKey("aggregator:publock:7:99")
 	assert.False(t, lock)
 
+	// P1: finalization tombstone keys must never be swept as buckets.
+	_, _, tomb := parseAggregatorBucketKey("aggregator:done:7:99")
+	assert.False(t, tomb, "tombstone keys must not parse as buckets")
+
 	_, _, legacy := parseAggregatorBucketKey("aggregator:42")
 	assert.False(t, legacy, "an org-only key (no email segment) must not parse")
+}
+
+// P1: once an email_id is finalized (emails.scored emitted + bucket Del'd) a
+// tombstone is written. A late component score arriving afterwards must be
+// dropped cleanly — it must NOT recreate a (plan-less) bucket that the sweeper
+// would re-log every tick, and the late-drop metric must increment.
+func TestHandle_Tombstone_SuppressesResurrectedBucket(t *testing.T) {
+	t.Parallel()
+
+	store := newFakeStore()
+	pub := &recorderPublisher{}
+	a := newAgg(t, store, pub)
+	ctx := context.Background()
+
+	emailID, orgID := "e-tomb", int64(1)
+
+	// Complete an email: plan + the one expected (header) score → emit + cleanup.
+	require.NoError(t, a.Handle(ctx, planMsg(t, emailID, orgID, contracts.TopicScoresHeader)))
+	require.NoError(t, a.Handle(ctx, headerMsg(t, emailID, orgID, 4242, 70)))
+	require.Equal(t, 1, pub.count(), "email must finalize")
+
+	// Tombstone + cleared bucket are the post-finalization state.
+	exists, err := store.Exists(ctx, tombstoneKey(orgID, emailID))
+	require.NoError(t, err)
+	assert.True(t, exists, "finalization must write a tombstone")
+	state, _ := store.HGetAll(ctx, keyForOrgEmail(orgID, emailID))
+	assert.Empty(t, state, "bucket must be cleared after finalization")
+
+	before := lateDropCount(t, a, "after_finalization")
+
+	// A late URL score arrives long after finalization — must be dropped, not stored.
+	require.NoError(t, a.Handle(ctx, envelopeMsg(t, contracts.TopicScoresURL, emailID, orgID, 88)))
+	assert.Equal(t, 1, pub.count(), "late score must not trigger another publish")
+
+	state, _ = store.HGetAll(ctx, keyForOrgEmail(orgID, emailID))
+	assert.Empty(t, state, "late score must NOT resurrect a (plan-less) zombie bucket")
+	assert.Equal(t, before+1, lateDropCount(t, a, "after_finalization"), "late drop must be metered")
+
+	// And a sweep over an empty key-space finds no planless zombie to log.
+	NewSweeper(a).tick(ctx)
+}
+
+// P1 disable switch: with the tombstone gate off, the historical behaviour is
+// preserved (a late score recreates a bucket). Guards the config wiring.
+func TestHandle_Tombstone_Disabled_RecreatesBucket(t *testing.T) {
+	t.Parallel()
+
+	store := newFakeStore()
+	pub := &recorderPublisher{}
+	log := zerolog.New(io.Discard)
+	cfg := Config{}
+	cfg.SetTombstoneFinalized(false)
+	a := New(cfg, store, pub, metrics.New(nil), log)
+	a.now = func() time.Time { return time.Date(2026, 5, 3, 10, 0, 0, 0, time.UTC) }
+	ctx := context.Background()
+
+	emailID, orgID := "e-notomb", int64(1)
+
+	require.NoError(t, a.Handle(ctx, planMsg(t, emailID, orgID, contracts.TopicScoresHeader)))
+	require.NoError(t, a.Handle(ctx, headerMsg(t, emailID, orgID, 4242, 70)))
+	require.Equal(t, 1, pub.count())
+
+	exists, err := store.Exists(ctx, tombstoneKey(orgID, emailID))
+	require.NoError(t, err)
+	assert.False(t, exists, "tombstone must not be written when the gate is disabled")
+
+	// Late score recreates a bucket (the pre-fix behaviour) — no tombstone gate.
+	require.NoError(t, a.Handle(ctx, envelopeMsg(t, contracts.TopicScoresURL, emailID, orgID, 88)))
+	state, _ := store.HGetAll(ctx, keyForOrgEmail(orgID, emailID))
+	assert.NotEmpty(t, state, "with the gate off a late score recreates the bucket")
+}
+
+// P3: the sweeper's planless-bucket path must DELETE the bucket on first
+// encounter (not just the lock) so it is never re-swept/re-logged. This kills
+// the log-amplification storm (44,871 logs / 2,881 emails in the incident).
+func TestSweeper_PlanlessBucket_DeletedSoItIsNotReswept(t *testing.T) {
+	t.Parallel()
+
+	store := newFakeStore()
+	pub := &recorderPublisher{}
+	a := newAgg(t, store, pub)
+	ctx := context.Background()
+
+	emailID, orgID := "e-noplan", int64(1)
+
+	// A lone score arrives with NO plan — the bucket exists but is plan-less.
+	a.now = func() time.Time { return time.Date(2026, 5, 3, 10, 0, 0, 0, time.UTC) }
+	require.NoError(t, a.Handle(ctx, envelopeMsg(t, contracts.TopicScoresURL, emailID, orgID, 50)))
+	state, _ := store.HGetAll(ctx, keyForOrgEmail(orgID, emailID))
+	require.NotEmpty(t, state)
+	_, hasPlan := state[fieldPlan]
+	require.False(t, hasPlan, "precondition: bucket has no plan")
+
+	// Age it past the timeout and sweep.
+	a.now = func() time.Time { return time.Date(2026, 5, 3, 10, 0, 31, 0, time.UTC) }
+	NewSweeper(a).tick(ctx)
+
+	assert.Equal(t, 0, pub.count(), "planless bucket must not publish a partial")
+	state, _ = store.HGetAll(ctx, keyForOrgEmail(orgID, emailID))
+	assert.Empty(t, state, "planless bucket must be DELETED on first sweep, not left to re-log until TTL")
+	assert.False(t, store.nxHeld(publishLockKey(orgID, emailID)), "sweep lock must be released")
+
+	// A subsequent sweep finds nothing to process (no re-log, no re-sweep).
+	NewSweeper(a).tick(ctx)
+	state, _ = store.HGetAll(ctx, keyForOrgEmail(orgID, emailID))
+	assert.Empty(t, state)
+}
+
+// lateDropCount reads the aggregator_late_drops_total counter for one reason.
+func lateDropCount(t *testing.T, a *Aggregator, reason string) int {
+	t.Helper()
+	return int(testutil.ToFloat64(a.metrics.LateDrops.WithLabelValues(reason)))
 }

--- a/services/svc-07-aggregator/internal/aggregator/packager.go
+++ b/services/svc-07-aggregator/internal/aggregator/packager.go
@@ -183,6 +183,19 @@ func publishLockKey(orgID int64, emailID string) string {
 	return fmt.Sprintf("%spublock:%d:%s", keyPrefix, orgID, emailID)
 }
 
+// tombstoneKey is a short-TTL marker written when an email_id is finalized
+// (emails.scored emitted and the bucket Del'd). Handle checks it BEFORE
+// (re)creating a bucket so a late component score that arrives after
+// finalization is dropped cleanly instead of resurrecting a plan-less
+// "zombie" bucket that the sweeper would re-log on every tick until TTL.
+//
+// The tombstone is NOT a bucket key (it carries the "done:" segment, which
+// parseAggregatorBucketKey rejects) so the sweeper never scans it as a
+// bucket.
+func tombstoneKey(orgID int64, emailID string) string {
+	return fmt.Sprintf("%sdone:%d:%s", keyPrefix, orgID, emailID)
+}
+
 // parseAggregatorBucketKey parses aggregator:{org}:{email}. Returns ok=false for
 // lock keys (aggregator:publock:...) or malformed keys.
 //
@@ -195,7 +208,7 @@ func parseAggregatorBucketKey(key string) (orgID int64, emailID string, ok bool)
 		return 0, "", false
 	}
 	rest := key[len(keyPrefix):]
-	if strings.HasPrefix(rest, "publock:") {
+	if strings.HasPrefix(rest, "publock:") || strings.HasPrefix(rest, "done:") {
 		return 0, "", false
 	}
 	colon := strings.LastIndexByte(rest, ':')

--- a/services/svc-07-aggregator/internal/aggregator/store.go
+++ b/services/svc-07-aggregator/internal/aggregator/store.go
@@ -18,6 +18,11 @@ type StateStore interface {
 	// SetNXEX performs SET key value NX EX ttlSecs. Returns true if the key
 	// was set (exclusive lock acquired). False means another holder has the lock.
 	SetNXEX(ctx context.Context, key string, ttlSecs int, value string) (bool, error)
+	// SetEX performs SET key value EX ttlSecs (unconditional, with TTL). Used
+	// for finalization tombstones, which must overwrite any stale tombstone.
+	SetEX(ctx context.Context, key string, ttlSecs int, value string) error
+	// Exists reports whether key is present (EXISTS key == 1).
+	Exists(ctx context.Context, key string) (bool, error)
 	// HSetIfAbsent sets field=value only if the field does not already
 	// exist (HSETNX). Returns true when the field was created.
 	HSetIfAbsent(ctx context.Context, key, field, value string) (bool, error)
@@ -61,6 +66,24 @@ func (s *ValkeyStore) SetNXEX(ctx context.Context, key string, ttlSecs int, valu
 		return false, fmt.Errorf("setnx %s: %w", key, err)
 	}
 	return true, nil
+}
+
+func (s *ValkeyStore) SetEX(ctx context.Context, key string, ttlSecs int, value string) error {
+	resp := s.client.Do(ctx,
+		s.client.B().Set().Key(key).Value(value).ExSeconds(int64(ttlSecs)).Build(),
+	)
+	if err := resp.Error(); err != nil {
+		return fmt.Errorf("setex %s: %w", key, err)
+	}
+	return nil
+}
+
+func (s *ValkeyStore) Exists(ctx context.Context, key string) (bool, error) {
+	n, err := s.client.Do(ctx, s.client.B().Exists().Key(key).Build()).AsInt64()
+	if err != nil {
+		return false, fmt.Errorf("exists %s: %w", key, err)
+	}
+	return n > 0, nil
 }
 
 func (s *ValkeyStore) HSetIfAbsent(ctx context.Context, key, field, value string) (bool, error) {

--- a/services/svc-07-aggregator/internal/aggregator/store_fake_test.go
+++ b/services/svc-07-aggregator/internal/aggregator/store_fake_test.go
@@ -21,6 +21,8 @@ type fakeStore struct {
 	errOnHSetNX func(key, field string) error
 	errOnSetNX  func(key string) error
 	errOnExpire func(key string) error
+	errOnSetEX  func(key string) error
+	errOnExists func(key string) error
 }
 
 func newFakeStore() *fakeStore {
@@ -45,6 +47,36 @@ func (f *fakeStore) SetNXEX(_ context.Context, key string, _ int, value string) 
 	f.stringNX[key] = struct{}{}
 	f.stringVals[key] = value
 	return true, nil
+}
+
+func (f *fakeStore) SetEX(_ context.Context, key string, _ int, value string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.errOnSetEX != nil {
+		if err := f.errOnSetEX(key); err != nil {
+			return err
+		}
+	}
+	f.stringNX[key] = struct{}{}
+	f.stringVals[key] = value
+	return nil
+}
+
+func (f *fakeStore) Exists(_ context.Context, key string) (bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.errOnExists != nil {
+		if err := f.errOnExists(key); err != nil {
+			return false, err
+		}
+	}
+	if _, ok := f.stringNX[key]; ok {
+		return true, nil
+	}
+	if _, ok := f.hashes[key]; ok {
+		return true, nil
+	}
+	return false, nil
 }
 
 func (f *fakeStore) HSetIfAbsent(_ context.Context, key, field, value string) (bool, error) {

--- a/services/svc-07-aggregator/internal/aggregator/timeout.go
+++ b/services/svc-07-aggregator/internal/aggregator/timeout.go
@@ -121,11 +121,29 @@ func (s *Sweeper) processKey(ctx context.Context, key string, threshold time.Tim
 	orgID = orgIDKey
 
 	// If the plan never arrived we cannot package a meaningful partial
-	// (we don't know which scores were expected). Drop the lock and let
-	// the bucket TTL out — a "no plan" bucket is a parser bug, not a
-	// pipeline timeout.
+	// (we don't know which scores were expected).
+	//
+	// P3 — log de-amplification. Previously this path only Del'd the lock and
+	// left the planless bucket to TTL out (~120 s), so EVERY 5 s sweep re-found
+	// it and re-logged "without plan" — ~15× amplification (44,871 logs / 2,881
+	// emails in the incident). We now DELETE the bucket itself on first
+	// encounter so it is never re-swept, and log exactly once at Warn.
+	//
+	// Safety: we only reach here when startedAt is already older than the
+	// partial-emit threshold (TimeoutSecs), i.e. the bucket has been alive
+	// past the full aggregation window with no plan. The plan is keyed and
+	// committed once by svc-02; it is not redelivered, so a bucket still
+	// plan-less past the window will NEVER get one — deleting it cannot race a
+	// legitimately-in-flight plan (that plan would have landed inside the
+	// window). With P1 tombstones, late-score resurrection (the dominant source
+	// of these zombies) is already blocked upstream, so this path now sees only
+	// genuine "plan never produced" buckets. Deleting is the correct terminal
+	// action and also stops the sweep CPU.
 	if _, ok := state[fieldPlan]; !ok {
-		a.log.Warn().Str("email_id", emailID).Msg("sweeper: bucket aged out without plan; dropping")
+		a.log.Warn().Str("email_id", emailID).Msg("sweeper: bucket aged out without plan; deleting")
+		if err := a.store.Del(ctx, key); err != nil {
+			a.log.Debug().Err(err).Str("email_id", emailID).Msg("sweeper: planless bucket del failed; relying on TTL")
+		}
 		_ = a.store.Del(ctx, lockKey)
 		return
 	}

--- a/services/svc-07-aggregator/internal/metrics/metrics.go
+++ b/services/svc-07-aggregator/internal/metrics/metrics.go
@@ -15,6 +15,12 @@ type Metrics struct {
 	PartialCompletions  prometheus.Counter
 	ActiveBuckets       prometheus.Gauge
 	PublishErrors       *prometheus.CounterVec // labels: kind=publish|del|hsetnx|hset
+	// LateDrops counts scores discarded after the email_id was already
+	// finalized (reason=after_finalization, P1 tombstone) or because the
+	// resolved internal_id was unresolved/0 (reason=internal_id_unresolved).
+	// These were previously silent; surfacing them turns the "url_risk_score
+	// NULL" symptom into an observable signal.
+	LateDrops *prometheus.CounterVec // labels: reason
 }
 
 // New registers the metrics on reg and returns the holder. Re-registering
@@ -59,6 +65,14 @@ func New(reg *prometheus.Registry) *Metrics {
 			Help: "Errors during emails.scored publish or Valkey housekeeping, by kind.",
 		},
 		[]string{"kind"},
+	))
+
+	m.LateDrops = registerCounterVec(reg, prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "aggregator_late_drops_total",
+			Help: "Component scores dropped without emit, by reason (after_finalization|internal_id_unresolved).",
+		},
+		[]string{"reason"},
 	))
 
 	return m

--- a/shared/config/config.go
+++ b/shared/config/config.go
@@ -341,7 +341,9 @@ func Load() (*Config, error) {
 		ML: MLConfig{
 			NLPServiceURL:    "http://localhost:8001",
 			URLModelPath:     "./ml/inference_script.py",
-			URLModelPoolSize: 3,
+			// Sized to match svc-03's per-email URL concurrency (maxURLConcurrency=8)
+			// so concurrent L1 predictions don't serialize on a smaller worker pool.
+			URLModelPoolSize: 8,
 		},
 		Enrichment: EnrichmentConfig{
 			WorkerCount: 10,

--- a/shared/kafka/consumer/consumer.go
+++ b/shared/kafka/consumer/consumer.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -50,6 +51,12 @@ const maxHandlerRetries = 8
 // after a handler error, so a fast-failing poison record does not spin the poll
 // loop while it burns through its retry budget.
 const retryBackoff = 200 * time.Millisecond
+
+// commitEvery bounds how many successfully-processed records accumulate before
+// the consumer commits, so draining a large backlog cannot spend minutes in a
+// single poll batch without advancing the committed offset (which would leave
+// the consumer reprocessing the same records and never making durable progress).
+const commitEvery = 200
 
 // Handler processes a single Kafka message and returns nil on success.
 //
@@ -142,6 +149,10 @@ func New(cfg Config, log zerolog.Logger, reg *prometheus.Registry) (*Consumer, e
 		kgo.ConsumeTopics(cfg.Topic),
 		kgo.DisableAutoCommit(),
 		kgo.WithHooks(k.Hooks()...),
+		// Surface franz-go's own group-coordination / commit problems (rebalances,
+		// commit failures) which are otherwise invisible. WARN keeps it quiet in
+		// steady state.
+		kgo.WithLogger(kgo.BasicLogger(os.Stderr, kgo.LogLevelWarn, nil)),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("kafka consumer: %w", err)
@@ -310,6 +321,17 @@ func (c *Consumer) Run(ctx context.Context, handler Handler) error {
 				c.observeProcessingLatency(c.cfg.Topic, c.cfg.GroupID, time.Since(start))
 				toCommit = append(toCommit, rec)
 				span.End()
+
+				// Commit incrementally so a single large poll batch (e.g. when
+				// draining a backlog) cannot process for minutes without ever
+				// advancing the committed offset. Without this, the offset only
+				// moves once the WHOLE batch finishes, so a big backlog leaves the
+				// consumer reprocessing the same records on every restart and never
+				// makes durable progress.
+				if len(toCommit) >= commitEvery {
+					c.commitBatch(ctx, toCommit)
+					toCommit = toCommit[:0]
+				}
 			}
 		})
 
@@ -323,17 +345,24 @@ func (c *Consumer) Run(ctx context.Context, handler Handler) error {
 		}
 
 		if len(toCommit) > 0 {
-			// Commit only the successfully-processed records, on a shutdown-
-			// independent context so the final batch is not dropped when ctx is
-			// already cancelled by SIGTERM (a dropped commit reprocesses the batch on
-			// the next restart).
-			commitCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-			if err := c.client.CommitRecords(commitCtx, toCommit...); err != nil {
-				c.observeError(c.cfg.Topic, c.cfg.GroupID, "commit")
-				c.log.Error().Err(err).Msg("commit offsets failed")
-			}
-			cancel()
+			c.commitBatch(ctx, toCommit)
 		}
+	}
+}
+
+// commitBatch synchronously commits the given successfully-processed records on
+// a shutdown-independent context so the batch is not dropped when ctx is already
+// cancelled by SIGTERM (a dropped commit reprocesses the batch on the next
+// restart). Commit failures are logged + metered but not fatal.
+func (c *Consumer) commitBatch(_ context.Context, recs []*kgo.Record) {
+	if len(recs) == 0 {
+		return
+	}
+	commitCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := c.client.CommitRecords(commitCtx, recs...); err != nil {
+		c.observeError(c.cfg.Topic, c.cfg.GroupID, "commit")
+		c.log.Error().Err(err).Msg("commit offsets failed")
 	}
 }
 

--- a/shared/kafka/consumer/consumer.go
+++ b/shared/kafka/consumer/consumer.go
@@ -39,14 +39,27 @@ type Config struct {
 	PollTimeout time.Duration
 }
 
+// maxHandlerRetries bounds how many consecutive times the SAME record may fail
+// its handler before the consumer gives up on it. Transient failures that
+// recover within this many polls are retried as before (at-least-once); a
+// permanently-failing ("poison") record is dead-lettered (logged) and its
+// offset committed so the partition advances instead of stalling forever.
+const maxHandlerRetries = 8
+
+// retryBackoff is the minimum delay inserted before a partition is re-fetched
+// after a handler error, so a fast-failing poison record does not spin the poll
+// loop while it burns through its retry budget.
+const retryBackoff = 200 * time.Millisecond
+
 // Handler processes a single Kafka message and returns nil on success.
 //
 // On a non-nil error the consumer logs the failure, increments error metrics,
 // and does NOT commit the record's offset: the partition is rewound to the
 // failed record so it (and the records after it) are re-fetched and retried on
-// the next poll (at-least-once). A permanently-failing record therefore stalls
-// its partition until it succeeds — the bounded-retry + dead-letter escape is a
-// deferred platform task (spec §16 D16 / P8 8a-v).
+// the next poll (at-least-once). To stop a permanently-failing record from
+// stalling its partition indefinitely, the same record is retried at most
+// maxHandlerRetries times; past that it is dead-lettered (structured ERROR log)
+// and its offset committed so the partition advances.
 type Handler func(ctx context.Context, msg Message) error
 
 // Message is the consumer's view of a Kafka record. The embedded
@@ -69,6 +82,16 @@ type Header struct {
 	Value []byte
 }
 
+// stuckRecord tracks the consecutive failure count for the single record that
+// is currently blocking a partition. We only ever keep one entry per partition
+// (the head record that keeps failing); it is replaced when the head offset
+// advances and removed when the partition succeeds, so this map cannot grow
+// unbounded.
+type stuckRecord struct {
+	offset   int64
+	failures int
+}
+
 // Consumer is a single-topic at-least-once Kafka consumer.
 type Consumer struct {
 	client      *kgo.Client
@@ -76,6 +99,11 @@ type Consumer struct {
 	cfg         Config
 	pollTimeout time.Duration
 	log         zerolog.Logger
+
+	// retries tracks the currently-stuck record per partition so a poison
+	// message can be bounded and dead-lettered rather than retried forever.
+	// Run is single-goroutine, so no locking is required.
+	retries map[int32]*stuckRecord
 
 	messagesTotal     *prometheus.CounterVec
 	errorsTotal       *prometheus.CounterVec
@@ -124,6 +152,7 @@ func New(cfg Config, log zerolog.Logger, reg *prometheus.Registry) (*Consumer, e
 		tracer:      tracer,
 		cfg:         cfg,
 		pollTimeout: cfg.PollTimeout,
+		retries:     make(map[int32]*stuckRecord),
 		log:         log.With().Str("component", "kafka-consumer").Str("group", cfg.GroupID).Str("topic", cfg.Topic).Logger(),
 	}
 
@@ -201,6 +230,7 @@ func (c *Consumer) Run(ctx context.Context, handler Handler) error {
 		// bounded-retry + dead-letter escape is the deferred platform task (§16 D16
 		// / P8 8a-v).
 		var toCommit []*kgo.Record
+		needsBackoff := false
 		fetches.EachPartition(func(ftp kgo.FetchTopicPartition) {
 			if ftp.Err != nil {
 				c.observeError(ftp.Topic, c.cfg.GroupID, "fetch")
@@ -234,18 +264,47 @@ func (c *Consumer) Run(ctx context.Context, handler Handler) error {
 				if err := handler(recCtx, msg); err != nil {
 					c.observeError(c.cfg.Topic, c.cfg.GroupID, "handler")
 					c.observeMessages(c.cfg.Topic, c.cfg.GroupID, "error")
-					recLog.Error().Err(err).Msg("kafka handler error; rewinding partition to retry (offset not committed)")
+
+					// Track consecutive failures of THIS record so a permanently
+					// failing ("poison") record cannot stall the partition forever.
+					fails := c.recordFailure(rec.Partition, rec.Offset)
+
+					if fails > maxHandlerRetries {
+						// Poison record: give up retrying, dead-letter it (structured
+						// ERROR log; this codebase has no DLQ topic convention), commit
+						// its offset so the partition advances, and continue processing
+						// the records after it.
+						recLog.Error().Err(err).
+							Int("failures", fails).
+							Int("max_retries", maxHandlerRetries).
+							Msg("kafka handler error budget exhausted; dead-lettering poison message and committing offset to advance partition")
+						c.observeError(c.cfg.Topic, c.cfg.GroupID, "deadletter")
+						c.clearFailure(rec.Partition)
+						span.RecordError(err)
+						span.End()
+						toCommit = append(toCommit, rec)
+						continue // skip this record; keep processing the partition
+					}
+
+					recLog.Error().Err(err).
+						Int("failures", fails).
+						Int("max_retries", maxHandlerRetries).
+						Msg("kafka handler error; rewinding partition to retry (offset not committed)")
 					// Rewind this partition to the failed record (carrying the leader
 					// epoch so the reset is fenced) so it and the records after it are
 					// re-fetched on the next poll.
 					c.client.SetOffsets(map[string]map[int32]kgo.EpochOffset{
 						rec.Topic: {rec.Partition: {Epoch: rec.LeaderEpoch, Offset: rec.Offset}},
 					})
+					needsBackoff = true
 					span.RecordError(err)
 					span.End()
 					return // stop this partition; records after the failure are not processed
 				}
 
+				// Success: clear any retry state for this partition so a later
+				// transient failure starts from a fresh budget.
+				c.clearFailure(rec.Partition)
 				sharedkafka.IncConsumed(c.cfg.GroupID, rec.Topic)
 				c.observeMessages(c.cfg.Topic, c.cfg.GroupID, "ok")
 				c.observeProcessingLatency(c.cfg.Topic, c.cfg.GroupID, time.Since(start))
@@ -253,6 +312,15 @@ func (c *Consumer) Run(ctx context.Context, handler Handler) error {
 				span.End()
 			}
 		})
+
+		if needsBackoff {
+			// Brief pause before re-fetching a rewound partition so a fast-failing
+			// record does not spin the poll loop while it burns its retry budget.
+			select {
+			case <-ctx.Done():
+			case <-time.After(retryBackoff):
+			}
+		}
 
 		if len(toCommit) > 0 {
 			// Commit only the successfully-processed records, on a shutdown-
@@ -284,6 +352,26 @@ func (c *Consumer) Ping(ctx context.Context) error {
 		return fmt.Errorf("kafka consumer ping: %w", err)
 	}
 	return nil
+}
+
+// recordFailure increments and returns the consecutive-failure count for the
+// record at (partition, offset). If the tracked offset for the partition has
+// advanced (a different record is now stuck, or the previous one was
+// dead-lettered) the count resets to 1. Only the current head record per
+// partition is tracked, so the map size is bounded by the partition count.
+func (c *Consumer) recordFailure(partition int32, offset int64) int {
+	if sr, ok := c.retries[partition]; ok && sr.offset == offset {
+		sr.failures++
+		return sr.failures
+	}
+	c.retries[partition] = &stuckRecord{offset: offset, failures: 1}
+	return 1
+}
+
+// clearFailure drops any tracked failure state for a partition. Called on
+// success and after a record is dead-lettered.
+func (c *Consumer) clearFailure(partition int32) {
+	delete(c.retries, partition)
 }
 
 func toHeaders(in []kgo.RecordHeader) []Header {

--- a/shared/kafka/consumer/consumer_test.go
+++ b/shared/kafka/consumer/consumer_test.go
@@ -1,0 +1,118 @@
+package consumer
+
+import "testing"
+
+// recordOutcome mirrors the decision the Run loop makes for a single record
+// based on the per-partition retry state. It exists so the bounded-retry /
+// dead-letter decision can be exercised without standing up a Kafka broker:
+// the live loop calls recordFailure/clearFailure exactly as modelled here.
+type recordOutcome int
+
+const (
+	outcomeCommit recordOutcome = iota // handler succeeded; commit + advance
+	outcomeRetry                       // transient failure; rewind + retry
+	outcomeDeadLetter                  // poison; dead-letter + commit to advance
+)
+
+// step replays one record through the consumer's retry bookkeeping and returns
+// the outcome the Run loop would take. handlerErr reports whether the handler
+// returned an error for this delivery.
+func (c *Consumer) step(partition int32, offset int64, handlerErr bool) recordOutcome {
+	if !handlerErr {
+		c.clearFailure(partition)
+		return outcomeCommit
+	}
+	fails := c.recordFailure(partition, offset)
+	if fails > maxHandlerRetries {
+		c.clearFailure(partition)
+		return outcomeDeadLetter
+	}
+	return outcomeRetry
+}
+
+func newTestConsumer() *Consumer {
+	return &Consumer{retries: make(map[int32]*stuckRecord)}
+}
+
+// TestPoisonRecordIsDeadLetteredAfterThreshold proves that a record whose
+// handler always errors is retried at most maxHandlerRetries times and is then
+// dead-lettered (offset committed / advanced) rather than retried forever.
+func TestPoisonRecordIsDeadLetteredAfterThreshold(t *testing.T) {
+	c := newTestConsumer()
+	const partition int32 = 0
+	const offset int64 = 42
+
+	// Re-deliver the same poison record. The first maxHandlerRetries failures
+	// must rewind-and-retry; the next must dead-letter.
+	for i := 1; i <= maxHandlerRetries; i++ {
+		if got := c.step(partition, offset, true); got != outcomeRetry {
+			t.Fatalf("delivery %d: got outcome %d, want retry", i, got)
+		}
+	}
+	if got := c.step(partition, offset, true); got != outcomeDeadLetter {
+		t.Fatalf("delivery %d: got outcome %d, want dead-letter", maxHandlerRetries+1, got)
+	}
+
+	// After dead-lettering, the partition's retry state must be cleared so the
+	// next record starts with a fresh budget and does not leak.
+	if _, ok := c.retries[partition]; ok {
+		t.Fatalf("retry state for partition %d not cleared after dead-letter", partition)
+	}
+}
+
+// TestTransientFailureThenSuccessDoesNotSkip proves that a record that errors a
+// few times (below the threshold) and then succeeds is committed normally and
+// is never dead-lettered — transient resilience is preserved.
+func TestTransientFailureThenSuccessDoesNotSkip(t *testing.T) {
+	c := newTestConsumer()
+	const partition int32 = 1
+	const offset int64 = 7
+
+	// A handful of transient failures, all under the budget.
+	const transientFails = 3
+	for i := 1; i <= transientFails; i++ {
+		if got := c.step(partition, offset, true); got != outcomeRetry {
+			t.Fatalf("transient failure %d: got outcome %d, want retry", i, got)
+		}
+	}
+
+	// Then the redelivery succeeds: it must commit, not skip/dead-letter.
+	if got := c.step(partition, offset, false); got != outcomeCommit {
+		t.Fatalf("recovery delivery: got outcome %d, want commit", got)
+	}
+
+	// Success must clear the retry state.
+	if _, ok := c.retries[partition]; ok {
+		t.Fatalf("retry state for partition %d not cleared after success", partition)
+	}
+}
+
+// TestRetryStateResetsWhenOffsetAdvances proves the per-partition tracker
+// follows the current head record: when a different offset starts failing, the
+// failure count restarts rather than carrying over, and only one entry per
+// partition is ever kept.
+func TestRetryStateResetsWhenOffsetAdvances(t *testing.T) {
+	c := newTestConsumer()
+	const partition int32 = 2
+
+	// Record at offset 10 fails twice.
+	if got := c.recordFailure(partition, 10); got != 1 {
+		t.Fatalf("offset 10 first failure: got %d want 1", got)
+	}
+	if got := c.recordFailure(partition, 10); got != 2 {
+		t.Fatalf("offset 10 second failure: got %d want 2", got)
+	}
+
+	// A different offset (the head advanced) must reset the count to 1.
+	if got := c.recordFailure(partition, 11); got != 1 {
+		t.Fatalf("offset 11 first failure: got %d want 1 (should reset)", got)
+	}
+
+	// Only one stuck record per partition is tracked.
+	if len(c.retries) != 1 {
+		t.Fatalf("retries map size: got %d want 1", len(c.retries))
+	}
+	if sr := c.retries[partition]; sr == nil || sr.offset != 11 || sr.failures != 1 {
+		t.Fatalf("tracker not following head record: %+v", sr)
+	}
+}

--- a/shared/postgres/repository/email_repo.go
+++ b/shared/postgres/repository/email_repo.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
+	"unicode/utf8"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
@@ -11,6 +13,23 @@ import (
 
 	db "github.com/saif/cybersiren/db/sqlc"
 	"github.com/saif/cybersiren/shared/postgres/pgconv"
+)
+
+// utf8Replacement is substituted for every invalid UTF-8 byte sequence found in
+// a text field before it reaches a UTF-8 Postgres column. Real-world emails
+// (and svc-02's own quoted-printable / base64 decoding into Windows-1252 bytes,
+// e.g. =97 → 0x97 em-dash) routinely produce non-UTF-8 bytes that Postgres
+// rejects with SQLSTATE 22021, NACKing the message and stalling the partition.
+const utf8Replacement = "�"
+
+// sentTimestampMin / sentTimestampMax are the inclusive bounds enforced by the
+// chk_emails_sent_timestamp_range CHECK constraint (migration 023): a raw Unix
+// epoch between 0 (1970-01-01 UTC) and 4102444800 (2100-01-01 UTC). A Date:
+// header that parses outside this window violates the constraint (SQLSTATE
+// 23514) and would otherwise stall the partition, so such values are nulled.
+const (
+	sentTimestampMin int64 = 0
+	sentTimestampMax int64 = 4102444800
 )
 
 // EmailRepository persists a parsed email and all of its child artefacts
@@ -131,6 +150,14 @@ func (r *EmailRepository) PersistParsed(ctx context.Context, orgID int64, in Per
 		return EmailKey{}, errors.New("email repository: nil pool")
 	}
 
+	// Coerce every text field to valid UTF-8 and clamp the sent timestamp into
+	// the DB's accepted range BEFORE any statement runs. This is the single
+	// chokepoint that guards every column — the parent email and all URL /
+	// attachment / recipient child rows — so no value can reach a UTF-8 column
+	// (SQLSTATE 22021) or the sent_timestamp range CHECK (SQLSTATE 23514) and
+	// wedge the partition on an un-retryable persist failure.
+	sanitizeParsed(&in)
+
 	var key EmailKey
 	err := WithOrgTx(ctx, r.pool, orgID, func(q *db.Queries) error {
 		k, err := persistParsedTx(ctx, q, orgID, in)
@@ -144,6 +171,87 @@ func (r *EmailRepository) PersistParsed(ctx context.Context, orgID int64, in Per
 		return EmailKey{}, err
 	}
 	return key, nil
+}
+
+// validUTF8 returns s with every invalid UTF-8 byte sequence replaced by the
+// Unicode replacement character. Valid input is returned unchanged (and the
+// fast path skips the allocation entirely). Content is preserved — only the
+// non-UTF-8 bytes Postgres would reject are rewritten.
+func validUTF8(s string) string {
+	if utf8.ValidString(s) {
+		return s
+	}
+	return strings.ToValidUTF8(s, utf8Replacement)
+}
+
+// sanitizeText coerces an optional text column to valid UTF-8 in place, leaving
+// NULL values untouched.
+func sanitizeText(t *pgtype.Text) {
+	if t.Valid {
+		t.String = validUTF8(t.String)
+	}
+}
+
+// sanitizeParsed coerces every text/string field destined for a UTF-8 column to
+// valid UTF-8 and forces an out-of-range (or unparseable→out-of-range) sent
+// timestamp to NULL, so the whole batch always satisfies the emails table's
+// encoding and range constraints. It mutates in place.
+func sanitizeParsed(in *PersistParsedFull) {
+	// Parent email row.
+	sanitizeText(&in.Email.SenderName)
+	sanitizeText(&in.Email.SenderEmail)
+	sanitizeText(&in.Email.SenderDomain)
+	sanitizeText(&in.Email.ReplyToEmail)
+	sanitizeText(&in.Email.ReturnPath)
+	sanitizeText(&in.Email.MessageID)
+	sanitizeText(&in.Email.MailerAgent)
+	sanitizeText(&in.Email.InReplyTo)
+	sanitizeText(&in.Email.ContentCharset)
+	sanitizeText(&in.Email.Precedence)
+	sanitizeText(&in.Email.ListID)
+	sanitizeText(&in.Email.Subject)
+	sanitizeText(&in.Email.BodyPlain)
+	sanitizeText(&in.Email.BodyHtml)
+	for i := range in.Email.ReferencesList {
+		in.Email.ReferencesList[i] = validUTF8(in.Email.ReferencesList[i])
+	}
+
+	// MessageID is also carried out-of-band for the email_identities dedup key.
+	in.MessageID = validUTF8(in.MessageID)
+
+	// Clamp/null the sent timestamp into the chk_emails_sent_timestamp_range
+	// window. NULL is the documented value for an unknown/garbage Date header.
+	if ts := in.Email.SentTimestamp; ts.Valid && (ts.Int64 < sentTimestampMin || ts.Int64 > sentTimestampMax) {
+		in.Email.SentTimestamp = pgtype.Int8{}
+	}
+
+	// URL children: enriched_threats inputs + email_urls visible_text.
+	for i := range in.URLs {
+		in.URLs[i].URL = validUTF8(in.URLs[i].URL)
+		sanitizeText(&in.URLs[i].Domain)
+		sanitizeText(&in.URLs[i].TLD)
+		sanitizeText(&in.URLs[i].VisibleText)
+	}
+
+	// Attachment children: attachment_library text + email_attachments link.
+	for i := range in.Attachments {
+		in.Attachments[i].Library.Sha256 = validUTF8(in.Attachments[i].Library.Sha256)
+		sanitizeText(&in.Attachments[i].Library.Md5)
+		sanitizeText(&in.Attachments[i].Library.Sha1)
+		sanitizeText(&in.Attachments[i].Library.ActualExtension)
+		sanitizeText(&in.Attachments[i].Library.StorageUri)
+		sanitizeText(&in.Attachments[i].Filename)
+		sanitizeText(&in.Attachments[i].ContentType)
+		sanitizeText(&in.Attachments[i].ContentID)
+		sanitizeText(&in.Attachments[i].Disposition)
+	}
+
+	// Recipient children: address + display_name + recipient_type.
+	for i := range in.Recipients {
+		in.Recipients[i].Address = validUTF8(in.Recipients[i].Address)
+		sanitizeText(&in.Recipients[i].DisplayName)
+		in.Recipients[i].RecipientType = validUTF8(in.Recipients[i].RecipientType)
+	}
 }
 
 // persistParsedTx runs the idempotent persist inside an already-open

--- a/shared/postgres/repository/email_repo.go
+++ b/shared/postgres/repository/email_repo.go
@@ -178,10 +178,15 @@ func (r *EmailRepository) PersistParsed(ctx context.Context, orgID int64, in Per
 // fast path skips the allocation entirely). Content is preserved — only the
 // non-UTF-8 bytes Postgres would reject are rewritten.
 func validUTF8(s string) string {
-	if utf8.ValidString(s) {
+	// Postgres TEXT columns reject NUL (0x00) even though it is valid UTF-8, so
+	// strip NUL in addition to coercing invalid byte sequences.
+	if utf8.ValidString(s) && !strings.ContainsRune(s, 0) {
 		return s
 	}
-	return strings.ToValidUTF8(s, utf8Replacement)
+	if !utf8.ValidString(s) {
+		s = strings.ToValidUTF8(s, utf8Replacement)
+	}
+	return strings.ReplaceAll(s, "\x00", "")
 }
 
 // sanitizeText coerces an optional text column to valid UTF-8 in place, leaving

--- a/shared/postgres/repository/email_repo_sanitize_test.go
+++ b/shared/postgres/repository/email_repo_sanitize_test.go
@@ -1,0 +1,215 @@
+package repository
+
+import (
+	"testing"
+	"unicode/utf8"
+
+	"github.com/jackc/pgx/v5/pgtype"
+
+	db "github.com/saif/cybersiren/db/sqlc"
+)
+
+// pgText is a tiny helper for building a non-NULL pgtype.Text in tests.
+func pgText(s string) pgtype.Text { return pgtype.Text{String: s, Valid: true} }
+
+// Bytes a real Windows-1252 quoted-printable/base64 decode leaves behind that
+// Postgres rejects on a UTF-8 column with SQLSTATE 22021. =97 → 0x97 em-dash,
+// =a0 → 0xa0 NBSP, =aa → 0xaa, =96 → 0x96 en-dash.
+const (
+	poison97 = "em\x97dash"
+	poisonA0 = "no\xa0break"
+	poisonAA = "junk\xaa"
+	poison96 = "en\x96dash"
+)
+
+// TestValidUTF8 proves the core coercion: invalid byte sequences become valid
+// UTF-8 (no 22021) while valid input is passed through untouched.
+func TestValidUTF8(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"ascii passthrough", "hello world", "hello world"},
+		{"valid multibyte passthrough", "café — déjà", "café — déjà"},
+		{"empty", "", ""},
+		{"0x97 em-dash", poison97, "em" + utf8Replacement + "dash"},
+		{"0xa0 nbsp", poisonA0, "no" + utf8Replacement + "break"},
+		{"0xaa", poisonAA, "junk" + utf8Replacement},
+		{"0x96 en-dash", poison96, "en" + utf8Replacement + "dash"},
+		// strings.ToValidUTF8 collapses a contiguous run of invalid bytes into a
+		// single replacement — the point is only that the result is valid UTF-8.
+		{"all four poison bytes", "\x97\x96\xa0\xaa", utf8Replacement},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			got := validUTF8(c.in)
+			if !utf8.ValidString(got) {
+				t.Fatalf("validUTF8(%q) = %q, still not valid UTF-8", c.in, got)
+			}
+			if got != c.want {
+				t.Fatalf("validUTF8(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+// TestSanitizeParsedCoercesEveryTextField proves that the single repository
+// chokepoint scrubs invalid UTF-8 out of every text/string field on the parent
+// email and all three child-row kinds, so no value can reach a UTF-8 column.
+func TestSanitizeParsedCoercesEveryTextField(t *testing.T) {
+	t.Parallel()
+	in := PersistParsedFull{
+		MessageID: poison97,
+		Email: db.InsertEmailParams{
+			MessageID:      pgText(poison97),
+			SenderName:     pgText(poison97),
+			SenderEmail:    pgText(poisonA0),
+			SenderDomain:   pgText(poisonAA),
+			ReplyToEmail:   pgText(poison96),
+			ReturnPath:     pgText(poison97),
+			MailerAgent:    pgText(poisonA0),
+			InReplyTo:      pgText(poisonAA),
+			ContentCharset: pgText(poison96),
+			Precedence:     pgText(poison97),
+			ListID:         pgText(poisonA0),
+			Subject:        pgText(poisonAA),
+			BodyPlain:      pgText(poison97),
+			BodyHtml:       pgText(poison96),
+			ReferencesList: []string{poison97, poisonA0},
+		},
+		URLs: []ParsedURL{{
+			URL:         poison97,
+			Domain:      pgText(poisonA0),
+			TLD:         pgText(poisonAA),
+			VisibleText: pgText(poison96),
+		}},
+		Attachments: []ParsedAttachment{{
+			Library: db.UpsertParsedAttachmentParams{
+				Sha256:          poison97,
+				Md5:             pgText(poisonA0),
+				Sha1:            pgText(poisonAA),
+				ActualExtension: pgText(poison96),
+				StorageUri:      pgText(poison97),
+			},
+			Filename:    pgText(poisonA0),
+			ContentType: pgText(poisonAA),
+			ContentID:   pgText(poison96),
+			Disposition: pgText(poison97),
+		}},
+		Recipients: []ChildRecipient{{
+			Address:       poisonA0,
+			DisplayName:   pgText(poisonAA),
+			RecipientType: poison96,
+		}},
+	}
+
+	sanitizeParsed(&in)
+
+	// Walk every string we wrote and assert it is now valid UTF-8.
+	check := func(label, s string) {
+		t.Helper()
+		if !utf8.ValidString(s) {
+			t.Errorf("%s still not valid UTF-8 after sanitize: %q", label, s)
+		}
+	}
+	checkText := func(label string, tx pgtype.Text) {
+		t.Helper()
+		if tx.Valid {
+			check(label, tx.String)
+		}
+	}
+
+	check("out-of-band MessageID", in.MessageID)
+	checkText("Email.MessageID", in.Email.MessageID)
+	checkText("Email.SenderName", in.Email.SenderName)
+	checkText("Email.SenderEmail", in.Email.SenderEmail)
+	checkText("Email.SenderDomain", in.Email.SenderDomain)
+	checkText("Email.ReplyToEmail", in.Email.ReplyToEmail)
+	checkText("Email.ReturnPath", in.Email.ReturnPath)
+	checkText("Email.MailerAgent", in.Email.MailerAgent)
+	checkText("Email.InReplyTo", in.Email.InReplyTo)
+	checkText("Email.ContentCharset", in.Email.ContentCharset)
+	checkText("Email.Precedence", in.Email.Precedence)
+	checkText("Email.ListID", in.Email.ListID)
+	checkText("Email.Subject", in.Email.Subject)
+	checkText("Email.BodyPlain", in.Email.BodyPlain)
+	checkText("Email.BodyHtml", in.Email.BodyHtml)
+	for i, r := range in.Email.ReferencesList {
+		check("Email.ReferencesList", r)
+		_ = i
+	}
+
+	check("URLs[0].URL", in.URLs[0].URL)
+	checkText("URLs[0].Domain", in.URLs[0].Domain)
+	checkText("URLs[0].TLD", in.URLs[0].TLD)
+	checkText("URLs[0].VisibleText", in.URLs[0].VisibleText)
+
+	check("Attachments[0].Library.Sha256", in.Attachments[0].Library.Sha256)
+	checkText("Attachments[0].Library.Md5", in.Attachments[0].Library.Md5)
+	checkText("Attachments[0].Library.Sha1", in.Attachments[0].Library.Sha1)
+	checkText("Attachments[0].Library.ActualExtension", in.Attachments[0].Library.ActualExtension)
+	checkText("Attachments[0].Library.StorageUri", in.Attachments[0].Library.StorageUri)
+	checkText("Attachments[0].Filename", in.Attachments[0].Filename)
+	checkText("Attachments[0].ContentType", in.Attachments[0].ContentType)
+	checkText("Attachments[0].ContentID", in.Attachments[0].ContentID)
+	checkText("Attachments[0].Disposition", in.Attachments[0].Disposition)
+
+	check("Recipients[0].Address", in.Recipients[0].Address)
+	checkText("Recipients[0].DisplayName", in.Recipients[0].DisplayName)
+	check("Recipients[0].RecipientType", in.Recipients[0].RecipientType)
+}
+
+// TestSanitizeParsedPreservesValidContent makes sure we only rewrite invalid
+// bytes — valid (incl. multibyte) content survives unchanged, so the fix never
+// silently drops legitimate text.
+func TestSanitizeParsedPreservesValidContent(t *testing.T) {
+	t.Parallel()
+	const subj = "Re: café déjà vu — 你好"
+	in := PersistParsedFull{Email: db.InsertEmailParams{Subject: pgText(subj)}}
+	sanitizeParsed(&in)
+	if in.Email.Subject.String != subj {
+		t.Fatalf("valid subject mutated: got %q want %q", in.Email.Subject.String, subj)
+	}
+}
+
+// TestSanitizeParsedSentTimestamp proves an out-of-range or garbage Date header
+// is nulled (rather than passed through to violate chk_emails_sent_timestamp_range,
+// SQLSTATE 23514), while an in-range value — including the boundary values and
+// epoch-zero — is preserved.
+func TestSanitizeParsedSentTimestamp(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name      string
+		in        pgtype.Int8
+		wantValid bool
+		wantVal   int64
+	}{
+		{"null stays null", pgtype.Int8{}, false, 0},
+		{"epoch zero preserved", pgtype.Int8{Int64: 0, Valid: true}, true, 0},
+		{"in range preserved", pgtype.Int8{Int64: 1_700_000_000, Valid: true}, true, 1_700_000_000},
+		{"lower bound preserved", pgtype.Int8{Int64: sentTimestampMin, Valid: true}, true, sentTimestampMin},
+		{"upper bound preserved", pgtype.Int8{Int64: sentTimestampMax, Valid: true}, true, sentTimestampMax},
+		{"negative nulled", pgtype.Int8{Int64: -1, Valid: true}, false, 0},
+		{"far future nulled", pgtype.Int8{Int64: sentTimestampMax + 1, Valid: true}, false, 0},
+		{"garbage huge nulled", pgtype.Int8{Int64: 99_999_999_999, Valid: true}, false, 0},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			in := PersistParsedFull{Email: db.InsertEmailParams{SentTimestamp: c.in}}
+			sanitizeParsed(&in)
+			got := in.Email.SentTimestamp
+			if got.Valid != c.wantValid {
+				t.Fatalf("Valid = %v, want %v", got.Valid, c.wantValid)
+			}
+			if got.Valid && got.Int64 != c.wantVal {
+				t.Fatalf("Int64 = %d, want %d", got.Int64, c.wantVal)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Hardens the analysis pipeline against poison messages and cuts svc-03 URL-scoring latency. Found while running the benchmark corpus through the full stack: real-world emails (non-UTF-8 bytes, odd `Date` headers, URL-dense bodies) were wedging partitions and dropping the URL component from verdicts.

## What's in here

**Stop poison messages stalling partitions**
- **svc-02** — parsed text/timestamps with non-UTF-8 bytes (Latin-1/cp1252, NUL `0x00`) or out-of-range `Date` headers failed the DB insert and were retried forever, wedging `emails.raw`. Added a single `sanitizeParsed` chokepoint: coerce every text field to valid UTF-8 (incl. NUL strip), null out-of-range timestamps. Fixes #207.
- **Shared Kafka consumer** — bounded handler retries (8) then dead-letter instead of rewinding non-transient failures forever. A single poison record can no longer block a partition.
- **svc-03** — added the missing `suspicious` value to the `threat_type_values` allowlist (migration 036).

**svc-07 aggregator resilience**
- Tombstone finalized emails so a late component score can't resurrect a plan-less "zombie" bucket (was ~44k logs / 10 min for ~2.9k emails). Configurable timeout/TTL via env. Delete plan-less buckets on first sweep. `aggregator_late_drops_total{reason}` metric.

**svc-03 URL-scoring latency (10× faster per URL)**
- Concurrent per-email URL scan (bounded) with dedup + per-email cap; DNS-gate the enricher (skip WHOIS+HTTP on non-resolving domains); staged early-exit (skip the network when domain-guard/L1 is already confident); cheap HTTP leg (32 KB) + tightened timeouts; circuit breaker. Mean per-URL scan **1.25s → 0.123s**.

**Consumer: incremental commit (fixes a backlog-induced offset freeze)**
- The consumer processed an entire poll batch inside `fetches.EachPartition` before committing once, so draining a large backlog kept the committed offset frozen for minutes while reprocessing the same records and never making durable progress (URL scores never reached verdicts under load). Now commits every 200 successfully-handled records, and wires franz-go's logger at WARN so rebalances/commit failures are visible.

## Validated end-to-end

- svc-02 fix: a 1,191-message poison backlog drained in 36s after redeploy.
- Dead-letter consumer: a NUL-byte poison was dead-lettered under a 5,936-email fire-all, no stall.
- svc-03 latency: mean per-URL 1.25s → 0.123s (live metric); throughput ~20 → ~282/min.
- svc-07: aged-out logs ~4,487 → ~306/min.
- Consumer commit fix: committed offset advances steadily through a backlog (was frozen); franz-go reports no rebalances/commit errors.
- **Full pipeline, paced, no backlog: svc-03 lag stays 0, and `url_risk_score` reaches verdicts again — 29/40 URL-bearing emails carried a non-zero URL score (was 0), including a URL-only phish that flipped to `suspicious` on the URL score alone (content score 1).**
- Unit tests added across changed packages; `go build ./...`, `go vet`, `go test` green per service.

## Notes / follow-ups
- Draining a large pre-existing backlog is still single-threaded (~5/s per instance); horizontal scale / partition-concurrency would speed bulk recovery but isn't needed for steady-state. (Not in this PR.)
