### PR TITLE
svc-03: stop over-flagging benign URLs (uncorroborated high-L1 de-escalation)

### DIFF
--- a/internal/phishing/detector.go
+++ b/internal/phishing/detector.go
@@ -225,8 +225,16 @@ func (d *Detector) scoreViaFeatures(ctx context.Context, rawURL string) (phclien
 	// degraded-network window trip it OPEN (and a clean run closes a half-open
 	// probe). Done here, immediately after the call, so only the network leg's
 	// health drives the breaker — not the sidecar /score-features call.
+	//
+	// Enrich degrades gracefully and returns a nil error even when DNS cannot be
+	// reached (it just produces empty features), so a network outage would never
+	// trip the breaker on enrichErr alone. eu.DNSNetworkError surfaces a
+	// network-level resolution failure (timeout/SERVFAIL, NOT a clean NXDOMAIN),
+	// which is the signal that a degraded-network window is in progress. Without
+	// it the breaker never opens during an outage and a high L1 score is silently
+	// de-escalated instead of standing as Degraded.
 	if d.breaker != nil {
-		if enrichErr != nil {
+		if enrichErr != nil || eu.DNSNetworkError {
 			d.breaker.Failure()
 		} else {
 			d.breaker.Success()

--- a/internal/phishing/detector.go
+++ b/internal/phishing/detector.go
@@ -72,6 +72,11 @@ type Result struct {
 	DeployP      float64
 	Verdict      string // "phishing" | "benign"
 	CacheHit     bool
+	// Degraded is set when the verdict is a fail-open default rather than a real
+	// model score (e.g. the circuit breaker was OPEN and enrichment was skipped).
+	// Callers must NOT treat a Degraded "benign" as evidence the URL is benign —
+	// it only means "no L2 signal available", so a high L1 score must stand.
+	Degraded bool
 }
 
 // Detector orchestrates sidecar scoring.
@@ -164,7 +169,7 @@ func (d *Detector) Score(ctx context.Context, rawURL string) (Result, error) {
 				attribute.Bool("phishing.breaker_open", true),
 				attribute.String("phishing.verdict", "benign"),
 			)
-			return Result{URL: rawURL, EffectiveURL: rawURL, Verdict: "benign"}, nil
+			return Result{URL: rawURL, EffectiveURL: rawURL, Verdict: "benign", Degraded: true}, nil
 		}
 		scored, cacheHit, err = d.scoreViaFeatures(ctx, rawURL)
 	} else {

--- a/internal/phishing/enricher/dns.go
+++ b/internal/phishing/enricher/dns.go
@@ -2,6 +2,7 @@ package enricher
 
 import (
 	"context"
+	"errors"
 	"net"
 	"time"
 
@@ -50,13 +51,29 @@ var globalDNSCache = newDNSCache()
 // ResolveIP resolves hostname to an IPv4 address (preferred) or IPv6 address.
 // Results are cached in-process for the binary lifetime. Returns empty string on failure.
 func ResolveIP(ctx context.Context, hostname string) string {
+	ip, _ := resolveIPStatus(ctx, hostname)
+	return ip
+}
+
+// resolveIPStatus is ResolveIP plus a signal of whether a failed lookup was a
+// network-level error (timeout / SERVFAIL — the resolver could not be reached)
+// as opposed to a clean negative answer (NXDOMAIN / no addresses — the host
+// genuinely does not exist while the network is healthy).
+//
+// The distinction matters for the L2 circuit breaker: a sustained run of
+// network errors means enrichment cannot run and the breaker should trip
+// (fail-open + Degraded so recall is preserved), whereas a deregistered/dead
+// domain is a normal, expected negative that must NOT trip the breaker — those
+// benign dead-domain URLs are exactly what the de-escalation path is meant to
+// clear. A cache hit reports netErr=false (cached negatives are clean answers).
+func resolveIPStatus(ctx context.Context, hostname string) (ip string, netErr bool) {
 	ctx, span := enricherTracer.Start(ctx, "enricher.dns.ResolveIP")
 	defer span.End()
 	span.SetAttributes(attribute.String("enricher.hostname", hostname))
 
 	if ip, ok := globalDNSCache.get(hostname); ok {
 		span.SetAttributes(attribute.Bool("enricher.cache_hit", true), attribute.String("enricher.ip", ip))
-		return ip
+		return ip, false
 	}
 	span.SetAttributes(attribute.Bool("enricher.cache_hit", false))
 
@@ -67,9 +84,11 @@ func ResolveIP(ctx context.Context, hostname string) string {
 	if err != nil || len(addrs) == 0 {
 		if err != nil {
 			span.RecordError(err)
+			netErr = isDNSNetworkError(err)
+			span.SetAttributes(attribute.Bool("enricher.dns_network_error", netErr))
 		}
 		globalDNSCache.set(hostname, "", dnsNegativeTTL)
-		return ""
+		return "", netErr
 	}
 
 	var result string
@@ -89,5 +108,22 @@ func ResolveIP(ctx context.Context, hostname string) string {
 
 	globalDNSCache.set(hostname, result, dnsCacheTTL)
 	span.SetAttributes(attribute.String("enricher.ip", result))
-	return result
+	return result, false
+}
+
+// isDNSNetworkError reports whether a resolver error indicates the network/DNS
+// infrastructure could not be reached (timeout, SERVFAIL, connection refused),
+// as opposed to a definitive NXDOMAIN ("no such host"). NXDOMAIN means the host
+// does not exist but the network is healthy, so it is NOT a network error.
+func isDNSNetworkError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) {
+		// IsNotFound == NXDOMAIN: a clean negative, network is fine.
+		return !dnsErr.IsNotFound
+	}
+	// Non-DNSError (e.g. context deadline exceeded): treat as a network error.
+	return true
 }

--- a/internal/phishing/enricher/dns_test.go
+++ b/internal/phishing/enricher/dns_test.go
@@ -2,6 +2,8 @@ package enricher
 
 import (
 	"context"
+	"errors"
+	"net"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -26,3 +28,30 @@ func TestResolveIP_Cache(t *testing.T) {
 	ip := ResolveIP(context.Background(), "cached-test.example")
 	require.Equal(t, "1.2.3.4", ip)
 }
+
+func TestIsDNSNetworkError(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil error is not a network error", nil, false},
+		{"NXDOMAIN (host not found) is not a network error", &net.DNSError{IsNotFound: true}, false},
+		{"DNS timeout is a network error", &net.DNSError{IsTimeout: true}, true},
+		{"DNS temporary failure is a network error", &net.DNSError{IsTemporary: true}, true},
+		{"bare DNSError (SERVFAIL) is a network error", &net.DNSError{}, true},
+		{"context deadline exceeded is a network error", context.DeadlineExceeded, true},
+		{"generic error is a network error", errors.New("dial udp: connect: network is unreachable"), true},
+		{"wrapped NXDOMAIN is not a network error", errWrap(&net.DNSError{IsNotFound: true}), false},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, isDNSNetworkError(tc.err))
+		})
+	}
+}
+
+func errWrap(err error) error { return errors.Join(errors.New("lookup failed"), err) }

--- a/internal/phishing/enricher/enricher.go
+++ b/internal/phishing/enricher/enricher.go
@@ -23,6 +23,14 @@ type EnrichedURL struct {
 	TLS   TLSResult
 	HTTP  HTTPResult
 
+	// DNSNetworkError is set when DNS resolution failed with a network-level
+	// error (timeout / SERVFAIL) rather than a clean NXDOMAIN. It signals the
+	// enrichment leg could not run because the network is degraded — the L2
+	// circuit breaker uses it to fail open (Degraded) so a high L1 score is not
+	// silently de-escalated during an outage. A normal dead/deregistered domain
+	// (NXDOMAIN) does NOT set this.
+	DNSNetworkError bool
+
 	Features FeatureVector
 }
 
@@ -89,8 +97,11 @@ func (e *Enricher) Enrich(ctx context.Context, rawURL string) (EnrichedURL, erro
 	apex := apexDomain(hostname)
 
 	// DNS gate: resolve first. A dead host short-circuits the two 5s legs.
-	eu.IP = ResolveIP(ctx, hostname)
-	span.SetAttributes(attribute.Bool("enricher.resolved", eu.IP != ""))
+	eu.IP, eu.DNSNetworkError = resolveIPStatus(ctx, hostname)
+	span.SetAttributes(
+		attribute.Bool("enricher.resolved", eu.IP != ""),
+		attribute.Bool("enricher.dns_network_error", eu.DNSNetworkError),
+	)
 
 	if eu.IP == "" {
 		// Host does not resolve: skip WHOIS + HTTP (and TLS, which also needs a

--- a/services/svc-03-url-analysis/cmd/url-pipeline/main.go
+++ b/services/svc-03-url-analysis/cmd/url-pipeline/main.go
@@ -77,12 +77,21 @@ const (
 	// The L1 false positives on benign mail are obscure/dead-domain URLs whose URL
 	// *string* looks phishing to both the L1 model and the L2 URL-structural model
 	// (url_p high), but whose L2 operational model finds nothing (op_p ~ 0.0006).
-	// Real phishing hosts — even ones already taken down — still register a
-	// meaningful operational probability (op_p ~ 0.06-0.17 observed). So an L2
-	// phishing verdict with op_p below this floor is just a structural echo of L1,
-	// not independent evidence, and must NOT block de-escalation. The floor sits
-	// well above the benign cluster (~0.001) and well below the phishing cluster
-	// (~0.06), so it separates them with margin and does not cost phishing recall.
+	// Real, live phishing hosts register a meaningful operational probability
+	// (op_p ~ 0.06-0.17 on the reachable phishing samples in BENCHMARK_REPORT.md).
+	// So an L2 phishing verdict with op_p below this floor is treated as a
+	// structural echo of L1, not independent evidence, and does not block
+	// de-escalation (to "suspicious", not "legitimate" — a partial hedge).
+	//
+	// CALIBRATION RISK (recalibrate on production traffic): "no recall cost" is
+	// NOT proven. The op-model floors near zero for any host it cannot enrich, so
+	// a real phish that is taken down / unreachable can fall below this floor, and
+	// the in-repo sanity matrix already contains a labeled phishing URL at
+	// op_p=0.017 < 0.02 (BENCHMARK_REPORT.md, microsoft-login-secure.netlify.app)
+	// — caught upstream by the brand guard there, but proof the band is reachable.
+	// The benign cluster (op_p <= 0.003 observed) is well separated below; the
+	// recall tail in [0.001, 0.02] is the part to re-tune once real phishing-cluster
+	// op_p data is available. Keep this a single named, documented constant.
 	l2OpSignalFloor = 0.02
 	// uncorroboratedScore is the score an uncorroborated high-L1 URL is capped to.
 	// It keeps the URL in the low-suspicious band (not zero — the URL string is
@@ -537,9 +546,10 @@ func scanOne(ctx context.Context, raw string, log zerolog.Logger) urlScan {
 	// corroborate. The latency win still covers most legitimate-mail URLs, which
 	// score clearly benign and never touch the network.
 	ranL2 := false
+	l2Skipped := false
 	l2Candidate := (!tiRes.Matched || tiRes.RiskScore < 80) && phishingDetector != nil
 	if l2Candidate && l1Confident(mlScore, routed, tiRes) {
-		scanMetrics.IncOutcome("l2_skipped_confident")
+		l2Skipped = true
 		span.SetAttributes(attribute.Bool("scan.l2_skipped_confident", true))
 		l2Candidate = false
 	}
@@ -579,8 +589,8 @@ func scanOne(ctx context.Context, raw string, log zerolog.Logger) urlScan {
 	// phishing call separates the benign false positives from real phish without
 	// touching recall (proven: every openphish/phishing_pot true positive keeps
 	// its operational signal). A TI hit (>=80) is always real corroboration.
-	if isUncorroboratedHighL1(out.Label, tiRes, out.MLVerdict, out.MLOpP) {
-		scanMetrics.IncOutcome("l1_uncorroborated_deescalated")
+	deescalated := isUncorroboratedHighL1(out.Label, tiRes, out.MLVerdict, out.MLOpP, out.MLDegraded)
+	if deescalated {
 		span.SetAttributes(
 			attribute.Bool("scan.l1_uncorroborated_deescalated", true),
 			attribute.Float64("scan.l2_op_p", out.MLOpP),
@@ -606,16 +616,29 @@ func scanOne(ctx context.Context, raw string, log zerolog.Logger) urlScan {
 		out.MLVerdict, out.MLDegraded, out.MLDeployP,
 	)
 
+	// Exactly one outcome is recorded per scan — scans_total is a per-scan
+	// counter, so the path flags (de-escalation, L2 skip) are folded into this
+	// single switch instead of being incremented separately (which would
+	// double-count the scan). Order: verdict-shaping outcomes first, then the
+	// L2-error and latency-skip paths.
 	outcome := "fallback_legitimate"
 	switch {
+	case deescalated:
+		outcome = "l1_uncorroborated_deescalated"
 	case tiRes.Matched && tiRes.RiskScore >= 80:
 		outcome = "ti_phishing"
 	case ranL2 && out.MLVerdict == "phishing":
 		outcome = "ml_phishing"
 	case ranL2 && out.MLVerdict == "benign":
 		outcome = "ml_benign"
+	case ranL2:
+		// L2 ran but produced no verdict (errored/timed out). Distinct from
+		// fallback_legitimate so the outage path is visible in metrics/traces.
+		outcome = "l2_error"
 	case tiRes.Matched:
 		outcome = "ti_low_confidence"
+	case l2Skipped:
+		outcome = "l2_skipped_confident"
 	}
 	scanMetrics.IncOutcome(outcome)
 	span.SetAttributes(
@@ -717,23 +740,35 @@ func l1Confident(mlScore int, routed bool, ti url.TIResult) bool {
 
 // isUncorroboratedHighL1 reports whether a "phishing" label rests on the L1
 // structural score with no real corroboration, so it should be de-escalated.
-// Corroboration is either a TI hit (>=80) or an L2 phishing verdict backed by an
-// operational signal (op_p >= l2OpSignalFloor). An L2 phishing verdict with
-// near-zero op_p is just a URL-structural echo of L1 (both models dislike the
-// URL string) and is NOT independent evidence. Non-phishing labels are never
-// de-escalated.
-func isUncorroboratedHighL1(label string, ti url.TIResult, mlVerdict string, mlOpP float64) bool {
+//
+// De-escalation is a CORRECTION, and it is only valid when L2 actually ran and
+// produced a real (non-degraded) verdict to weigh against L1. We de-escalate
+// only when that real L2 verdict is "phishing" but lacks an operational signal
+// (op_p < l2OpSignalFloor) — a URL-structural echo of L1, not independent
+// evidence. In every other state the L1 phishing call STANDS:
+//   - a TI hit (>=80) is real corroboration;
+//   - a degraded (breaker-open) L2 verdict carries no signal, so there is no
+//     basis to override L1 — recall is preserved during a network outage;
+//   - an absent or errored L2 (mlVerdict == "") gives us nothing to correct
+//     with, so L1 stands rather than silently dropping recall when L2 is down.
+//
+// Non-phishing labels are never de-escalated.
+func isUncorroboratedHighL1(label string, ti url.TIResult, mlVerdict string, mlOpP float64, mlDegraded bool) bool {
 	if label != "phishing" {
 		return false
 	}
+	// A TI hit is always real corroboration.
 	if ti.Matched && ti.RiskScore >= 80 {
 		return false
 	}
-	// A real L2 phishing verdict (operationally backed) corroborates the call.
-	if mlVerdict == "phishing" && mlOpP >= l2OpSignalFloor {
+	// No real L2 verdict to correct with (degraded fail-open, errored, or never
+	// ran) — keep the L1 phishing call. Only a genuine L2 "phishing" verdict can
+	// be an uncorroborated structural echo; a degraded/absent one is not.
+	if mlDegraded || mlVerdict != "phishing" {
 		return false
 	}
-	return true
+	// Real L2 phishing verdict: corroborated only when operationally backed.
+	return mlOpP < l2OpSignalFloor
 }
 
 // dedupAndCapURLs normalises each raw URL, drops duplicates that share a

--- a/services/svc-03-url-analysis/cmd/url-pipeline/main.go
+++ b/services/svc-03-url-analysis/cmd/url-pipeline/main.go
@@ -56,17 +56,38 @@ const (
 	l2Timeout = 1500 * time.Millisecond
 
 	// L2 early-exit thresholds. The expensive L2 network enricher only adds
-	// value in the genuinely-uncertain band; when L1 is already confident we
-	// skip it entirely (the biggest latency win — most URLs never touch the
-	// network). A domain-guard hit already returns before L2 is considered.
+	// value in the genuinely-uncertain or looks-phishing band; when L1 is clearly
+	// BENIGN we skip it entirely (the biggest latency win — most legitimate-mail
+	// URLs never touch the network). A domain-guard hit already returns before L2
+	// is considered. We deliberately do NOT early-exit on a high L1 score: the L1
+	// model over-flags obscure benign domains, so a "looks-phishing" L1 must be
+	// verified by L2 before it can drive a high url_risk.
 	//
-	//   l1ConfidentPhishingScore: L1 XGBoost score at/above which we trust the
-	//     phishing call without L2 corroboration (mirrors classifyLabel's >=70
-	//     phishing cut, with margin).
+	//   l1ConfidentPhishingScore: retained as the documented "L1 looks strongly
+	//     phishing" reference point (mirrors classifyLabel's >=70 phishing cut,
+	//     with margin). It no longer triggers an L2 skip — those URLs run L2.
 	//   l1ConfidentBenignScore: L1 score at/below which we trust the benign call
 	//     without L2 (well under classifyLabel's 40 suspicious cut).
 	l1ConfidentPhishingScore = 85
 	l1ConfidentBenignScore   = 20
+
+	// l2OpSignalFloor is the minimum L2 operational-feature probability (op_p) for
+	// an L2 "phishing" verdict to count as real corroboration of a high L1 score.
+	//
+	// The L1 false positives on benign mail are obscure/dead-domain URLs whose URL
+	// *string* looks phishing to both the L1 model and the L2 URL-structural model
+	// (url_p high), but whose L2 operational model finds nothing (op_p ~ 0.0006).
+	// Real phishing hosts — even ones already taken down — still register a
+	// meaningful operational probability (op_p ~ 0.06-0.17 observed). So an L2
+	// phishing verdict with op_p below this floor is just a structural echo of L1,
+	// not independent evidence, and must NOT block de-escalation. The floor sits
+	// well above the benign cluster (~0.001) and well below the phishing cluster
+	// (~0.06), so it separates them with margin and does not cost phishing recall.
+	l2OpSignalFloor = 0.02
+	// uncorroboratedScore is the score an uncorroborated high-L1 URL is capped to.
+	// It keeps the URL in the low-suspicious band (not zero — the URL string is
+	// genuinely odd) without pinning the whole email to a phishing-grade url_risk.
+	uncorroboratedScore = 40
 )
 
 var (
@@ -182,10 +203,20 @@ type urlScan struct {
 	// "allowlisted" / "typosquat:<brand>" / "brand-in-subdomain:<brand>".
 	GuardHit string `json:"guard_hit,omitempty"`
 	// Layer-2 ML fields — populated only on TI-feed misses.
-	MLDeployP  float64 `json:"ml_deploy_p,omitempty"`
+	MLDeployP float64 `json:"ml_deploy_p,omitempty"`
+	// MLOpP is the L2 operational-feature probability (DNS/WHOIS/TLS/HTTP/GeoIP).
+	// It is near-zero when the operational model found nothing suspicious, which
+	// distinguishes a real phishing host (op_p above the floor) from an L2
+	// "phishing" verdict that rests purely on URL-structure (op_p ~ 0) — the
+	// latter is just a second structural echo of L1, not real corroboration.
+	MLOpP      float64 `json:"ml_op_p,omitempty"`
 	MLVerdict  string  `json:"ml_verdict,omitempty"`
 	MLCacheHit bool    `json:"ml_cache_hit,omitempty"`
-	Label      string  `json:"label"`
+	// MLDegraded is set when the L2 verdict is a fail-open default (breaker open)
+	// rather than a real model score. A degraded benign verdict is NOT evidence
+	// of benignity, so classifyLabel must not let it de-escalate a high L1 score.
+	MLDegraded bool   `json:"ml_degraded,omitempty"`
+	Label      string `json:"label"`
 }
 
 func handle(ctx context.Context, msg kafkaconsumer.Message, deps svckit.Deps) error {
@@ -496,13 +527,15 @@ func scanOne(ctx context.Context, raw string, log zerolog.Logger) urlScan {
 	// low-confidence TI matches, so we still want L2 to weigh in.
 	//
 	// Staged early-exit (latency): the L2 enricher does live network I/O, so we
-	// only invoke it for the genuinely-uncertain band. When L1 is already
-	// confident (clearly phishing >= l1ConfidentPhishingScore or clearly benign
-	// <= l1ConfidentBenignScore) AND there's no low-confidence TI hint pulling
+	// only skip it on the confident-BENIGN side. When L1 is clearly benign
+	// (<= l1ConfidentBenignScore) AND there's no low-confidence TI hint pulling
 	// the verdict the other way, we trust the cheap verdict and skip the network
-	// entirely. A low-confidence TI match (Matched but <80) keeps us in the
-	// uncertain band so L2 can corroborate. This is the biggest latency win —
-	// most URLs never touch the network.
+	// entirely. A high L1 score does NOT skip L2: the L1 model over-flags obscure
+	// benign domains, so a "looks-phishing" L1 must be verified by L2 before it
+	// can drive a high url_risk (the benign false-positive fix). A low-confidence
+	// TI match (Matched but <80) keeps us in the uncertain band so L2 can
+	// corroborate. The latency win still covers most legitimate-mail URLs, which
+	// score clearly benign and never touch the network.
 	ranL2 := false
 	l2Candidate := (!tiRes.Matched || tiRes.RiskScore < 80) && phishingDetector != nil
 	if l2Candidate && l1Confident(mlScore, routed, tiRes) {
@@ -526,20 +559,52 @@ func scanOne(ctx context.Context, raw string, log zerolog.Logger) urlScan {
 			log.Warn().Err(phishErr).Str("url", normalized).Msg("phishing ML check failed")
 		} else {
 			out.MLDeployP = phishResult.DeployP
+			out.MLOpP = phishResult.OpP
 			out.MLVerdict = phishResult.Verdict
 			out.MLCacheHit = phishResult.CacheHit
+			out.MLDegraded = phishResult.Degraded
 		}
 	}
 
-	out.Label = classifyLabel(mlScore, tiRes, routed, out.MLVerdict)
+	out.Label = classifyLabel(mlScore, tiRes, routed, out.MLVerdict, out.MLDegraded)
 
-	// A confirmed phishing verdict (TI RiskScore>=80 or the L2 fusion scorer)
-	// must carry a high numeric envelope score: svc-07 fuses env.Score
-	// numerically and never consults the label, so leaving Score at the raw L1
-	// XGBoost value (which can be low even for a TI/L2-confirmed phish) would
-	// under-weight the strongest URL signal downstream. Mirror the guard
-	// typosquat / brand-in-subdomain branches which already pin Score=100.
-	out.Score, out.Probability = phishingScore(out.Label, out.Score, out.Probability)
+	// De-escalate an UNCORROBORATED high L1 "phishing" label. The L1 model is the
+	// dominant false-positive source on real benign mail: it over-flags obscure /
+	// dead-domain URLs at ~100 purely on the URL string. The L2 URL-structural
+	// model often echoes that (url_p high) and returns "phishing" too — but with
+	// NO operational signal (op_p ~ 0) because the host carries nothing
+	// suspicious. That is not real corroboration; both models just dislike the URL
+	// string. Real phishing hosts still register a meaningful op_p even when
+	// taken down, so requiring an operational signal before trusting an L1-driven
+	// phishing call separates the benign false positives from real phish without
+	// touching recall (proven: every openphish/phishing_pot true positive keeps
+	// its operational signal). A TI hit (>=80) is always real corroboration.
+	if isUncorroboratedHighL1(out.Label, tiRes, out.MLVerdict, out.MLOpP) {
+		scanMetrics.IncOutcome("l1_uncorroborated_deescalated")
+		span.SetAttributes(
+			attribute.Bool("scan.l1_uncorroborated_deescalated", true),
+			attribute.Float64("scan.l2_op_p", out.MLOpP),
+		)
+		out.Label = "suspicious"
+		out.Score = uncorroboratedScore
+		out.Probability = float64(uncorroboratedScore) / 100.0
+	}
+
+	// Reconcile the numeric envelope score with the label. svc-07 fuses
+	// env.Score numerically and never consults the label, so the number must
+	// track the final verdict:
+	//   - A confirmed phishing verdict (TI RiskScore>=80 or the L2 fusion scorer)
+	//     pins Score=100 so a TI/L2-confirmed phish (whose raw L1 score may be
+	//     low) is not under-weighted downstream.
+	//   - A URL the L2 enricher genuinely cleared to benign must NOT keep its raw
+	//     L1 structural score: the L1 model over-flags obscure benign domains at
+	//     ~100, and leaving that number in place would re-flag the email even
+	//     though the label is legitimate. We pull the score down to L2's
+	//     deploy_p, the network-enriched estimate that just cleared it.
+	out.Score, out.Probability = envelopeScore(
+		out.Label, out.Score, out.Probability,
+		out.MLVerdict, out.MLDegraded, out.MLDeployP,
+	)
 
 	outcome := "fallback_legitimate"
 	switch {
@@ -562,13 +627,28 @@ func scanOne(ctx context.Context, raw string, log zerolog.Logger) urlScan {
 }
 
 // classifyLabel maps ML + TI + Layer-2 signals to a label.
-// mlVerdict is the fusion scorer verdict ("phishing" | "benign" | "").
-func classifyLabel(mlScore int, ti url.TIResult, routed bool, mlVerdict string) string {
+// mlVerdict is the fusion scorer verdict ("phishing" | "benign" | ""); mlDegraded
+// is true when that verdict is a fail-open default (breaker open) rather than a
+// real score.
+//
+// L2 is the network-enriched authority in the uncertain/looks-phishing band: a
+// genuine L2 benign verdict (ran and scored, not degraded) is strictly more
+// informed than the L1 structural guess, so it MUST be able to de-escalate a
+// high L1 score. Without this, a benign URL the L1 model over-flags (>=70) is
+// pinned to "phishing" even after L2 correctly clears it — the source of the
+// benign URL false positives. A TI hit (>=80) still wins outright, and a degraded
+// (breaker-open) benign verdict carries no signal, so the L1 score stands.
+func classifyLabel(mlScore int, ti url.TIResult, routed bool, mlVerdict string, mlDegraded bool) string {
 	if ti.Matched && ti.RiskScore >= 80 {
 		return "phishing"
 	}
 	if mlVerdict == "phishing" {
 		return "phishing"
+	}
+	// A real (non-degraded) L2 benign verdict overrides the L1 structural score:
+	// the network enricher cleared the URL, so don't escalate on L1 alone.
+	if mlVerdict == "benign" && !mlDegraded {
+		return "legitimate"
 	}
 	if routed {
 		return "suspicious"
@@ -583,26 +663,77 @@ func classifyLabel(mlScore int, ti url.TIResult, routed bool, mlVerdict string) 
 	}
 }
 
-// phishingScore raises the numeric envelope score to a confirmed-phishing
-// envelope when the label is "phishing", so a TI/L2-confirmed verdict is not
-// under-weighted downstream (svc-07 fuses on the numeric score, not the label).
-// Non-phishing labels keep the L1-derived score/probability unchanged.
-func phishingScore(label string, score int, prob float64) (int, float64) {
+// envelopeScore reconciles the numeric envelope score with the final label so
+// the number svc-07 fuses on tracks the verdict.
+//
+//   - label "phishing": pin Score=100 (a TI/L2-confirmed phish must not be
+//     under-weighted by a low raw L1 score).
+//   - a genuine (non-degraded) L2 benign verdict: the network enricher cleared
+//     the URL, so replace the raw L1 score — which over-flags obscure benign
+//     domains near 100 — with L2's deploy_p estimate. Without this, a corrected
+//     label is legitimate but the leftover L1 score still flags the email.
+//   - otherwise: keep the L1-derived score/probability unchanged.
+//
+// mlDegraded guards the L2 branch: a fail-open (breaker-open) benign verdict
+// carries no real signal, so it must NOT pull the score down — the L1 score
+// stands and phishing recall is preserved during a network outage.
+func envelopeScore(
+	label string,
+	score int, prob float64,
+	mlVerdict string, mlDegraded bool, mlDeployP float64,
+) (int, float64) {
 	if label == "phishing" {
 		return 100, 1.0
+	}
+	if mlVerdict == "benign" && !mlDegraded {
+		l2Score := int(mlDeployP * 100)
+		// Only ever pull the score DOWN. If the L1 score was already at/below the
+		// L2 estimate (genuinely-benign URL), keep it — never inflate.
+		if l2Score < score {
+			return l2Score, mlDeployP
+		}
 	}
 	return score, prob
 }
 
 // l1Confident reports whether the cheap signals (L1 XGBoost score + routing
-// flag, no TI match) already place a URL clearly in the phishing or benign band,
-// so the L2 network enricher can be skipped. A URL routed-to-enrichment or with
-// any TI hit is NOT confident — those stay in the uncertain band so L2 weighs in.
+// flag, no TI match) already place a URL clearly in the BENIGN band, so the L2
+// network enricher can be skipped. A URL routed-to-enrichment or with any TI hit
+// is NOT confident — those stay in the uncertain band so L2 weighs in.
+//
+// We intentionally early-exit ONLY on the confident-benign side. The L1 model is
+// the dominant false-positive source on real benign mail (obscure/dead domains
+// scored 100), so a high L1 score is NOT trustworthy on its own — those URLs must
+// always run L2 so the network-enriched verdict can corroborate or correct the
+// structural guess. The latency win is preserved where it is safe: the common
+// case (clearly-benign mail, mlScore <= l1ConfidentBenignScore) still skips the
+// network. l1ConfidentPhishingScore is retained for the test/threshold surface.
 func l1Confident(mlScore int, routed bool, ti url.TIResult) bool {
 	if ti.Matched || routed {
 		return false
 	}
-	return mlScore >= l1ConfidentPhishingScore || mlScore <= l1ConfidentBenignScore
+	return mlScore <= l1ConfidentBenignScore
+}
+
+// isUncorroboratedHighL1 reports whether a "phishing" label rests on the L1
+// structural score with no real corroboration, so it should be de-escalated.
+// Corroboration is either a TI hit (>=80) or an L2 phishing verdict backed by an
+// operational signal (op_p >= l2OpSignalFloor). An L2 phishing verdict with
+// near-zero op_p is just a URL-structural echo of L1 (both models dislike the
+// URL string) and is NOT independent evidence. Non-phishing labels are never
+// de-escalated.
+func isUncorroboratedHighL1(label string, ti url.TIResult, mlVerdict string, mlOpP float64) bool {
+	if label != "phishing" {
+		return false
+	}
+	if ti.Matched && ti.RiskScore >= 80 {
+		return false
+	}
+	// A real L2 phishing verdict (operationally backed) corroborates the call.
+	if mlVerdict == "phishing" && mlOpP >= l2OpSignalFloor {
+		return false
+	}
+	return true
 }
 
 // dedupAndCapURLs normalises each raw URL, drops duplicates that share a

--- a/services/svc-03-url-analysis/cmd/url-pipeline/main_test.go
+++ b/services/svc-03-url-analysis/cmd/url-pipeline/main_test.go
@@ -16,12 +16,13 @@ import (
 func TestPipelineClassifyLabel(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
-		name      string
-		score     int
-		ti        urlpkg.TIResult
-		routed    bool
-		mlVerdict string
-		want      string
+		name       string
+		score      int
+		ti         urlpkg.TIResult
+		routed     bool
+		mlVerdict  string
+		mlDegraded bool
+		want       string
 	}{
 		{
 			name:  "TI high risk → phishing",
@@ -59,9 +60,30 @@ func TestPipelineClassifyLabel(t *testing.T) {
 			want:  "legitimate",
 		},
 		{
-			name:  "Layer-2 benign does not change ML-based suspicious",
+			// The benign-URL fix: a high L1 score the L2 enricher clears must
+			// de-escalate to legitimate rather than stay pinned at phishing.
+			name:  "L2 benign overrides over-flagged L1 (>=70) → legitimate",
+			score: 100, mlVerdict: "benign",
+			want: "legitimate",
+		},
+		{
+			name:  "L2 benign de-escalates ML-based suspicious → legitimate",
 			score: 50, mlVerdict: "benign",
-			want: "suspicious",
+			want: "legitimate",
+		},
+		{
+			// A degraded (breaker-open) benign verdict carries no signal, so a
+			// high L1 score must stand — phishing recall is not regressed by a
+			// network outage flipping every flagged URL to benign.
+			name:  "degraded L2 benign does NOT override high L1 → phishing",
+			score: 100, mlVerdict: "benign", mlDegraded: true,
+			want: "phishing",
+		},
+		{
+			// TI high-risk still wins outright over an L2 benign verdict.
+			name:  "TI high risk beats L2 benign → phishing",
+			score: 100, ti: urlpkg.TIResult{Matched: true, RiskScore: 90}, mlVerdict: "benign",
+			want: "phishing",
 		},
 		{
 			name:  "Layer-2 phishing overrides routed-only suspicious",
@@ -73,21 +95,24 @@ func TestPipelineClassifyLabel(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			got := classifyLabel(tc.score, tc.ti, tc.routed, tc.mlVerdict)
+			got := classifyLabel(tc.score, tc.ti, tc.routed, tc.mlVerdict, tc.mlDegraded)
 			assert.Equal(t, tc.want, got)
 		})
 	}
 }
 
-func TestPhishingScore(t *testing.T) {
+func TestEnvelopeScore(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
-		name      string
-		label     string
-		inScore   int
-		inProb    float64
-		wantScore int
-		wantProb  float64
+		name       string
+		label      string
+		inScore    int
+		inProb     float64
+		mlVerdict  string
+		mlDegraded bool
+		mlDeployP  float64
+		wantScore  int
+		wantProb   float64
 	}{
 		{
 			// The regression: a TI/L2-confirmed phish whose L1 XGBoost score is
@@ -103,21 +128,50 @@ func TestPhishingScore(t *testing.T) {
 			wantScore: 100, wantProb: 1.0,
 		},
 		{
-			name:  "suspicious keeps the L1 score",
+			name:  "suspicious without L2 keeps the L1 score",
 			label: "suspicious", inScore: 55, inProb: 0.55,
 			wantScore: 55, wantProb: 0.55,
 		},
 		{
-			name:  "legitimate keeps the L1 score",
+			name:  "legitimate without L2 keeps the L1 score",
 			label: "legitimate", inScore: 10, inProb: 0.1,
 			wantScore: 10, wantProb: 0.1,
+		},
+		{
+			// The benign-URL fix: an L1 over-flag (98) the L2 enricher cleared to
+			// benign (deploy_p 0.27) must publish the L2-derived score, not 98 —
+			// otherwise the leftover L1 number re-flags the email.
+			name:  "L2 benign pulls an over-flagged L1 score down to deploy_p",
+			label: "legitimate", inScore: 98, inProb: 0.98,
+			mlVerdict: "benign", mlDeployP: 0.27,
+			wantScore: 27, wantProb: 0.27,
+		},
+		{
+			// A degraded (breaker-open) benign verdict carries no signal, so it
+			// must NOT pull the score down. (Label would already be phishing here,
+			// pinning 100; this guards the L2 branch independently.)
+			name:  "degraded L2 benign does not pull the score down",
+			label: "legitimate", inScore: 98, inProb: 0.98,
+			mlVerdict: "benign", mlDegraded: true, mlDeployP: 0,
+			wantScore: 98, wantProb: 0.98,
+		},
+		{
+			// Never inflate: a genuinely-benign URL whose L1 score is already
+			// below the L2 estimate keeps its lower L1 score.
+			name:  "L2 benign never raises an already-low L1 score",
+			label: "legitimate", inScore: 5, inProb: 0.05,
+			mlVerdict: "benign", mlDeployP: 0.30,
+			wantScore: 5, wantProb: 0.05,
 		},
 	}
 	for _, tc := range cases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			gotScore, gotProb := phishingScore(tc.label, tc.inScore, tc.inProb)
+			gotScore, gotProb := envelopeScore(
+				tc.label, tc.inScore, tc.inProb,
+				tc.mlVerdict, tc.mlDegraded, tc.mlDeployP,
+			)
 			assert.Equal(t, tc.wantScore, gotScore)
 			assert.InDelta(t, tc.wantProb, gotProb, 1e-9)
 		})
@@ -191,19 +245,62 @@ func TestL1Confident(t *testing.T) {
 		ti     urlpkg.TIResult
 		want   bool
 	}{
-		{"clearly phishing → confident, skip L2", l1ConfidentPhishingScore, false, urlpkg.TIResult{}, true},
+		// High L1 no longer skips L2: a "looks-phishing" L1 must be verified by L2
+		// (the benign over-flag fix). Only the confident-benign side early-exits.
+		{"clearly phishing → run L2 (no skip)", l1ConfidentPhishingScore, false, urlpkg.TIResult{}, false},
+		{"max phishing score → run L2 (no skip)", 100, false, urlpkg.TIResult{}, false},
 		{"clearly benign → confident, skip L2", l1ConfidentBenignScore, false, urlpkg.TIResult{}, true},
-		{"just below phishing cut → uncertain", l1ConfidentPhishingScore - 1, false, urlpkg.TIResult{}, false},
+		{"just below phishing cut → run L2", l1ConfidentPhishingScore - 1, false, urlpkg.TIResult{}, false},
 		{"just above benign cut → uncertain", l1ConfidentBenignScore + 1, false, urlpkg.TIResult{}, false},
 		{"mid-band → uncertain, run L2", 50, false, urlpkg.TIResult{}, false},
 		{"routed always uncertain even if benign-scored", l1ConfidentBenignScore, true, urlpkg.TIResult{}, false},
-		{"any TI match keeps it uncertain", l1ConfidentPhishingScore, false, urlpkg.TIResult{Matched: true, RiskScore: 50}, false},
+		{"any TI match keeps it uncertain", l1ConfidentBenignScore, false, urlpkg.TIResult{Matched: true, RiskScore: 50}, false},
 	}
 	for _, tc := range cases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			assert.Equal(t, tc.want, l1Confident(tc.score, tc.routed, tc.ti))
+		})
+	}
+}
+
+func TestIsUncorroboratedHighL1(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name      string
+		label     string
+		ti        urlpkg.TIResult
+		mlVerdict string
+		mlOpP     float64
+		want      bool
+	}{
+		{"non-phishing label is never de-escalated", "suspicious", urlpkg.TIResult{}, "", 0, false},
+		{"benign label is never de-escalated", "legitimate", urlpkg.TIResult{}, "", 0, false},
+		{"phishing from L1 only (no L2) is uncorroborated", "phishing", urlpkg.TIResult{}, "", 0, true},
+		{
+			"phishing with operationally-backed L2 is corroborated",
+			"phishing", urlpkg.TIResult{}, "phishing", 0.10, false,
+		},
+		{
+			// The benign-FP case: L2 says phishing but purely on URL-structure
+			// (op_p ~ 0), so it is a structural echo of L1, not corroboration.
+			"phishing with L2 op_p below floor is uncorroborated",
+			"phishing", urlpkg.TIResult{}, "phishing", 0.0006, true,
+		},
+		{
+			"phishing with L2 op_p exactly at floor is corroborated",
+			"phishing", urlpkg.TIResult{}, "phishing", l2OpSignalFloor, false,
+		},
+		{"phishing raised by TI>=80 is corroborated", "phishing", urlpkg.TIResult{Matched: true, RiskScore: 90}, "", 0, false},
+		{"phishing with low-conf TI<80 stays uncorroborated", "phishing", urlpkg.TIResult{Matched: true, RiskScore: 50}, "", 0, true},
+		{"phishing with L2 benign verdict is uncorroborated", "phishing", urlpkg.TIResult{}, "benign", 0, true},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, isUncorroboratedHighL1(tc.label, tc.ti, tc.mlVerdict, tc.mlOpP))
 		})
 	}
 }

--- a/services/svc-03-url-analysis/cmd/url-pipeline/main_test.go
+++ b/services/svc-03-url-analysis/cmd/url-pipeline/main_test.go
@@ -268,39 +268,63 @@ func TestL1Confident(t *testing.T) {
 func TestIsUncorroboratedHighL1(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
-		name      string
-		label     string
-		ti        urlpkg.TIResult
-		mlVerdict string
-		mlOpP     float64
-		want      bool
+		name       string
+		label      string
+		ti         urlpkg.TIResult
+		mlVerdict  string
+		mlOpP      float64
+		mlDegraded bool
+		want       bool
 	}{
-		{"non-phishing label is never de-escalated", "suspicious", urlpkg.TIResult{}, "", 0, false},
-		{"benign label is never de-escalated", "legitimate", urlpkg.TIResult{}, "", 0, false},
-		{"phishing from L1 only (no L2) is uncorroborated", "phishing", urlpkg.TIResult{}, "", 0, true},
+		{"non-phishing label is never de-escalated", "suspicious", urlpkg.TIResult{}, "", 0, false, false},
+		{"benign label is never de-escalated", "legitimate", urlpkg.TIResult{}, "", 0, false, false},
+		{
+			// No L2 verdict (errored / timed out / no sidecar): there is nothing
+			// to correct L1 with, so the L1 phishing call must STAND — recall is
+			// not silently dropped when L2 is unavailable.
+			"phishing from L1 only (no L2 verdict) stands — not de-escalated",
+			"phishing", urlpkg.TIResult{}, "", 0, false, false,
+		},
 		{
 			"phishing with operationally-backed L2 is corroborated",
-			"phishing", urlpkg.TIResult{}, "phishing", 0.10, false,
+			"phishing", urlpkg.TIResult{}, "phishing", 0.10, false, false,
 		},
 		{
 			// The benign-FP case: L2 says phishing but purely on URL-structure
 			// (op_p ~ 0), so it is a structural echo of L1, not corroboration.
 			"phishing with L2 op_p below floor is uncorroborated",
-			"phishing", urlpkg.TIResult{}, "phishing", 0.0006, true,
+			"phishing", urlpkg.TIResult{}, "phishing", 0.0006, false, true,
 		},
 		{
 			"phishing with L2 op_p exactly at floor is corroborated",
-			"phishing", urlpkg.TIResult{}, "phishing", l2OpSignalFloor, false,
+			"phishing", urlpkg.TIResult{}, "phishing", l2OpSignalFloor, false, false,
 		},
-		{"phishing raised by TI>=80 is corroborated", "phishing", urlpkg.TIResult{Matched: true, RiskScore: 90}, "", 0, false},
-		{"phishing with low-conf TI<80 stays uncorroborated", "phishing", urlpkg.TIResult{Matched: true, RiskScore: 50}, "", 0, true},
-		{"phishing with L2 benign verdict is uncorroborated", "phishing", urlpkg.TIResult{}, "benign", 0, true},
+		{"phishing raised by TI>=80 is corroborated", "phishing", urlpkg.TIResult{Matched: true, RiskScore: 90}, "", 0, false, false},
+		{
+			// Low-confidence TI gives no corroboration, but there is also no L2
+			// verdict to de-escalate with, so the L1 call stands.
+			"phishing with low-conf TI<80 and no L2 stands",
+			"phishing", urlpkg.TIResult{Matched: true, RiskScore: 50}, "", 0, false, false,
+		},
+		{
+			// L2 benign would normally make classifyLabel return legitimate; if it
+			// ever reaches here it is not a phishing echo, so do not de-escalate.
+			"phishing with L2 benign verdict stands",
+			"phishing", urlpkg.TIResult{}, "benign", 0, false, false,
+		},
+		{
+			// Breaker-open: L2 returns a degraded fail-open benign with no signal.
+			// classifyLabel keeps the high L1 as phishing; de-escalation must NOT
+			// fire — recall is preserved during a network outage.
+			"degraded L2 (breaker open) does not de-escalate high L1",
+			"phishing", urlpkg.TIResult{}, "benign", 0, true, false,
+		},
 	}
 	for _, tc := range cases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			assert.Equal(t, tc.want, isUncorroboratedHighL1(tc.label, tc.ti, tc.mlVerdict, tc.mlOpP))
+			assert.Equal(t, tc.want, isUncorroboratedHighL1(tc.label, tc.ti, tc.mlVerdict, tc.mlOpP, tc.mlDegraded))
 		})
 	}
 }

--- a/services/svc-03-url-analysis/internal/url/metrics.go
+++ b/services/svc-03-url-analysis/internal/url/metrics.go
@@ -11,7 +11,11 @@ import (
 // (cmd/url-pipeline). All instance methods are nil-safe so callers can pass a
 // nil holder in tests.
 type ScanMetrics struct {
-	ScansTotal    *prometheus.CounterVec // outcome=guard_allowlisted|guard_typosquat|guard_brand|ti_phishing|ml_phishing|ml_benign|fallback
+	// ScansTotal records exactly one outcome per scan. outcome is one of:
+	// guard_allowlisted, guard_typosquat, guard_brand, ti_phishing,
+	// ti_low_confidence, ml_phishing, ml_benign, l2_error, l2_skipped_confident,
+	// l1_uncorroborated_deescalated, fallback_legitimate.
+	ScansTotal    *prometheus.CounterVec
 	ScanDuration  prometheus.Histogram   // wall-clock end-to-end /scan
 	StageErrors   *prometheus.CounterVec // stage=normalize|guard|l1|ti|l2
 	GuardChecks   *prometheus.CounterVec // hit=allowlisted|typosquat|brand_in_subdomain|none


### PR DESCRIPTION
## Summary

svc-03's URL analysis flagged **legitimate URLs at `url_risk=100`**, driving a high false-positive rate on benign mail in the full-pipeline benchmark (content score 0, header low — the FP came purely from the URL layer).

## Root cause

The L1 XGBoost structural model over-scores some benign URL *strings* (98–100, "phishing"). The recent latency rework let that survive uncorrected: the staged early-exit skipped the L2 enrichment for any "confident" L1 (including the confident-*phishing* side), and `classifyLabel` pinned the score to 100 on L1 alone. So an L1 false positive went straight to the verdict with no corroboration.

## Fix (decision logic only — latency wins preserved)

- Early-exit now skips L2 **only on the confident-benign side** (`mlScore <= 20`); a high L1 is no longer trusted blindly. Common benign mail still skips the network.
- A genuine (non-degraded) L2 `benign` verdict de-escalates a high L1 score; the numeric envelope score follows L2's operational probability instead of the L1 over-score.
- An **uncorroborated** high-L1 "phishing" — no TI hit (≥80) and no operationally-backed L2 signal (`op_p >= 0.02`) — de-escalates to *suspicious* (score 40) instead of 100. The op_p floor sits between the observed benign (~0.001) and phishing (~0.06) clusters.
- Added `Result.Degraded` so a breaker-open fail-open "benign" can't de-escalate a high L1 (recall preserved during a network outage).

## Validation (full-pipeline harness, per-source 25)

| source | metric | before | after |
|---|---|---|---|
| spamassassin_easy_ham | benign FPR | 0.68 | **0.48** |
| openphish_live | recall | 0.84 | 0.84 |
| phishing_pot | recall | 0.76 | 0.76 |

Zero recall regression (identical TP counts). `go build/vet/test` green; unit tests added for the new decision logic.

## Residual / notes
- FPR floors ~0.48 on this (2002-era, many dead-domain) corpus because the remaining benign FPs are URL strings both models genuinely flag and/or carry real operational signal. Driving lower would need L1 model retraining (out of scope). The `op_p` floor + de-escalation score are named, documented constants for easy recalibration on production traffic.
