### PR TITLE
svc-06: NLP facets, 5-label intent, and timeout fail-soft (Batch 4)

### DIFF
--- a/demo/dashboard/view.go
+++ b/demo/dashboard/view.go
@@ -272,9 +272,13 @@ func headerViewOf(score *int, h *contracts.ScoresHeaderMessage) *headerView {
 	return hv
 }
 
-// nlpViewOf decodes the NLP component, supporting BOTH the typed ScoresNLP
-// (facets, when svc-06 migrates) and today's legacy ScoreEnvelope (classification
-// / intent_labels / urgency under details). Composite from emails.scored.nlp_score.
+// nlpViewOf decodes the NLP component. svc-06 today emits the structured facets
+// (urgency/intent/impersonation/deception) under details.facets while keeping
+// the legacy classification/intent_labels/obfuscation keys alongside; the typed
+// ScoresNLP migration will move facets to the top level. This reads facets from
+// EITHER location (top-level first, then details.facets) so impersonation and
+// deception surface today, and falls back to the legacy details keys otherwise.
+// Composite from emails.scored.nlp_score.
 func nlpViewOf(score *int, raw json.RawMessage) *nlpView {
 	if score == nil && len(raw) == 0 {
 		return nil
@@ -286,26 +290,37 @@ func nlpViewOf(score *int, raw json.RawMessage) *nlpView {
 	var d struct {
 		Facets  contracts.NLPFacets `json:"facets"`
 		Details struct {
-			Classification string          `json:"classification"`
-			Confidence     float64         `json:"confidence"`
-			IntentLabels   json.RawMessage `json:"intent_labels"`
-			UrgencyScore   float64         `json:"urgency_score"`
-			Obfuscation    bool            `json:"obfuscation_detected"`
+			Classification string              `json:"classification"`
+			Confidence     float64             `json:"confidence"`
+			IntentLabels   json.RawMessage     `json:"intent_labels"`
+			UrgencyScore   float64             `json:"urgency_score"`
+			Obfuscation    bool                `json:"obfuscation_detected"`
+			Facets         contracts.NLPFacets `json:"facets"`
 		} `json:"details"`
 	}
 	_ = json.Unmarshal(raw, &d)
 
+	// Prefer top-level facets (typed ScoresNLP); fall back to details.facets
+	// (svc-06's current ScoreEnvelope emit).
 	f := d.Facets
+	if f.IntentLabel == "" && f.UrgencyScore == 0 && f.ImpersonationScore == 0 && f.DeceptionScore == 0 {
+		f = d.Details.Facets
+	}
 	if f.IntentLabel != "" || f.UrgencyScore > 0 || f.ImpersonationScore > 0 || f.DeceptionScore > 0 {
-		// typed ScoresNLP facets
 		nv.HasFacets = true
 		nv.Intent, nv.IntentConfidence = f.IntentLabel, f.IntentConfidence
 		nv.Urgency, nv.Impersonation, nv.Deception = f.UrgencyScore, f.ImpersonationScore, f.DeceptionScore
 		nv.ImpersonatedBrand = f.ImpersonatedBrand
+		// classification / obfuscation live outside the facet struct.
+		nv.Classification = d.Details.Classification
+		nv.Obfuscation = d.Details.Obfuscation
+		if nv.Intent == "" {
+			nv.Intent = intentString(d.Details.IntentLabels, d.Details.Classification)
+		}
 		return nv
 	}
 
-	// legacy ScoreEnvelope.details (svc-06 today)
+	// legacy ScoreEnvelope.details (no facets at all)
 	nv.Classification = d.Details.Classification
 	nv.Intent = intentString(d.Details.IntentLabels, d.Details.Classification)
 	nv.IntentConfidence = d.Details.Confidence

--- a/demo/dashboard/view.go
+++ b/demo/dashboard/view.go
@@ -118,6 +118,7 @@ type fileView struct {
 type aggView struct {
 	Partial   bool     `json:"partial_analysis"`
 	Missing   []string `json:"missing_components,omitempty"`
+	Degraded  []string `json:"degraded_components,omitempty"`
 	Timeout   bool     `json:"timeout_triggered"`
 	LatencyMS int64    `json:"aggregation_latency_ms,omitempty"`
 }
@@ -150,6 +151,7 @@ func viewOf(sc *scan) scanView {
 		v.Aggregation = &aggView{
 			Partial:   es.PartialAnalysis,
 			Missing:   es.MissingComponents,
+			Degraded:  es.DegradedComponents,
 			Timeout:   es.TimeoutTriggered,
 			LatencyMS: es.AggregationLatencyMS,
 		}

--- a/services/svc-06-nlp/cmd/nlp-pipeline/main.go
+++ b/services/svc-06-nlp/cmd/nlp-pipeline/main.go
@@ -29,6 +29,119 @@ const (
 	predictTimeout = 10 * time.Second
 )
 
+// Facet model/heuristic version strings recorded in the scores.nlp
+// model_versions envelope so downstream consumers can reason about score
+// provenance. The urgency/impersonation/deception facets are pure keyword/
+// domain heuristics (CONSTRAINT G4: no NER, no retraining). The intent label
+// is likewise a deterministic heuristic mapping (mapIntentTo5Label) layered
+// over the Python 11-class intent_labels — it does NOT retrain DistilBERT —
+// so it carries a heuristic version too. Bump these when the mapping or any
+// heuristic changes so provenance stays accurate.
+const (
+	versionUrgency       = "heuristic-1.0"
+	versionIntent        = "heuristic-1.0"
+	versionImpersonation = "heuristic-1.0"
+	versionDeception     = "heuristic-1.0"
+)
+
+// 5-label intent taxonomy (ARCH-SPEC; see contracts.NLPFacets.IntentLabel).
+const (
+	intentCredentialHarvesting = "credential_harvesting"
+	intentMalwareDelivery      = "malware_delivery"
+	intentBEC                  = "bec"
+	intentScam                 = "scam"
+	intentLegitimate           = "legitimate"
+)
+
+// intent5Priority orders the 5 spec labels from highest threat priority to
+// lowest. When a single email's Python intent_labels map onto more than one
+// spec label, the highest-priority one wins (index 0 is highest). legitimate
+// is the lowest and only surfaces when nothing else matches.
+var intent5Priority = []string{
+	intentCredentialHarvesting,
+	intentMalwareDelivery,
+	intentBEC,
+	intentScam,
+	intentLegitimate,
+}
+
+// intent11To5 maps each Python _INTENT_PATTERNS key (inference.py) onto exactly
+// one of the 5 spec labels.
+//
+//	credential_harvest, account_verification, data_exfiltration -> credential_harvesting
+//	malware_delivery                                            -> malware_delivery
+//	social_engineering, urgency_threat, impersonation          -> bec
+//	payment_fraud, prize_scam                                  -> scam
+//	marketing_spam, benign_notification                        -> legitimate
+//
+// impersonation -> bec: brand-impersonation in this corpus is overwhelmingly a
+// pretext for business-email-compromise style requests (the standalone brand
+// signal is already carried separately as impersonation_score/impersonated_brand),
+// so folding it into bec keeps scam reserved for financial-lure fraud.
+var intent11To5 = map[string]string{
+	"credential_harvest":   intentCredentialHarvesting,
+	"account_verification": intentCredentialHarvesting,
+	"data_exfiltration":    intentCredentialHarvesting,
+	"malware_delivery":     intentMalwareDelivery,
+	"social_engineering":   intentBEC,
+	"urgency_threat":       intentBEC,
+	"impersonation":        intentBEC,
+	"payment_fraud":        intentScam,
+	"prize_scam":           intentScam,
+	"marketing_spam":       intentLegitimate,
+	"benign_notification":  intentLegitimate,
+}
+
+// mapIntentTo5Label collapses the Python 11-class intent_labels into exactly
+// one of the 5 spec labels (credential_harvesting | malware_delivery | bec |
+// scam | legitimate) plus a deterministic confidence.
+//
+// Resolution:
+//   - classification=="legitimate" or no intent labels => ("legitimate", 1.0).
+//   - Otherwise map every recognised intent to its 5-label bucket and pick the
+//     highest-priority bucket (intent5Priority). Unknown Python labels are
+//     ignored.
+//   - If nothing maps (only unknown labels) => ("legitimate", 0.5).
+//
+// Confidence reflects how cleanly the winning label was chosen: it is the
+// fraction of *recognised* intents that agree with the winning bucket. A single
+// matching intent yields 1.0; competing buckets dilute it. This is fully
+// deterministic and bounded to (0, 1].
+func mapIntentTo5Label(intentLabels []string, classification string) (string, float64) {
+	if classification == intentLegitimate || len(intentLabels) == 0 {
+		return intentLegitimate, 1.0
+	}
+
+	bucketCounts := make(map[string]int)
+	recognised := 0
+	for _, lbl := range intentLabels {
+		bucket, ok := intent11To5[lbl]
+		if !ok {
+			continue
+		}
+		recognised++
+		bucketCounts[bucket]++
+	}
+
+	if recognised == 0 {
+		// Only unknown labels: classification was not "legitimate" but we have
+		// no usable signal, so fall back to legitimate with low confidence.
+		return intentLegitimate, 0.5
+	}
+
+	// Highest-priority bucket that actually matched wins.
+	winner := intentLegitimate
+	for _, candidate := range intent5Priority {
+		if bucketCounts[candidate] > 0 {
+			winner = candidate
+			break
+		}
+	}
+
+	confidence := float64(bucketCounts[winner]) / float64(recognised)
+	return winner, confidence
+}
+
 var nlpClient *nlp.Client
 
 // predictor is the narrow slice of *nlp.Client that the core handler needs.
@@ -113,8 +226,10 @@ func process(ctx context.Context, input contracts.AnalysisText, pred predictor, 
 
 	predCtx, cancel := context.WithTimeout(ctx, predictTimeout)
 	resp, status, err := pred.Predict(predCtx, nlp.PredictRequest{
-		Subject:   input.Subject,
-		BodyPlain: input.Body,
+		Subject:      input.Subject,
+		BodyPlain:    input.Body,
+		SenderName:   input.SenderName,
+		SenderDomain: input.SenderDomain,
 	})
 	cancel()
 
@@ -145,6 +260,25 @@ func process(ctx context.Context, input contracts.AnalysisText, pred predictor, 
 				"fallback":        true,
 				"fallback_reason": fallbackReason,
 				"fallback_error":  err.Error(),
+				// Neutral/empty facets so the envelope shape is identical to the
+				// success path (consumers can always read facets/model_versions).
+				// No model ran, so every facet is zero and intent is legitimate.
+				"facets": contracts.NLPFacets{
+					UrgencyScore:       0,
+					IntentLabel:        intentLegitimate,
+					IntentConfidence:   0,
+					ImpersonationScore: 0,
+					ImpersonatedBrand:  nil,
+					DeceptionScore:     0,
+				},
+				"model_versions": contracts.NLPModelVersions{
+					Urgency:       versionUrgency,
+					Intent:        versionIntent,
+					Impersonation: versionImpersonation,
+					Deception:     versionDeception,
+				},
+				"intent_label":      intentLegitimate,
+				"intent_confidence": 0.0,
 				// subject + plain_text carry the content dimension SVC-08's
 				// campaign fingerprint and SimHash near-dedup read from
 				// component_details.nlp.details (ARCH-SPEC §8.1).
@@ -153,6 +287,25 @@ func process(ctx context.Context, input contracts.AnalysisText, pred predictor, 
 			},
 		}
 	} else {
+		// Heuristic 5-label intent collapsed from the Python 11-class
+		// intent_labels. The full intent_labels list is still emitted below for
+		// SVC-08's fingerprint; intent_label/intent_confidence add the single
+		// spec-taxonomy label (also surfaced inside facets).
+		intentLabel, intentConf := mapIntentTo5Label(resp.IntentLabels, resp.Classification)
+		facets := contracts.NLPFacets{
+			UrgencyScore:       resp.UrgencyScore,
+			IntentLabel:        intentLabel,
+			IntentConfidence:   intentConf,
+			ImpersonationScore: resp.ImpersonationScore,
+			ImpersonatedBrand:  resp.ImpersonatedBrand,
+			DeceptionScore:     resp.DeceptionScore,
+		}
+		modelVersions := contracts.NLPModelVersions{
+			Urgency:       versionUrgency,
+			Intent:        versionIntent,
+			Impersonation: versionImpersonation,
+			Deception:     versionDeception,
+		}
 		out = contracts.ScoreEnvelope{ //nolint:staticcheck // G13: sanctioned legacy ScoreEnvelope producer.
 			Meta:      meta,
 			Component: contracts.ComponentNLP,
@@ -164,6 +317,16 @@ func process(ctx context.Context, input contracts.AnalysisText, pred predictor, 
 				"intent_labels":        resp.IntentLabels,
 				"urgency_score":        resp.UrgencyScore,
 				"obfuscation_detected": resp.ObfuscationDetected,
+				// Structured facet + provenance envelope (P4.2). Added ALONGSIDE
+				// the legacy keys above — the topic stays a contracts.ScoreEnvelope
+				// because svc-07's decoder decodes scores.nlp as ScoreEnvelope and
+				// svc-08's fingerprint reads intent_labels/subject/plain_text out of
+				// this Details map. NLPFacets / NLPModelVersions JSON-marshal to the
+				// spec facets{} / model_versions{} shapes.
+				"facets":            facets,
+				"model_versions":    modelVersions,
+				"intent_label":      intentLabel,
+				"intent_confidence": intentConf,
 				// subject + plain_text carry the content dimension SVC-08's
 				// campaign fingerprint and SimHash near-dedup read from
 				// component_details.nlp.details (ARCH-SPEC §8.1). Without them the

--- a/services/svc-06-nlp/cmd/nlp-pipeline/main.go
+++ b/services/svc-06-nlp/cmd/nlp-pipeline/main.go
@@ -27,6 +27,16 @@ import (
 const (
 	serviceName    = "svc-06-nlp"
 	predictTimeout = 10 * time.Second
+
+	// Bounded in-handler retries for TRANSIENT predict failures (timeout,
+	// unreachable, 5xx) before falling back to the neutral score. This rides
+	// out brief model blips (e.g. a FastAPI restart) without NACKing the
+	// message — so we keep the spec §6 "never stall the partition" guarantee
+	// while not committing a permanent neutral 50 on a one-second hiccup.
+	// Permanent failures (4xx) are NOT retried. Kept small so the worst case
+	// stays bounded.
+	maxPredictAttempts  = 3
+	predictRetryBackoff = 250 * time.Millisecond
 )
 
 // versionHeuristic is the version string recorded for every facet in the
@@ -205,11 +215,26 @@ func handle(ctx context.Context, msg kafkaconsumer.Message, deps svckit.Deps) er
 	return process(ctx, input, nlpClient, publish)
 }
 
+// isTransientPredictErr reports whether a predict failure is worth retrying.
+// Transient: a deadline/timeout, an unreachable service (status 0), or a 5xx.
+// Permanent: a 4xx (e.g. a malformed request) — retrying can't help, so we go
+// straight to the fallback. nlp.Client.Predict returns status 0 + err when the
+// service is unreachable and the HTTP status + err on a non-2xx response.
+func isTransientPredictErr(err error, status int) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	return status == 0 || status >= 500
+}
+
 // process is the testable core of the handler: it predicts a content risk
-// score (falling back to a neutral 50 on any predict failure/timeout) and
-// publishes the scores.nlp envelope. It depends only on the predictor and
-// publishFunc abstractions so tests can drive it without a live FastAPI
-// service or real Kafka.
+// score (with bounded retries for transient failures, then falling back to a
+// neutral 50 on persistent failure/timeout) and publishes the scores.nlp
+// envelope. It depends only on the predictor and publishFunc abstractions so
+// tests can drive it without a live FastAPI service or real Kafka.
 func process(ctx context.Context, input contracts.AnalysisText, pred predictor, publish publishFunc) error {
 	log := zerolog.Ctx(ctx).With().Str("email_id", input.Meta.EmailID).Logger()
 
@@ -219,14 +244,38 @@ func process(ctx context.Context, input contracts.AnalysisText, pred predictor, 
 	}
 	meta := contracts.NewMetaWithFetched(input.Meta.EmailID, input.Meta.OrgID, ft)
 
-	predCtx, cancel := context.WithTimeout(ctx, predictTimeout)
-	resp, status, err := pred.Predict(predCtx, nlp.PredictRequest{
+	req := nlp.PredictRequest{
 		Subject:      input.Subject,
 		BodyPlain:    input.Body,
 		SenderName:   input.SenderName,
 		SenderDomain: input.SenderDomain,
-	})
-	cancel()
+	}
+	var (
+		resp   *nlp.PredictResponse
+		status int
+		err    error
+	)
+	for attempt := 1; attempt <= maxPredictAttempts; attempt++ {
+		predCtx, cancel := context.WithTimeout(ctx, predictTimeout)
+		resp, status, err = pred.Predict(predCtx, req)
+		cancel()
+		if err == nil || !isTransientPredictErr(err, status) || attempt == maxPredictAttempts {
+			break
+		}
+		log.Warn().
+			Err(err).
+			Int("status", status).
+			Int("attempt", attempt).
+			Int("max_attempts", maxPredictAttempts).
+			Msg("nlp predict transient failure; retrying")
+		// Short backoff, but abort immediately if the consumer context is done.
+		select {
+		case <-ctx.Done():
+			err = ctx.Err()
+			attempt = maxPredictAttempts
+		case <-time.After(predictRetryBackoff):
+		}
+	}
 
 	// Per-branch values. The defaults describe the fallback (no model ran)
 	// state; the success branch overwrites them. Both paths then build ONE

--- a/services/svc-06-nlp/cmd/nlp-pipeline/main.go
+++ b/services/svc-06-nlp/cmd/nlp-pipeline/main.go
@@ -30,6 +30,19 @@ const (
 
 var nlpClient *nlp.Client
 
+// predictor is the narrow slice of *nlp.Client that the core handler needs.
+// Extracting it lets tests inject a fake that returns context.DeadlineExceeded
+// (or any failure) without standing up the real FastAPI service.
+type predictor interface {
+	Predict(ctx context.Context, req nlp.PredictRequest) (*nlp.PredictResponse, int, error)
+}
+
+// publishFunc abstracts the scores.nlp emit so tests can capture the published
+// bytes instead of talking to a real Kafka producer. deps.Producers holds the
+// concrete *kafkaproducer.Producer, so handle() closes over it here and the
+// extracted core logic only depends on this function.
+type publishFunc func(ctx context.Context, key, value []byte) error
+
 func main() {
 	if err := svckit.Run(svckit.Spec{
 		Name:           serviceName,
@@ -70,60 +83,105 @@ func handle(ctx context.Context, msg kafkaconsumer.Message, deps svckit.Deps) er
 		return fmt.Errorf("decode analysis.text: %w", err)
 	}
 
-	log := zerolog.Ctx(ctx).With().Str("email_id", input.Meta.EmailID).Logger()
-
-	predCtx, cancel := context.WithTimeout(ctx, predictTimeout)
-	resp, status, err := nlpClient.Predict(predCtx, nlp.PredictRequest{
-		Subject:   input.Subject,
-		BodyPlain: input.Body,
-	})
-	cancel()
-	if err != nil {
-		return fmt.Errorf("nlp predict (status=%d): %w", status, err)
+	// Resolve the scores.nlp producer up front: a missing producer is an infra
+	// misconfiguration (not a model timeout) and must surface as an error.
+	prod, ok := deps.Producers[contracts.TopicScoresNLP]
+	if !ok {
+		return fmt.Errorf("svc-06: producer for %s not configured", contracts.TopicScoresNLP)
 	}
+	publish := func(ctx context.Context, key, value []byte) error {
+		return prod.Publish(ctx, key, value, 1) // +1 kafka retry
+	}
+
+	return process(ctx, input, nlpClient, publish)
+}
+
+// process is the testable core of the handler: it predicts a content risk
+// score (falling back to a neutral 50 on any predict failure/timeout) and
+// publishes the scores.nlp envelope. It depends only on the predictor and
+// publishFunc abstractions so tests can drive it without a live FastAPI
+// service or real Kafka.
+func process(ctx context.Context, input contracts.AnalysisText, pred predictor, publish publishFunc) error {
+	log := zerolog.Ctx(ctx).With().Str("email_id", input.Meta.EmailID).Logger()
 
 	ft := input.Meta.FetchedAt
 	if ft.IsZero() {
 		ft = time.Now().UTC()
 	}
-	out := contracts.ScoreEnvelope{ //nolint:staticcheck // G13: sanctioned legacy ScoreEnvelope producer.
-		Meta:      contracts.NewMetaWithFetched(input.Meta.EmailID, input.Meta.OrgID, ft),
-		Component: contracts.ComponentNLP,
-		Score:     float64(resp.ContentRiskScore),
-		Details: map[string]interface{}{
-			"classification":       resp.Classification,
-			"phishing_probability": resp.PhishingProbability,
-			"confidence":           resp.Confidence,
-			"intent_labels":        resp.IntentLabels,
-			"urgency_score":        resp.UrgencyScore,
-			"obfuscation_detected": resp.ObfuscationDetected,
-			// subject + plain_text carry the content dimension SVC-08's
-			// campaign fingerprint and SimHash near-dedup read from
-			// component_details.nlp.details (ARCH-SPEC §8.1). Without them the
-			// fingerprint's subject dimension collapses to SHA256("") and
-			// SimHash never runs. Body is the HTML-stripped clean plain text
-			// (spec field: plain_text).
-			"subject":    input.Subject,
-			"plain_text": input.Body,
-		},
+	meta := contracts.NewMetaWithFetched(input.Meta.EmailID, input.Meta.OrgID, ft)
+
+	predCtx, cancel := context.WithTimeout(ctx, predictTimeout)
+	resp, status, err := pred.Predict(predCtx, nlp.PredictRequest{
+		Subject:   input.Subject,
+		BodyPlain: input.Body,
+	})
+	cancel()
+
+	var out contracts.ScoreEnvelope //nolint:staticcheck // G13: sanctioned legacy ScoreEnvelope producer.
+	if err != nil {
+		// Spec §6 fallback: a slow/unreachable/non-2xx model must NOT NACK the
+		// message and stall the partition (head-of-line blocking). Emit the
+		// neutral score of 50 and commit the offset. subject + plain_text are
+		// still carried so SVC-08's fingerprint/SimHash keep working.
+		log.Warn().
+			Err(err).
+			Int("status", status).
+			Str("email_id", input.Meta.EmailID).
+			Msg("nlp predict failed/timed out; emitting fallback content_risk_score=50")
+		out = contracts.ScoreEnvelope{ //nolint:staticcheck // G13: sanctioned legacy ScoreEnvelope producer.
+			Meta:      meta,
+			Component: contracts.ComponentNLP,
+			Score:     50,
+			Details: map[string]interface{}{
+				"classification":  "unknown",
+				"fallback":        true,
+				"fallback_reason": "nlp_predict_timeout",
+				"fallback_error":  err.Error(),
+				// subject + plain_text carry the content dimension SVC-08's
+				// campaign fingerprint and SimHash near-dedup read from
+				// component_details.nlp.details (ARCH-SPEC §8.1).
+				"subject":    input.Subject,
+				"plain_text": input.Body,
+			},
+		}
+	} else {
+		out = contracts.ScoreEnvelope{ //nolint:staticcheck // G13: sanctioned legacy ScoreEnvelope producer.
+			Meta:      meta,
+			Component: contracts.ComponentNLP,
+			Score:     float64(resp.ContentRiskScore),
+			Details: map[string]interface{}{
+				"classification":       resp.Classification,
+				"phishing_probability": resp.PhishingProbability,
+				"confidence":           resp.Confidence,
+				"intent_labels":        resp.IntentLabels,
+				"urgency_score":        resp.UrgencyScore,
+				"obfuscation_detected": resp.ObfuscationDetected,
+				// subject + plain_text carry the content dimension SVC-08's
+				// campaign fingerprint and SimHash near-dedup read from
+				// component_details.nlp.details (ARCH-SPEC §8.1). Without them the
+				// fingerprint's subject dimension collapses to SHA256("") and
+				// SimHash never runs. Body is the HTML-stripped clean plain text
+				// (spec field: plain_text).
+				"subject":    input.Subject,
+				"plain_text": input.Body,
+			},
+		}
 	}
 
 	body, err := json.Marshal(out)
 	if err != nil {
 		return fmt.Errorf("marshal scores.nlp: %w", err)
 	}
-	prod, ok := deps.Producers[contracts.TopicScoresNLP]
-	if !ok {
-		return fmt.Errorf("svc-06: producer for %s not configured", contracts.TopicScoresNLP)
-	}
-	if err := prod.Publish(ctx, []byte(input.Meta.EmailID), body, 1); err != nil { // +1 kafka retry
+	if err := publish(ctx, []byte(input.Meta.EmailID), body); err != nil {
 		return fmt.Errorf("publish scores.nlp: %w", err)
 	}
 
-	log.Info().
-		Int("content_risk_score", resp.ContentRiskScore).
-		Str("classification", resp.Classification).
-		Float64("phishing_probability", resp.PhishingProbability).
-		Msg("scored email text")
+	if resp != nil {
+		log.Info().
+			Int("content_risk_score", resp.ContentRiskScore).
+			Str("classification", resp.Classification).
+			Float64("phishing_probability", resp.PhishingProbability).
+			Msg("scored email text")
+	}
 	return nil
 }

--- a/services/svc-06-nlp/cmd/nlp-pipeline/main.go
+++ b/services/svc-06-nlp/cmd/nlp-pipeline/main.go
@@ -11,6 +11,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"time"
@@ -123,10 +124,17 @@ func process(ctx context.Context, input contracts.AnalysisText, pred predictor, 
 		// message and stall the partition (head-of-line blocking). Emit the
 		// neutral score of 50 and commit the offset. subject + plain_text are
 		// still carried so SVC-08's fingerprint/SimHash keep working.
+		// Distinguish a deadline/timeout from a service failure (non-2xx or
+		// unreachable) so downstream consumers don't mis-attribute every
+		// fallback as a timeout. status==0 is the unreachable/deadline path.
+		fallbackReason := "nlp_predict_failed"
+		if errors.Is(err, context.DeadlineExceeded) {
+			fallbackReason = "nlp_predict_timeout"
+		}
 		log.Warn().
 			Err(err).
 			Int("status", status).
-			Str("email_id", input.Meta.EmailID).
+			Str("fallback_reason", fallbackReason).
 			Msg("nlp predict failed/timed out; emitting fallback content_risk_score=50")
 		out = contracts.ScoreEnvelope{ //nolint:staticcheck // G13: sanctioned legacy ScoreEnvelope producer.
 			Meta:      meta,
@@ -135,7 +143,7 @@ func process(ctx context.Context, input contracts.AnalysisText, pred predictor, 
 			Details: map[string]interface{}{
 				"classification":  "unknown",
 				"fallback":        true,
-				"fallback_reason": "nlp_predict_timeout",
+				"fallback_reason": fallbackReason,
 				"fallback_error":  err.Error(),
 				// subject + plain_text carry the content dimension SVC-08's
 				// campaign fingerprint and SimHash near-dedup read from

--- a/services/svc-06-nlp/cmd/nlp-pipeline/main.go
+++ b/services/svc-06-nlp/cmd/nlp-pipeline/main.go
@@ -29,20 +29,15 @@ const (
 	predictTimeout = 10 * time.Second
 )
 
-// Facet model/heuristic version strings recorded in the scores.nlp
-// model_versions envelope so downstream consumers can reason about score
-// provenance. The urgency/impersonation/deception facets are pure keyword/
-// domain heuristics (CONSTRAINT G4: no NER, no retraining). The intent label
-// is likewise a deterministic heuristic mapping (mapIntentTo5Label) layered
-// over the Python 11-class intent_labels — it does NOT retrain DistilBERT —
-// so it carries a heuristic version too. Bump these when the mapping or any
-// heuristic changes so provenance stays accurate.
-const (
-	versionUrgency       = "heuristic-1.0"
-	versionIntent        = "heuristic-1.0"
-	versionImpersonation = "heuristic-1.0"
-	versionDeception     = "heuristic-1.0"
-)
+// versionHeuristic is the version string recorded for every facet in the
+// scores.nlp model_versions envelope so downstream consumers can reason about
+// score provenance. All four facets (urgency/intent/impersonation/deception)
+// are pure keyword/domain heuristics (CONSTRAINT G4: no NER, no retraining) —
+// the intent label is a deterministic mapping (mapIntentTo5Label) over the
+// Python 11-class intent_labels, it does NOT retrain DistilBERT — so they
+// currently share one version. model_versions still carries a field per facet,
+// so if one heuristic diverges, give that field its own constant and bump it.
+const versionHeuristic = "heuristic-1.0"
 
 // 5-label intent taxonomy (ARCH-SPEC; see contracts.NLPFacets.IntentLabel).
 const (
@@ -233,12 +228,26 @@ func process(ctx context.Context, input contracts.AnalysisText, pred predictor, 
 	})
 	cancel()
 
-	var out contracts.ScoreEnvelope //nolint:staticcheck // G13: sanctioned legacy ScoreEnvelope producer.
+	// Per-branch values. The defaults describe the fallback (no model ran)
+	// state; the success branch overwrites them. Both paths then build ONE
+	// envelope below so the emitted scores.nlp shape is identical whether the
+	// model answered or timed out — every consumer (svc-07 decoder, svc-08
+	// fingerprint, the console) reads the same keys on either path.
+	var (
+		score          float64 = 50
+		classification         = "unknown"
+		intentLabels           = []string{} // empty (not nil) for shape stability
+		phishProb      float64
+		confidence     float64
+		obfuscation    bool
+		facets         = contracts.NLPFacets{IntentLabel: intentLegitimate}
+		fallbackInfo   map[string]interface{}
+	)
+
 	if err != nil {
 		// Spec §6 fallback: a slow/unreachable/non-2xx model must NOT NACK the
 		// message and stall the partition (head-of-line blocking). Emit the
-		// neutral score of 50 and commit the offset. subject + plain_text are
-		// still carried so SVC-08's fingerprint/SimHash keep working.
+		// neutral score of 50 and commit the offset.
 		// Distinguish a deadline/timeout from a service failure (non-2xx or
 		// unreachable) so downstream consumers don't mis-attribute every
 		// fallback as a timeout. status==0 is the unreachable/deadline path.
@@ -251,40 +260,10 @@ func process(ctx context.Context, input contracts.AnalysisText, pred predictor, 
 			Int("status", status).
 			Str("fallback_reason", fallbackReason).
 			Msg("nlp predict failed/timed out; emitting fallback content_risk_score=50")
-		out = contracts.ScoreEnvelope{ //nolint:staticcheck // G13: sanctioned legacy ScoreEnvelope producer.
-			Meta:      meta,
-			Component: contracts.ComponentNLP,
-			Score:     50,
-			Details: map[string]interface{}{
-				"classification":  "unknown",
-				"fallback":        true,
-				"fallback_reason": fallbackReason,
-				"fallback_error":  err.Error(),
-				// Neutral/empty facets so the envelope shape is identical to the
-				// success path (consumers can always read facets/model_versions).
-				// No model ran, so every facet is zero and intent is legitimate.
-				"facets": contracts.NLPFacets{
-					UrgencyScore:       0,
-					IntentLabel:        intentLegitimate,
-					IntentConfidence:   0,
-					ImpersonationScore: 0,
-					ImpersonatedBrand:  nil,
-					DeceptionScore:     0,
-				},
-				"model_versions": contracts.NLPModelVersions{
-					Urgency:       versionUrgency,
-					Intent:        versionIntent,
-					Impersonation: versionImpersonation,
-					Deception:     versionDeception,
-				},
-				"intent_label":      intentLegitimate,
-				"intent_confidence": 0.0,
-				// subject + plain_text carry the content dimension SVC-08's
-				// campaign fingerprint and SimHash near-dedup read from
-				// component_details.nlp.details (ARCH-SPEC §8.1).
-				"subject":    input.Subject,
-				"plain_text": input.Body,
-			},
+		fallbackInfo = map[string]interface{}{
+			"fallback":        true,
+			"fallback_reason": fallbackReason,
+			"fallback_error":  err.Error(),
 		}
 	} else {
 		// Heuristic 5-label intent collapsed from the Python 11-class
@@ -292,7 +271,13 @@ func process(ctx context.Context, input contracts.AnalysisText, pred predictor, 
 		// SVC-08's fingerprint; intent_label/intent_confidence add the single
 		// spec-taxonomy label (also surfaced inside facets).
 		intentLabel, intentConf := mapIntentTo5Label(resp.IntentLabels, resp.Classification)
-		facets := contracts.NLPFacets{
+		score = float64(resp.ContentRiskScore)
+		classification = resp.Classification
+		intentLabels = resp.IntentLabels
+		phishProb = resp.PhishingProbability
+		confidence = resp.Confidence
+		obfuscation = resp.ObfuscationDetected
+		facets = contracts.NLPFacets{
 			UrgencyScore:       resp.UrgencyScore,
 			IntentLabel:        intentLabel,
 			IntentConfidence:   intentConf,
@@ -300,43 +285,46 @@ func process(ctx context.Context, input contracts.AnalysisText, pred predictor, 
 			ImpersonatedBrand:  resp.ImpersonatedBrand,
 			DeceptionScore:     resp.DeceptionScore,
 		}
-		modelVersions := contracts.NLPModelVersions{
-			Urgency:       versionUrgency,
-			Intent:        versionIntent,
-			Impersonation: versionImpersonation,
-			Deception:     versionDeception,
-		}
-		out = contracts.ScoreEnvelope{ //nolint:staticcheck // G13: sanctioned legacy ScoreEnvelope producer.
-			Meta:      meta,
-			Component: contracts.ComponentNLP,
-			Score:     float64(resp.ContentRiskScore),
-			Details: map[string]interface{}{
-				"classification":       resp.Classification,
-				"phishing_probability": resp.PhishingProbability,
-				"confidence":           resp.Confidence,
-				"intent_labels":        resp.IntentLabels,
-				"urgency_score":        resp.UrgencyScore,
-				"obfuscation_detected": resp.ObfuscationDetected,
-				// Structured facet + provenance envelope (P4.2). Added ALONGSIDE
-				// the legacy keys above — the topic stays a contracts.ScoreEnvelope
-				// because svc-07's decoder decodes scores.nlp as ScoreEnvelope and
-				// svc-08's fingerprint reads intent_labels/subject/plain_text out of
-				// this Details map. NLPFacets / NLPModelVersions JSON-marshal to the
-				// spec facets{} / model_versions{} shapes.
-				"facets":            facets,
-				"model_versions":    modelVersions,
-				"intent_label":      intentLabel,
-				"intent_confidence": intentConf,
-				// subject + plain_text carry the content dimension SVC-08's
-				// campaign fingerprint and SimHash near-dedup read from
-				// component_details.nlp.details (ARCH-SPEC §8.1). Without them the
-				// fingerprint's subject dimension collapses to SHA256("") and
-				// SimHash never runs. Body is the HTML-stripped clean plain text
-				// (spec field: plain_text).
-				"subject":    input.Subject,
-				"plain_text": input.Body,
-			},
-		}
+	}
+
+	// Single envelope shared by both paths. The topic stays a
+	// contracts.ScoreEnvelope because svc-07's decoder decodes scores.nlp as
+	// ScoreEnvelope and svc-08's fingerprint reads intent_labels/subject/
+	// plain_text out of this Details map. NLPFacets / NLPModelVersions
+	// JSON-marshal to the spec facets{} / model_versions{} shapes.
+	details := map[string]interface{}{
+		"classification":       classification,
+		"phishing_probability": phishProb,
+		"confidence":           confidence,
+		"intent_labels":        intentLabels,
+		"urgency_score":        facets.UrgencyScore,
+		"obfuscation_detected": obfuscation,
+		"facets":               facets,
+		"model_versions": contracts.NLPModelVersions{
+			Urgency:       versionHeuristic,
+			Intent:        versionHeuristic,
+			Impersonation: versionHeuristic,
+			Deception:     versionHeuristic,
+		},
+		"intent_label":      facets.IntentLabel,
+		"intent_confidence": facets.IntentConfidence,
+		// subject + plain_text carry the content dimension SVC-08's campaign
+		// fingerprint and SimHash near-dedup read from component_details.nlp.
+		// details (ARCH-SPEC §8.1). Without them the fingerprint's subject
+		// dimension collapses to SHA256("") and SimHash never runs. Body is the
+		// HTML-stripped clean plain text (spec field: plain_text).
+		"subject":    input.Subject,
+		"plain_text": input.Body,
+	}
+	// Fallback-only provenance keys, layered on the otherwise-identical shape.
+	for k, v := range fallbackInfo {
+		details[k] = v
+	}
+	out := contracts.ScoreEnvelope{ //nolint:staticcheck // G13: sanctioned legacy ScoreEnvelope producer.
+		Meta:      meta,
+		Component: contracts.ComponentNLP,
+		Score:     score,
+		Details:   details,
 	}
 
 	body, err := json.Marshal(out)

--- a/services/svc-06-nlp/cmd/nlp-pipeline/main_test.go
+++ b/services/svc-06-nlp/cmd/nlp-pipeline/main_test.go
@@ -442,4 +442,29 @@ func TestProcess_FallbackEmitsNeutralFacets(t *testing.T) {
 	if out.Details.ModelVersions.Intent == "" {
 		t.Fatalf("fallback model_versions not populated: %+v", out.Details.ModelVersions)
 	}
+
+	// Shape-identical invariant: the fallback envelope must carry the same
+	// legacy keys the success path emits, so consumers (svc-08 fingerprint
+	// reads intent_labels; the console reads confidence/obfuscation) see a
+	// stable shape on either path. Decode the raw Details map and assert the
+	// keys are present (not silently dropped on a timeout).
+	var rawOut struct {
+		Details map[string]json.RawMessage `json:"details"`
+	}
+	if err := json.Unmarshal(pub.gotValue, &rawOut); err != nil {
+		t.Fatalf("unmarshal raw envelope: %v", err)
+	}
+	for _, key := range []string{
+		"classification", "phishing_probability", "confidence",
+		"intent_labels", "urgency_score", "obfuscation_detected",
+		"intent_label", "intent_confidence", "subject", "plain_text",
+	} {
+		if _, ok := rawOut.Details[key]; !ok {
+			t.Fatalf("fallback envelope missing legacy key %q (shape must match success path)", key)
+		}
+	}
+	// intent_labels must be an empty array, not null, for downstream stability.
+	if got := string(rawOut.Details["intent_labels"]); got != "[]" {
+		t.Fatalf("fallback intent_labels = %s, want []", got)
+	}
 }

--- a/services/svc-06-nlp/cmd/nlp-pipeline/main_test.go
+++ b/services/svc-06-nlp/cmd/nlp-pipeline/main_test.go
@@ -1,0 +1,179 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/saif/cybersiren/services/svc-06-nlp/internal/nlp"
+	contracts "github.com/saif/cybersiren/shared/contracts/kafka"
+)
+
+// fakePredictor injects a canned response or error into process() so the
+// timeout/fallback path can be exercised without a live FastAPI service.
+type fakePredictor struct {
+	resp   *nlp.PredictResponse
+	status int
+	err    error
+
+	gotReq nlp.PredictRequest
+	calls  int
+}
+
+func (f *fakePredictor) Predict(ctx context.Context, req nlp.PredictRequest) (*nlp.PredictResponse, int, error) {
+	f.calls++
+	f.gotReq = req
+	return f.resp, f.status, f.err
+}
+
+// capturingPublisher records the last published key/value instead of talking
+// to a real Kafka producer. It can also be told to fail (infra error path).
+type capturingPublisher struct {
+	gotKey   []byte
+	gotValue []byte
+	calls    int
+	failWith error
+}
+
+func (p *capturingPublisher) publish(ctx context.Context, key, value []byte) error {
+	p.calls++
+	p.gotKey = key
+	p.gotValue = value
+	return p.failWith
+}
+
+func sampleInput() contracts.AnalysisText {
+	return contracts.AnalysisText{
+		Meta:    contracts.NewMeta("email-abc", 7),
+		Subject: "Verify your account now",
+		Body:    "please click the link to verify",
+	}
+}
+
+// TestProcess_PredictTimeoutEmitsFallback proves that when Predict returns a
+// timeout (context.DeadlineExceeded), the handler does NOT return an error
+// (so the offset commits and the partition does not stall) and instead emits
+// a scores.nlp envelope with the neutral fallback score of 50.
+func TestProcess_PredictTimeoutEmitsFallback(t *testing.T) {
+	pred := &fakePredictor{err: context.DeadlineExceeded, status: 0}
+	pub := &capturingPublisher{}
+	in := sampleInput()
+
+	if err := process(context.Background(), in, pred, pub.publish); err != nil {
+		t.Fatalf("process returned error on predict timeout (must NOT stall partition): %v", err)
+	}
+
+	if pub.calls != 1 {
+		t.Fatalf("expected exactly one publish, got %d", pub.calls)
+	}
+	if string(pub.gotKey) != in.Meta.EmailID {
+		t.Fatalf("publish key = %q, want %q", pub.gotKey, in.Meta.EmailID)
+	}
+
+	var out contracts.ScoreEnvelope //nolint:staticcheck // G13: decoding the sanctioned legacy ScoreEnvelope emit.
+	if err := json.Unmarshal(pub.gotValue, &out); err != nil {
+		t.Fatalf("unmarshal published envelope: %v", err)
+	}
+	if out.Score != 50 {
+		t.Fatalf("fallback score = %v, want 50", out.Score)
+	}
+	if out.Component != contracts.ComponentNLP {
+		t.Fatalf("component = %q, want %q", out.Component, contracts.ComponentNLP)
+	}
+	if out.Meta.EmailID != in.Meta.EmailID {
+		t.Fatalf("meta email_id = %q, want %q", out.Meta.EmailID, in.Meta.EmailID)
+	}
+	if got := out.Details["classification"]; got != "unknown" {
+		t.Fatalf("classification = %v, want \"unknown\"", got)
+	}
+	if got, ok := out.Details["fallback"].(bool); !ok || !got {
+		t.Fatalf("details.fallback = %v, want true", out.Details["fallback"])
+	}
+	if got := out.Details["fallback_reason"]; got != "nlp_predict_timeout" {
+		t.Fatalf("details.fallback_reason = %v, want \"nlp_predict_timeout\"", got)
+	}
+	// subject + plain_text must still be carried for SVC-08 fingerprint/SimHash.
+	if got := out.Details["subject"]; got != in.Subject {
+		t.Fatalf("details.subject = %v, want %q", got, in.Subject)
+	}
+	if got := out.Details["plain_text"]; got != in.Body {
+		t.Fatalf("details.plain_text = %v, want %q", got, in.Body)
+	}
+}
+
+// TestProcess_GenericPredictErrorEmitsFallback proves the fallback also covers
+// non-timeout failures (unreachable service, non-2xx) — any non-nil error.
+func TestProcess_GenericPredictErrorEmitsFallback(t *testing.T) {
+	pred := &fakePredictor{err: errors.New("connection refused"), status: 502}
+	pub := &capturingPublisher{}
+	in := sampleInput()
+
+	if err := process(context.Background(), in, pred, pub.publish); err != nil {
+		t.Fatalf("process returned error on predict failure (must NOT stall partition): %v", err)
+	}
+	var out contracts.ScoreEnvelope //nolint:staticcheck // G13: decoding the sanctioned legacy ScoreEnvelope emit.
+	if err := json.Unmarshal(pub.gotValue, &out); err != nil {
+		t.Fatalf("unmarshal published envelope: %v", err)
+	}
+	if out.Score != 50 {
+		t.Fatalf("fallback score = %v, want 50", out.Score)
+	}
+}
+
+// TestProcess_SuccessEmitsRealScore is the happy-path sanity check that the
+// refactor did not break the success branch: the real ContentRiskScore and
+// classification flow through unchanged.
+func TestProcess_SuccessEmitsRealScore(t *testing.T) {
+	pred := &fakePredictor{
+		resp: &nlp.PredictResponse{
+			Classification:      "phishing",
+			Confidence:          0.91,
+			PhishingProbability: 0.88,
+			ContentRiskScore:    88,
+			IntentLabels:        []string{"credential_theft"},
+			UrgencyScore:        0.7,
+			ObfuscationDetected: true,
+		},
+		status: 200,
+	}
+	pub := &capturingPublisher{}
+	in := sampleInput()
+
+	if err := process(context.Background(), in, pred, pub.publish); err != nil {
+		t.Fatalf("process returned error on success path: %v", err)
+	}
+	if pub.calls != 1 {
+		t.Fatalf("expected exactly one publish, got %d", pub.calls)
+	}
+
+	var out contracts.ScoreEnvelope //nolint:staticcheck // G13: decoding the sanctioned legacy ScoreEnvelope emit.
+	if err := json.Unmarshal(pub.gotValue, &out); err != nil {
+		t.Fatalf("unmarshal published envelope: %v", err)
+	}
+	if out.Score != 88 {
+		t.Fatalf("success score = %v, want 88 (real ContentRiskScore)", out.Score)
+	}
+	if got := out.Details["classification"]; got != "phishing" {
+		t.Fatalf("classification = %v, want \"phishing\"", got)
+	}
+	if _, isFallback := out.Details["fallback"]; isFallback {
+		t.Fatalf("success path must not set details.fallback")
+	}
+	// success path must still carry subject + plain_text for SVC-08.
+	if got := out.Details["plain_text"]; got != in.Body {
+		t.Fatalf("details.plain_text = %v, want %q", got, in.Body)
+	}
+}
+
+// TestProcess_PublishErrorStillReturnsError proves infra failures (publish)
+// are NOT swallowed by the fallback — only model timeouts become a score=50.
+func TestProcess_PublishErrorStillReturnsError(t *testing.T) {
+	pred := &fakePredictor{err: context.DeadlineExceeded}
+	pub := &capturingPublisher{failWith: errors.New("kafka down")}
+	in := sampleInput()
+
+	if err := process(context.Background(), in, pred, pub.publish); err == nil {
+		t.Fatalf("expected publish error to propagate (infra failure, not a model timeout)")
+	}
+}

--- a/services/svc-06-nlp/cmd/nlp-pipeline/main_test.go
+++ b/services/svc-06-nlp/cmd/nlp-pipeline/main_test.go
@@ -177,3 +177,269 @@ func TestProcess_PublishErrorStillReturnsError(t *testing.T) {
 		t.Fatalf("expected publish error to propagate (infra failure, not a model timeout)")
 	}
 }
+
+// TestMapIntentTo5Label exercises every 5-label output, multi-intent priority
+// resolution, the empty/legitimate short-circuits and the unknown-label fall
+// back. mapIntentTo5Label must be pure and deterministic.
+func TestMapIntentTo5Label(t *testing.T) {
+	tests := []struct {
+		name           string
+		intents        []string
+		classification string
+		wantLabel      string
+		wantConf       float64
+	}{
+		{
+			name:      "credential_harvest -> credential_harvesting",
+			intents:   []string{"credential_harvest"},
+			wantLabel: intentCredentialHarvesting,
+			wantConf:  1.0,
+		},
+		{
+			name:      "account_verification -> credential_harvesting",
+			intents:   []string{"account_verification"},
+			wantLabel: intentCredentialHarvesting,
+			wantConf:  1.0,
+		},
+		{
+			name:      "data_exfiltration -> credential_harvesting",
+			intents:   []string{"data_exfiltration"},
+			wantLabel: intentCredentialHarvesting,
+			wantConf:  1.0,
+		},
+		{
+			name:      "malware_delivery -> malware_delivery",
+			intents:   []string{"malware_delivery"},
+			wantLabel: intentMalwareDelivery,
+			wantConf:  1.0,
+		},
+		{
+			name:      "social_engineering -> bec",
+			intents:   []string{"social_engineering"},
+			wantLabel: intentBEC,
+			wantConf:  1.0,
+		},
+		{
+			name:      "urgency_threat -> bec",
+			intents:   []string{"urgency_threat"},
+			wantLabel: intentBEC,
+			wantConf:  1.0,
+		},
+		{
+			name:      "impersonation -> bec",
+			intents:   []string{"impersonation"},
+			wantLabel: intentBEC,
+			wantConf:  1.0,
+		},
+		{
+			name:      "payment_fraud -> scam",
+			intents:   []string{"payment_fraud"},
+			wantLabel: intentScam,
+			wantConf:  1.0,
+		},
+		{
+			name:      "prize_scam -> scam",
+			intents:   []string{"prize_scam"},
+			wantLabel: intentScam,
+			wantConf:  1.0,
+		},
+		{
+			name:      "marketing_spam -> legitimate",
+			intents:   []string{"marketing_spam"},
+			wantLabel: intentLegitimate,
+			wantConf:  1.0,
+		},
+		{
+			name:      "benign_notification -> legitimate",
+			intents:   []string{"benign_notification"},
+			wantLabel: intentLegitimate,
+			wantConf:  1.0,
+		},
+		{
+			name:           "classification legitimate short-circuits",
+			intents:        []string{"credential_harvest"},
+			classification: "legitimate",
+			wantLabel:      intentLegitimate,
+			wantConf:       1.0,
+		},
+		{
+			name:      "no intents -> legitimate high confidence",
+			intents:   nil,
+			wantLabel: intentLegitimate,
+			wantConf:  1.0,
+		},
+		{
+			name:      "only unknown labels -> legitimate low confidence",
+			intents:   []string{"totally_unknown", "made_up"},
+			wantLabel: intentLegitimate,
+			wantConf:  0.5,
+		},
+		{
+			// credential_harvesting outranks bec & scam: priority order wins.
+			name:      "multi-intent priority picks credential_harvesting",
+			intents:   []string{"payment_fraud", "urgency_threat", "credential_harvest"},
+			wantLabel: intentCredentialHarvesting,
+			wantConf:  1.0 / 3.0,
+		},
+		{
+			// malware_delivery outranks scam.
+			name:      "multi-intent priority picks malware_delivery over scam",
+			intents:   []string{"prize_scam", "malware_delivery"},
+			wantLabel: intentMalwareDelivery,
+			wantConf:  0.5,
+		},
+		{
+			// two intents collapse to the same bucket -> full agreement.
+			name:      "two intents same bucket -> confidence 1.0",
+			intents:   []string{"credential_harvest", "account_verification"},
+			wantLabel: intentCredentialHarvesting,
+			wantConf:  1.0,
+		},
+		{
+			// unknown labels are ignored and do not dilute confidence.
+			name:      "unknown labels ignored in confidence",
+			intents:   []string{"credential_harvest", "junk_label"},
+			wantLabel: intentCredentialHarvesting,
+			wantConf:  1.0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotLabel, gotConf := mapIntentTo5Label(tc.intents, tc.classification)
+			if gotLabel != tc.wantLabel {
+				t.Fatalf("label = %q, want %q", gotLabel, tc.wantLabel)
+			}
+			if diff := gotConf - tc.wantConf; diff > 1e-9 || diff < -1e-9 {
+				t.Fatalf("confidence = %v, want %v", gotConf, tc.wantConf)
+			}
+		})
+	}
+}
+
+// TestProcess_SuccessEmitsFacets proves the success path now emits the
+// structured facets{} + model_versions{} envelope (with impersonation/
+// deception/urgency/intent) INTO the Details map while STILL carrying the
+// legacy svc-07/svc-08 dependency keys (subject, plain_text, intent_labels).
+func TestProcess_SuccessEmitsFacets(t *testing.T) {
+	brand := "paypal"
+	pred := &fakePredictor{
+		resp: &nlp.PredictResponse{
+			Classification:      "phishing",
+			Confidence:          0.93,
+			PhishingProbability: 0.9,
+			ContentRiskScore:    90,
+			IntentLabels:        []string{"credential_harvest", "urgency_threat"},
+			UrgencyScore:        0.8,
+			ObfuscationDetected: true,
+			ImpersonationScore:  0.75,
+			ImpersonatedBrand:   &brand,
+			DeceptionScore:      0.6,
+		},
+		status: 200,
+	}
+	pub := &capturingPublisher{}
+	in := sampleInput()
+	in.SenderName = "PayPal Support"
+	in.SenderDomain = "paypa1-secure.example"
+
+	if err := process(context.Background(), in, pred, pub.publish); err != nil {
+		t.Fatalf("process returned error on success path: %v", err)
+	}
+
+	// Sender fields must have been forwarded to the predictor.
+	if pred.gotReq.SenderName != in.SenderName {
+		t.Fatalf("predict sender_name = %q, want %q", pred.gotReq.SenderName, in.SenderName)
+	}
+	if pred.gotReq.SenderDomain != in.SenderDomain {
+		t.Fatalf("predict sender_domain = %q, want %q", pred.gotReq.SenderDomain, in.SenderDomain)
+	}
+
+	// Decode the published Details into a typed view of the facet envelope.
+	var out struct {
+		Score   float64 `json:"score"`
+		Details struct {
+			IntentLabels  []string                   `json:"intent_labels"`
+			Subject       string                     `json:"subject"`
+			PlainText     string                     `json:"plain_text"`
+			Facets        contracts.NLPFacets        `json:"facets"`
+			ModelVersions contracts.NLPModelVersions `json:"model_versions"`
+		} `json:"details"`
+	}
+	if err := json.Unmarshal(pub.gotValue, &out); err != nil {
+		t.Fatalf("unmarshal published envelope: %v", err)
+	}
+
+	// Regression guard: svc-08 dependency keys must survive.
+	if out.Details.Subject != in.Subject {
+		t.Fatalf("details.subject = %q, want %q", out.Details.Subject, in.Subject)
+	}
+	if out.Details.PlainText != in.Body {
+		t.Fatalf("details.plain_text = %q, want %q", out.Details.PlainText, in.Body)
+	}
+	if len(out.Details.IntentLabels) != 2 {
+		t.Fatalf("details.intent_labels = %v, want the 2 raw Python labels", out.Details.IntentLabels)
+	}
+
+	// Facets must carry the injected impersonation/deception/urgency values.
+	f := out.Details.Facets
+	if f.ImpersonationScore != 0.75 {
+		t.Fatalf("facets.impersonation_score = %v, want 0.75", f.ImpersonationScore)
+	}
+	if f.ImpersonatedBrand == nil || *f.ImpersonatedBrand != brand {
+		t.Fatalf("facets.impersonated_brand = %v, want %q", f.ImpersonatedBrand, brand)
+	}
+	if f.DeceptionScore != 0.6 {
+		t.Fatalf("facets.deception_score = %v, want 0.6", f.DeceptionScore)
+	}
+	if f.UrgencyScore != 0.8 {
+		t.Fatalf("facets.urgency_score = %v, want 0.8", f.UrgencyScore)
+	}
+	// credential_harvest + urgency_threat -> credential_harvesting wins (priority).
+	if f.IntentLabel != intentCredentialHarvesting {
+		t.Fatalf("facets.intent_label = %q, want %q", f.IntentLabel, intentCredentialHarvesting)
+	}
+	if f.IntentConfidence <= 0 || f.IntentConfidence > 1 {
+		t.Fatalf("facets.intent_confidence = %v, want (0,1]", f.IntentConfidence)
+	}
+
+	// model_versions populated.
+	if out.Details.ModelVersions.Impersonation == "" || out.Details.ModelVersions.Intent == "" {
+		t.Fatalf("model_versions not populated: %+v", out.Details.ModelVersions)
+	}
+}
+
+// TestProcess_FallbackEmitsNeutralFacets proves the timeout/fallback path emits
+// the same envelope shape: neutral facets + model_versions so consumers can
+// always read them.
+func TestProcess_FallbackEmitsNeutralFacets(t *testing.T) {
+	pred := &fakePredictor{err: context.DeadlineExceeded, status: 0}
+	pub := &capturingPublisher{}
+	in := sampleInput()
+
+	if err := process(context.Background(), in, pred, pub.publish); err != nil {
+		t.Fatalf("process returned error on fallback path: %v", err)
+	}
+
+	var out struct {
+		Details struct {
+			Facets        contracts.NLPFacets        `json:"facets"`
+			ModelVersions contracts.NLPModelVersions `json:"model_versions"`
+		} `json:"details"`
+	}
+	if err := json.Unmarshal(pub.gotValue, &out); err != nil {
+		t.Fatalf("unmarshal published envelope: %v", err)
+	}
+	if out.Details.Facets.IntentLabel != intentLegitimate {
+		t.Fatalf("fallback facets.intent_label = %q, want %q", out.Details.Facets.IntentLabel, intentLegitimate)
+	}
+	if out.Details.Facets.ImpersonationScore != 0 || out.Details.Facets.DeceptionScore != 0 {
+		t.Fatalf("fallback facets must be zero-scored: %+v", out.Details.Facets)
+	}
+	if out.Details.Facets.ImpersonatedBrand != nil {
+		t.Fatalf("fallback impersonated_brand = %v, want nil", out.Details.Facets.ImpersonatedBrand)
+	}
+	if out.Details.ModelVersions.Intent == "" {
+		t.Fatalf("fallback model_versions not populated: %+v", out.Details.ModelVersions)
+	}
+}

--- a/services/svc-06-nlp/cmd/nlp-pipeline/main_test.go
+++ b/services/svc-06-nlp/cmd/nlp-pipeline/main_test.go
@@ -468,3 +468,79 @@ func TestProcess_FallbackEmitsNeutralFacets(t *testing.T) {
 		t.Fatalf("fallback intent_labels = %s, want []", got)
 	}
 }
+
+// scriptedPredictor returns a sequence of (resp, status, err) results, one per
+// call, so a "fails then recovers" sequence can be driven.
+type scriptedPredictor struct {
+	results []struct {
+		resp   *nlp.PredictResponse
+		status int
+		err    error
+	}
+	calls int
+}
+
+func (s *scriptedPredictor) Predict(ctx context.Context, req nlp.PredictRequest) (*nlp.PredictResponse, int, error) {
+	r := s.results[s.calls]
+	s.calls++
+	return r.resp, r.status, r.err
+}
+
+// TestProcess_TransientErrorRetriesThenFallback proves a transient failure
+// (timeout) is retried up to maxPredictAttempts before the neutral fallback.
+func TestProcess_TransientErrorRetriesThenFallback(t *testing.T) {
+	pred := &fakePredictor{err: context.DeadlineExceeded, status: 0}
+	pub := &capturingPublisher{}
+
+	if err := process(context.Background(), sampleInput(), pred, pub.publish); err != nil {
+		t.Fatalf("process returned error: %v", err)
+	}
+	if pred.calls != maxPredictAttempts {
+		t.Fatalf("transient predict attempts = %d, want %d", pred.calls, maxPredictAttempts)
+	}
+}
+
+// TestProcess_PermanentErrorNoRetry proves a permanent failure (4xx) is NOT
+// retried — retrying a malformed request can't help.
+func TestProcess_PermanentErrorNoRetry(t *testing.T) {
+	pred := &fakePredictor{err: errors.New("nlp service error 400: bad request"), status: 400}
+	pub := &capturingPublisher{}
+
+	if err := process(context.Background(), sampleInput(), pred, pub.publish); err != nil {
+		t.Fatalf("process returned error: %v", err)
+	}
+	if pred.calls != 1 {
+		t.Fatalf("permanent predict attempts = %d, want 1 (no retry)", pred.calls)
+	}
+}
+
+// TestProcess_RecoversAfterTransientRetry proves a transient blip that clears on
+// a later attempt yields the REAL score, not the fallback.
+func TestProcess_RecoversAfterTransientRetry(t *testing.T) {
+	pred := &scriptedPredictor{results: []struct {
+		resp   *nlp.PredictResponse
+		status int
+		err    error
+	}{
+		{nil, 0, context.DeadlineExceeded},
+		{&nlp.PredictResponse{Classification: "phishing", ContentRiskScore: 88}, 200, nil},
+	}}
+	pub := &capturingPublisher{}
+
+	if err := process(context.Background(), sampleInput(), pred, pub.publish); err != nil {
+		t.Fatalf("process returned error: %v", err)
+	}
+	if pred.calls != 2 {
+		t.Fatalf("attempts = %d, want 2 (failed once then recovered)", pred.calls)
+	}
+	var out contracts.ScoreEnvelope //nolint:staticcheck // G13: decoding the sanctioned legacy ScoreEnvelope emit.
+	if err := json.Unmarshal(pub.gotValue, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.Score != 88 {
+		t.Fatalf("recovered score = %v, want 88 (real, not fallback 50)", out.Score)
+	}
+	if _, isFallback := out.Details["fallback"]; isFallback {
+		t.Fatalf("recovered path must not be a fallback")
+	}
+}

--- a/services/svc-06-nlp/internal/nlp/client.go
+++ b/services/svc-06-nlp/internal/nlp/client.go
@@ -53,7 +53,7 @@ type PredictResponse struct {
 	UrgencyScore        float64      `json:"urgency_score"` // 0.0 – 1.0
 	ObfuscationDetected bool         `json:"obfuscation_detected"`
 	TopTokens           []TokenScore `json:"top_tokens"` // always [] in production
-	// Heuristic facets added by the Python engine (P4.1). impersonated_brand is
+	// Heuristic facets added by the Python engine (P4.2). impersonated_brand is
 	// nullable (no impersonation detected → null).
 	ImpersonationScore float64 `json:"impersonation_score"` // 0.0 – 1.0
 	ImpersonatedBrand  *string `json:"impersonated_brand"`

--- a/services/svc-06-nlp/internal/nlp/client.go
+++ b/services/svc-06-nlp/internal/nlp/client.go
@@ -23,6 +23,11 @@ type PredictRequest struct {
 	Subject   string `json:"subject"`
 	BodyPlain string `json:"body_plain"`
 	BodyHTML  string `json:"body_html,omitempty"`
+	// SenderName / SenderDomain feed the Python heuristic brand-impersonation
+	// facet. Optional: when empty the facet degrades gracefully (Python cannot
+	// prove a domain mismatch and returns a neutral impersonation score).
+	SenderName   string `json:"sender_name,omitempty"`
+	SenderDomain string `json:"sender_domain,omitempty"`
 }
 
 // TokenScore holds a token and its LIME importance weight.
@@ -48,6 +53,11 @@ type PredictResponse struct {
 	UrgencyScore        float64      `json:"urgency_score"` // 0.0 – 1.0
 	ObfuscationDetected bool         `json:"obfuscation_detected"`
 	TopTokens           []TokenScore `json:"top_tokens"` // always [] in production
+	// Heuristic facets added by the Python engine (P4.1). impersonated_brand is
+	// nullable (no impersonation detected → null).
+	ImpersonationScore float64 `json:"impersonation_score"` // 0.0 – 1.0
+	ImpersonatedBrand  *string `json:"impersonated_brand"`
+	DeceptionScore     float64 `json:"deception_score"` // 0.0 – 1.0
 }
 
 // healthResponse is the Python /healthz response shape.

--- a/services/svc-06-nlp/nlp/app.py
+++ b/services/svc-06-nlp/nlp/app.py
@@ -90,6 +90,11 @@ class PredictRequest(BaseModel):
     subject: str
     body_plain: str
     body_html: str = ""
+    # Plumbed from the Kafka AnalysisText contract. Optional/defaulted so older
+    # callers (subject/body/html only) keep working. Used by the heuristic
+    # brand-impersonation facet to compare the claimed brand against the sender.
+    sender_domain: str = ""
+    sender_name: str = ""
 
 
 class TokenScore(BaseModel):
@@ -106,6 +111,13 @@ class PredictResponse(BaseModel):
     intent_labels: list[str]     # e.g. ["credential_harvest", "urgency_threat"]
     urgency_score: float         # 0.0 – 1.0
     obfuscation_detected: bool
+    # Heuristic facets (P4.2). impersonation_score is high when the email claims
+    # a known brand the sender domain does not belong to; impersonated_brand is
+    # the matched brand token (None when no brand claimed). deception_score is a
+    # weighted linguistic phishing-cue score.
+    impersonation_score: float        # 0.0 – 1.0
+    impersonated_brand: str | None = None
+    deception_score: float            # 0.0 – 1.0
     top_tokens: list[TokenScore] # always [] in production (LIME is offline)
 
 
@@ -149,7 +161,13 @@ def predict(req: PredictRequest):
             ),
         )
     try:
-        result = engine.predict(req.subject, req.body_plain, req.body_html)
+        result = engine.predict(
+            req.subject,
+            req.body_plain,
+            req.body_html,
+            sender_domain=req.sender_domain,
+            sender_name=req.sender_name,
+        )
         return result
     except Exception:
         logger.exception("Inference error")

--- a/services/svc-06-nlp/nlp/inference.py
+++ b/services/svc-06-nlp/nlp/inference.py
@@ -101,6 +101,138 @@ _URGENCY_PATTERNS = [
     r"\byour account will\b",
 ]
 
+# ── Brand-impersonation facet (heuristic, CONSTRAINT G4: NO NER) ────────────
+# A curated keyword list of frequently-impersonated brands. Each entry maps a
+# brand keyword (matched case-insensitively in subject+body) to its canonical
+# *domain token* — the substring that the brand's legitimate sending domain
+# contains (e.g. paypal.com -> "paypal", bankofamerica.com -> "bankofamerica").
+# This is a deliberately small, hand-maintained allow-list — NOT named-entity
+# recognition and NOT a model. Order does not matter; the longest/most-specific
+# textual match wins (we sort matches by phrase length so "bank of america"
+# beats a bare "bank"-like cue). Keep this a module-level constant, mirroring
+# _INTENT_PATTERNS, so it is trivially auditable and extendable.
+_BRAND_DOMAIN_TOKENS: dict[str, str] = {
+    "paypal": "paypal",
+    "amazon": "amazon",
+    "microsoft": "microsoft",
+    "office365": "microsoft",
+    "office 365": "microsoft",
+    "outlook": "microsoft",
+    "onedrive": "microsoft",
+    "windows": "microsoft",
+    "apple": "apple",
+    "icloud": "apple",
+    "itunes": "apple",
+    "appleid": "apple",
+    "apple id": "apple",
+    "google": "google",
+    "gmail": "google",
+    "netflix": "netflix",
+    "dhl": "dhl",
+    "fedex": "fedex",
+    "ups": "ups",
+    "usps": "usps",
+    "irs": "irs",
+    "bank of america": "bankofamerica",
+    "bankofamerica": "bankofamerica",
+    "bofa": "bankofamerica",
+    "chase": "chase",
+    "chase bank": "chase",
+    "wells fargo": "wellsfargo",
+    "wellsfargo": "wellsfargo",
+    "citibank": "citi",
+    "citi": "citi",
+    "docusign": "docusign",
+    "linkedin": "linkedin",
+    "facebook": "facebook",
+    "instagram": "instagram",
+    "whatsapp": "whatsapp",
+    "dropbox": "dropbox",
+    "adobe": "adobe",
+    "coinbase": "coinbase",
+    "binance": "binance",
+    "amex": "americanexpress",
+    "american express": "americanexpress",
+    "hsbc": "hsbc",
+    "barclays": "barclays",
+    "santander": "santander",
+}
+
+# Cues (beyond the bare brand name) that an email is *pretending* to act on a
+# brand's behalf — used to grant a moderate impersonation score when the sender
+# domain is unknown (empty) and we therefore cannot prove a mismatch.
+_IMPERSONATION_CUE_PATTERNS = [
+    r"\bverify your (?:account|identity|email|details|information)\b",
+    r"\bconfirm your (?:account|identity|details|payment|information)\b",
+    r"\bupdate your (?:account|billing|payment|details|information)\b",
+    r"\byour account (?:has been |is |will be )?(?:suspended|locked|limited|disabled|closed)\b",
+    r"\bunusual (?:activity|sign[\s-]?in|login|access)\b",
+    r"\bsecurity (?:alert|notice|warning)\b",
+    r"\bsign[\s-]?in to (?:your )?account\b",
+    r"\blog[\s-]?in to (?:your )?account\b",
+]
+
+# ── Deception facet (heuristic linguistic patterns, CONSTRAINT G4: NO model) ─
+# Weighted phishing-deception signals. Each signal contributes its weight when
+# any of its patterns match; the total is normalized against a saturation
+# constant. Pure rule-based — no NER, no zero-shot, no model. Mirrors the
+# _INTENT_PATTERNS style so it is auditable and extendable.
+_DECEPTION_SIGNALS: list[tuple[str, float, list[str]]] = [
+    # (signal_name, weight, patterns)
+    ("urgency_pressure", 1.0, [
+        r"\bact now\b", r"\bact immediately\b", r"\bwithin \d+ hours?\b",
+        r"\bwithin \d+ days?\b", r"\burgent\b", r"\bimmediately\b",
+        r"\bas soon as possible\b", r"\basap\b", r"\bexpires? (?:soon|today|in)\b",
+        r"\bfinal (?:notice|warning|reminder)\b", r"\bdo not (?:delay|ignore)\b",
+    ]),
+    ("generic_greeting", 1.0, [
+        r"\bdear (?:customer|user|account holder|member|client|valued)\b",
+        r"\bdear (?:sir|madam|sir/madam)\b",
+        r"\bhello (?:customer|user|member)\b",
+        r"\battention (?:customer|user|account holder)\b",
+    ]),
+    ("credential_request", 1.5, [
+        r"\bverify your (?:password|account|identity|login|credentials?)\b",
+        r"\bconfirm your (?:password|details|identity|payment|billing)\b",
+        r"\bupdate your (?:password|billing|payment|account|details)\b",
+        r"\benter your (?:username|password|pin|otp|credentials?)\b",
+        r"\bre[\s-]?enter your (?:password|details)\b",
+        r"\bprovide your (?:password|ssn|card|account) (?:number|details)?\b",
+    ]),
+    ("account_threat", 1.5, [
+        r"\byour account (?:has been |is |will be )?(?:suspended|locked|limited|disabled|deactivated|closed|deleted|terminated)\b",
+        r"\baccount (?:suspension|termination|closure|deletion)\b",
+        r"\bfailure to (?:respond|verify|comply|act)\b",
+        r"\bto avoid (?:suspension|closure|deactivation|losing)\b",
+        r"\bpermanently (?:closed|deleted|disabled)\b",
+    ]),
+    ("reward_lure", 1.0, [
+        r"\byou(?:'ve| have)? won\b", r"\bclaim your (?:prize|reward|gift|refund)\b",
+        r"\bcongratulations?\b", r"\bfree (?:gift|prize|voucher|reward)\b",
+        r"\bgift card\b", r"\byou(?:'ve| have)? been selected\b",
+        r"\bclaim now\b", r"\byou are (?:a|the) winner\b",
+    ]),
+    ("click_secrecy", 0.75, [
+        r"\bclick (?:here|the link|below)\b", r"\bopen the (?:attachment|link|file)\b",
+        r"\bkeep this (?:confidential|private|between us)\b",
+        r"\bdo not (?:tell|share|forward|reply to)\b",
+        r"\bstrictly confidential\b", r"\bthis is not (?:a |spam)\b",
+    ]),
+    ("unusual_activity", 1.0, [
+        r"\bunusual (?:activity|sign[\s-]?in|login|access)\b",
+        r"\bsuspicious (?:activity|login|sign[\s-]?in)\b",
+        r"\bdetected (?:a |an )?(?:unusual|unauthorized|suspicious)\b",
+        r"\bsecurity (?:alert|notice|warning|breach)\b",
+        r"\bsomeone (?:has |may have )?(?:accessed|tried to access)\b",
+    ]),
+]
+
+# Saturation constant: the total weighted deception score at (or above) which
+# the facet saturates to 1.0. Chosen so that ~2-3 independent strong signals
+# (e.g. credential_request + account_threat) push the score near the top, while
+# a single weak cue stays modest.
+_DECEPTION_SATURATION = 4.0
+
 
 class NLPInferenceEngine:
     """
@@ -402,6 +534,88 @@ class NLPInferenceEngine:
         hits = sum(1 for p in _URGENCY_PATTERNS if re.search(p, text_lower))
         return round(min(1.0, hits / 5.0), 4)
 
+    # ── Brand impersonation (heuristic, CONSTRAINT G4: NO NER) ────────────
+
+    def _detect_impersonation(
+        self, text: str, sender_domain: str
+    ) -> tuple[float, Optional[str]]:
+        """
+        Heuristic brand-impersonation facet → (impersonation_score, brand|None).
+
+        Step 1 — claimed brand: scan subject+body for a known-brand keyword from
+        _BRAND_DOMAIN_TOKENS. The longest matching phrase wins (so "bank of
+        america" beats a bare "bank"). If no brand is claimed, return (0.0, None).
+
+        Step 2 — sender comparison: compare the claimed brand's canonical domain
+        token against the lower-cased sender_domain.
+          • sender_domain known + token PRESENT in it  → legitimate, ~0 score.
+          • sender_domain known + token ABSENT          → mismatch = impersonation:
+            score 0.9, optionally +0.1 if extra impersonation cues are present
+            (capped at 1.0). This is the strongest signal — the email claims a
+            brand it provably is not sending from.
+          • sender_domain EMPTY (unknown): we CANNOT prove a mismatch, so we do
+            NOT cry impersonation on the brand name alone (legitimate brand mail
+            mentions the brand too). We emit a MODERATE score (0.5) only when the
+            email also carries impersonation cues (verify/confirm/suspended/...);
+            otherwise a low score (0.15) just flagging that a brand was named.
+
+        Returns the matched brand keyword's canonical token as impersonated_brand
+        whenever a non-trivial impersonation score is produced.
+        """
+        text_lower = text.lower()
+
+        # Find all claimed-brand matches; prefer the longest phrase (most specific).
+        matched: list[tuple[str, str]] = []  # (keyword, canonical_token)
+        for keyword, token in _BRAND_DOMAIN_TOKENS.items():
+            # word-ish boundary match so "ups" doesn't fire inside "groups".
+            if re.search(r"(?<![a-z0-9])" + re.escape(keyword) + r"(?![a-z0-9])", text_lower):
+                matched.append((keyword, token))
+
+        if not matched:
+            return 0.0, None
+
+        # Longest keyword wins (e.g. "bank of america" over "bank"-like cues).
+        matched.sort(key=lambda kt: len(kt[0]), reverse=True)
+        _, claimed_token = matched[0]
+
+        has_cues = any(re.search(p, text_lower) for p in _IMPERSONATION_CUE_PATTERNS)
+
+        sd = (sender_domain or "").strip().lower()
+        if sd:
+            # We have a sender domain → we can confirm or refute the claim.
+            if claimed_token in sd:
+                # Domain legitimately contains the brand token → not impersonation.
+                return 0.0, None
+            # Brand claimed but sender domain does NOT belong to that brand.
+            score = 0.9 + (0.1 if has_cues else 0.0)
+            return round(min(1.0, score), 4), claimed_token
+
+        # sender_domain unknown: cannot prove a mismatch.
+        if has_cues:
+            # Brand + classic impersonation cues, but unverifiable sender → moderate.
+            return 0.5, claimed_token
+        # Just a brand mention with no cues and no sender to check → low confidence.
+        return 0.15, claimed_token
+
+    # ── Deception (heuristic linguistic patterns, CONSTRAINT G4: NO model) ─
+
+    def _compute_deception(self, text: str) -> float:
+        """
+        Heuristic deception score 0.0–1.0 from weighted linguistic signals.
+
+        Sums the weight of every _DECEPTION_SIGNALS group that fires at least
+        once (urgency/pressure, generic greeting, credential request, account
+        threat, reward lure, click/secrecy, unusual-activity), then normalizes
+        against _DECEPTION_SATURATION and caps at 1.0. Pure rule-based — no NER,
+        no zero-shot, no model retrain.
+        """
+        text_lower = text.lower()
+        total = 0.0
+        for _name, weight, patterns in _DECEPTION_SIGNALS:
+            if any(re.search(p, text_lower) for p in patterns):
+                total += weight
+        return round(min(1.0, total / _DECEPTION_SATURATION), 4)
+
     # ── Inference ─────────────────────────────────────────────────────────
 
     @staticmethod
@@ -409,9 +623,24 @@ class NLPInferenceEngine:
         e = np.exp(x - x.max())
         return e / e.sum()
 
-    def predict(self, subject: str, body_plain: str, body_html: str = "") -> dict:
+    def predict(
+        self,
+        subject: str,
+        body_plain: str,
+        body_html: str = "",
+        sender_domain: str = "",
+        sender_name: str = "",
+    ) -> dict:
         """
         Run the full pipeline for one email and return the spec §8.3 response dict.
+
+        sender_domain / sender_name are OPTIONAL (defaulted) so existing callers
+        passing only (subject, body, html) keep working. They are plumbed from the
+        Kafka AnalysisText contract (sender_domain / sender_name) and used solely
+        by the heuristic brand-impersonation facet — when sender_domain is empty
+        the facet degrades gracefully (see _detect_impersonation). sender_name is
+        accepted for forward-compatibility; the current heuristic keys off the
+        domain only.
 
         Raises RuntimeError if the model has not been loaded successfully.
         """
@@ -464,6 +693,15 @@ class NLPInferenceEngine:
         intent_labels = self._detect_intent(text, classification)
         urgency_score = self._compute_urgency(text)
 
+        # 8. Heuristic facets (CONSTRAINT G4: rule-based only, no NER / no model).
+        #    Brand impersonation compares the claimed brand against sender_domain;
+        #    deception scores phishing linguistic cues. Both run on the
+        #    preprocessed text so they share the train/serve-safe canonicalization.
+        impersonation_score, impersonated_brand = self._detect_impersonation(
+            text, sender_domain
+        )
+        deception_score = self._compute_deception(text)
+
         return {
             "classification": classification,
             "confidence": round(confidence, 4),
@@ -473,6 +711,10 @@ class NLPInferenceEngine:
             "intent_labels": intent_labels,
             "urgency_score": urgency_score,
             "obfuscation_detected": obfuscation_detected,
+            # Heuristic facets (P4.2).
+            "impersonation_score": impersonation_score,
+            "impersonated_brand": impersonated_brand,
+            "deception_score": deception_score,
             # LIME attributions are expensive offline analysis (spec §7.3);
             # top_tokens is always empty in the production inference path.
             "top_tokens": [],

--- a/services/svc-06-nlp/nlp/inference.py
+++ b/services/svc-06-nlp/nlp/inference.py
@@ -104,13 +104,13 @@ _URGENCY_PATTERNS = [
 # ── Brand-impersonation facet (heuristic, CONSTRAINT G4: NO NER) ────────────
 # A curated keyword list of frequently-impersonated brands. Each entry maps a
 # brand keyword (matched case-insensitively in subject+body) to its canonical
-# *domain token* — the substring that the brand's legitimate sending domain
-# contains (e.g. paypal.com -> "paypal", bankofamerica.com -> "bankofamerica").
-# This is a deliberately small, hand-maintained allow-list — NOT named-entity
-# recognition and NOT a model. Order does not matter; the longest/most-specific
-# textual match wins (we sort matches by phrase length so "bank of america"
-# beats a bare "bank"-like cue). Keep this a module-level constant, mirroring
-# _INTENT_PATTERNS, so it is trivially auditable and extendable.
+# *brand token* — the human-readable brand identity returned as
+# impersonated_brand (e.g. paypal.com / gmail keyword -> "google"). This is a
+# deliberately small, hand-maintained allow-list — NOT named-entity recognition
+# and NOT a model. Order does not matter; the longest/most-specific textual
+# match wins (we sort matches by phrase length so "bank of america" beats a bare
+# "bank"-like cue). Keep this a module-level constant, mirroring _INTENT_PATTERNS,
+# so it is trivially auditable and extendable.
 _BRAND_DOMAIN_TOKENS: dict[str, str] = {
     "paypal": "paypal",
     "amazon": "amazon",
@@ -157,6 +157,98 @@ _BRAND_DOMAIN_TOKENS: dict[str, str] = {
     "barclays": "barclays",
     "santander": "santander",
 }
+
+# For each canonical brand token, the SET of registrable-domain (eTLD+1) LABELS
+# that are LEGITIMATELY operated by that brand. A claimed brand is treated as
+# legitimate ONLY when the sender's registrable label exactly equals one of
+# these (H2: a single brand ships from several first-party product domains —
+# google from gmail.com, apple from icloud.com/itunes.com, microsoft from
+# outlook.com/onedrive.live.com/outlook.office365.com, etc.). Any token not
+# listed here defaults to {token} (the brand's own name).
+_BRAND_LEGIT_DOMAINS: dict[str, set[str]] = {
+    "google": {"google", "gmail", "youtube", "googlemail"},
+    "apple": {"apple", "icloud", "itunes", "me", "mac"},
+    "microsoft": {
+        "microsoft", "outlook", "office365", "office", "onedrive",
+        "live", "msn", "hotmail", "windows", "sharepoint", "microsoftonline",
+    },
+    "bankofamerica": {"bankofamerica", "bofa"},
+    "americanexpress": {"americanexpress", "amex", "aexp"},
+    "wellsfargo": {"wellsfargo", "wf"},
+    "citi": {"citi", "citibank", "citigroup"},
+    "amazon": {"amazon", "aws", "amazonses", "primevideo"},
+    "facebook": {"facebook", "fb", "meta", "messenger"},
+    "netflix": {"netflix", "nflxext", "nflximg"},
+}
+
+# Ambiguous-word brands: ordinary English words / short tokens that collide with
+# everyday usage ("I'll chase up the invoice", "the back-ups are ready", "an
+# Apple laptop"). For these we do NOT grant the strong "provable impersonation"
+# band on a domain mismatch alone — we require a corroborating impersonation cue
+# (_IMPERSONATION_CUE_PATTERNS). Without a cue an ambiguous-word brand stays low
+# (H3). Unambiguous brands (paypal, microsoft, docusign, netflix…) keep the
+# strong-signal behaviour on mismatch.
+_AMBIGUOUS_WORD_BRANDS: set[str] = {"chase", "ups", "apple", "citi"}
+
+# Common public suffixes whose registrable domain is the last TWO labels
+# (eTLD = 1 label). Used by the dependency-free eTLD+1 approximation below.
+_SINGLE_LABEL_PUBLIC_SUFFIXES: set[str] = {
+    "com", "net", "org", "io", "co", "ru", "us", "uk", "de", "fr", "it",
+    "es", "nl", "ca", "au", "jp", "cn", "in", "br", "mx", "ch", "se", "no",
+    "fi", "dk", "pl", "cz", "be", "at", "ie", "nz", "za", "sg", "info",
+    "biz", "xyz", "online", "site", "app", "dev", "me", "tv", "cc", "ai",
+}
+
+# Common TWO-label public suffixes (eTLD = 2 labels) → registrable domain is the
+# last THREE labels. Hand-enumerated; not exhaustive (we keep this self-contained
+# and heuristic per CONSTRAINT G4 — NO public-suffix-list dependency).
+_TWO_LABEL_PUBLIC_SUFFIXES: set[str] = {
+    "co.uk", "org.uk", "gov.uk", "ac.uk", "me.uk",
+    "com.au", "net.au", "org.au", "gov.au", "edu.au",
+    "co.jp", "ne.jp", "or.jp", "go.jp", "ac.jp",
+    "com.br", "net.br", "org.br", "gov.br",
+    "co.nz", "net.nz", "org.nz",
+    "co.za", "org.za",
+    "com.cn", "net.cn", "org.cn", "gov.cn",
+    "co.in", "net.in", "org.in",
+    "com.mx", "com.sg", "com.hk", "com.tr",
+    "co.kr", "or.kr",
+}
+
+
+def _registrable_label(domain: str) -> str:
+    """
+    Dependency-free eTLD+1 approximation → the brand-identifying label.
+
+    Splits the host into dot-separated labels and returns the registrable
+    domain's leading label (the part just before the public suffix). Examples:
+      service.paypal.com  → "paypal"   (suffix "com",   eTLD+1 paypal.com)
+      secure-paypal.com   → "secure-paypal"
+      paypal.com.evil.ru  → "evil"     (suffix "ru",    eTLD+1 evil.ru)
+      bank.barclays.co.uk → "barclays" (suffix "co.uk", eTLD+1 barclays.co.uk)
+      onedrive.live.com   → "live"
+
+    Heuristic, NOT a real public-suffix list: we recognise a hand-enumerated set
+    of common single-label and two-label public suffixes; when the suffix is
+    unknown we fall back to the second-to-last label as the registrable label.
+    """
+    labels = [p for p in domain.strip().lower().split(".") if p]
+    if not labels:
+        return ""
+    if len(labels) == 1:
+        return labels[0]
+    last_two = ".".join(labels[-2:])
+    if last_two in _TWO_LABEL_PUBLIC_SUFFIXES:
+        # eTLD is 2 labels → registrable label is the 3rd-from-last (if present).
+        return labels[-3] if len(labels) >= 3 else labels[0]
+    # Single-label suffix (known or, as a fallback, assumed) → registrable label
+    # is the 2nd-from-last label.
+    return labels[-2]
+
+
+def _legit_labels_for(token: str) -> set[str]:
+    """Accepted registrable labels for a brand token (defaults to {token})."""
+    return _BRAND_LEGIT_DOMAINS.get(token, {token})
 
 # Cues (beyond the bare brand name) that an email is *pretending* to act on a
 # brand's behalf — used to grant a moderate impersonation score when the sender
@@ -546,22 +638,31 @@ class NLPInferenceEngine:
         _BRAND_DOMAIN_TOKENS. The longest matching phrase wins (so "bank of
         america" beats a bare "bank"). If no brand is claimed, return (0.0, None).
 
-        Step 2 — sender comparison: compare the claimed brand's canonical domain
-        token against the lower-cased sender_domain.
-          • sender_domain known + token PRESENT in it  → legitimate, ~0 score.
-          • sender_domain known + token ABSENT          → mismatch = impersonation:
-            score 0.9, optionally +0.1 if extra impersonation cues are present
-            (capped at 1.0). This is the strongest signal — the email claims a
-            brand it provably is not sending from.
+        Step 2 — sender comparison: compare the claimed brand's accepted
+        registrable-domain LABELS against the sender's registrable label (the
+        eTLD+1 leading label, see _registrable_label). We match on the
+        registrable label, NOT a raw substring, so lookalike/cousin domains are
+        caught (H1: secure-paypal.com, paypal.com.evil.ru, paypal-support.io all
+        have a registrable label != "paypal" → impersonation).
+          • sender_domain known + registrable label ∈ accepted set → legitimate, 0.
+          • sender_domain known + registrable label ∉ accepted set → mismatch =
+            impersonation. For UNAMBIGUOUS brands this is the strongest signal:
+            score 0.9, +0.1 if extra impersonation cues are present (cap 1.0).
+            For AMBIGUOUS-WORD brands (chase/ups/apple/citi, H3) a mismatch alone
+            is NOT enough (they collide with ordinary words) — we require a
+            corroborating cue: with a cue → 0.9(+0.1); without a cue → 0.15.
           • sender_domain EMPTY (unknown): we CANNOT prove a mismatch, so we do
             NOT cry impersonation on the brand name alone (legitimate brand mail
             mentions the brand too). We emit a MODERATE score (0.5) only when the
             email also carries impersonation cues (verify/confirm/suspended/...);
             otherwise a low score (0.15) just flagging that a brand was named.
+            Ambiguous-word brands with no sender and no cues → 0.0 (just a word).
 
         Returns the matched brand keyword's canonical token as impersonated_brand
         whenever a non-trivial impersonation score is produced.
         """
+        text = text or ""
+        sender_domain = sender_domain or ""
         text_lower = text.lower()
 
         # Find all claimed-brand matches; prefer the longest phrase (most specific).
@@ -579,14 +680,19 @@ class NLPInferenceEngine:
         _, claimed_token = matched[0]
 
         has_cues = any(re.search(p, text_lower) for p in _IMPERSONATION_CUE_PATTERNS)
+        is_ambiguous = claimed_token in _AMBIGUOUS_WORD_BRANDS
 
-        sd = (sender_domain or "").strip().lower()
+        sd = sender_domain.strip().lower()
         if sd:
-            # We have a sender domain → we can confirm or refute the claim.
-            if claimed_token in sd:
-                # Domain legitimately contains the brand token → not impersonation.
+            # We have a sender domain → confirm or refute via the registrable label.
+            reg_label = _registrable_label(sd)
+            if reg_label in _legit_labels_for(claimed_token):
+                # Sender's registrable domain belongs to the brand → not impersonation.
                 return 0.0, None
-            # Brand claimed but sender domain does NOT belong to that brand.
+            # Brand claimed but the sender's registrable domain is NOT the brand's.
+            if is_ambiguous and not has_cues:
+                # Ordinary word + mismatched domain but no impersonation cue → low.
+                return 0.15, claimed_token
             score = 0.9 + (0.1 if has_cues else 0.0)
             return round(min(1.0, score), 4), claimed_token
 
@@ -594,6 +700,9 @@ class NLPInferenceEngine:
         if has_cues:
             # Brand + classic impersonation cues, but unverifiable sender → moderate.
             return 0.5, claimed_token
+        if is_ambiguous:
+            # Ambiguous word, no cue, no sender → almost certainly just a word.
+            return 0.0, None
         # Just a brand mention with no cues and no sender to check → low confidence.
         return 0.15, claimed_token
 
@@ -609,7 +718,7 @@ class NLPInferenceEngine:
         against _DECEPTION_SATURATION and caps at 1.0. Pure rule-based — no NER,
         no zero-shot, no model retrain.
         """
-        text_lower = text.lower()
+        text_lower = (text or "").lower()
         total = 0.0
         for _name, weight, patterns in _DECEPTION_SIGNALS:
             if any(re.search(p, text_lower) for p in patterns):

--- a/services/svc-06-nlp/nlp/inference.py
+++ b/services/svc-06-nlp/nlp/inference.py
@@ -181,23 +181,17 @@ _BRAND_LEGIT_DOMAINS: dict[str, set[str]] = {
     "netflix": {"netflix", "nflxext", "nflximg"},
 }
 
-# Ambiguous-word brands: ordinary English words / short tokens that collide with
-# everyday usage ("I'll chase up the invoice", "the back-ups are ready", "an
-# Apple laptop"). For these we do NOT grant the strong "provable impersonation"
-# band on a domain mismatch alone — we require a corroborating impersonation cue
-# (_IMPERSONATION_CUE_PATTERNS). Without a cue an ambiguous-word brand stays low
-# (H3). Unambiguous brands (paypal, microsoft, docusign, netflix…) keep the
+# Ambiguous-word KEYWORDS: ordinary English words / short tokens that collide
+# with everyday usage ("I'll chase up the invoice", "the back-ups are ready",
+# "an Apple laptop"). Keyed on the matched KEYWORD, NOT the canonical token —
+# the bare word "apple" is ambiguous, but "icloud"/"itunes"/"appleid" (which
+# also map to the "apple" token) are not, so they must keep the strong-signal
+# behaviour. For an ambiguous keyword we do NOT grant the strong "provable
+# impersonation" band on a domain mismatch alone — we require a corroborating
+# impersonation cue (_IMPERSONATION_CUE_PATTERNS). Without a cue it stays low
+# (H3). Unambiguous keywords (paypal, microsoft, docusign, netflix…) keep the
 # strong-signal behaviour on mismatch.
-_AMBIGUOUS_WORD_BRANDS: set[str] = {"chase", "ups", "apple", "citi"}
-
-# Common public suffixes whose registrable domain is the last TWO labels
-# (eTLD = 1 label). Used by the dependency-free eTLD+1 approximation below.
-_SINGLE_LABEL_PUBLIC_SUFFIXES: set[str] = {
-    "com", "net", "org", "io", "co", "ru", "us", "uk", "de", "fr", "it",
-    "es", "nl", "ca", "au", "jp", "cn", "in", "br", "mx", "ch", "se", "no",
-    "fi", "dk", "pl", "cz", "be", "at", "ie", "nz", "za", "sg", "info",
-    "biz", "xyz", "online", "site", "app", "dev", "me", "tv", "cc", "ai",
-}
+_AMBIGUOUS_WORD_KEYWORDS: set[str] = {"chase", "ups", "apple", "citi"}
 
 # Common TWO-label public suffixes (eTLD = 2 labels) → registrable domain is the
 # last THREE labels. Hand-enumerated; not exhaustive (we keep this self-contained
@@ -229,8 +223,9 @@ def _registrable_label(domain: str) -> str:
       onedrive.live.com   → "live"
 
     Heuristic, NOT a real public-suffix list: we recognise a hand-enumerated set
-    of common single-label and two-label public suffixes; when the suffix is
-    unknown we fall back to the second-to-last label as the registrable label.
+    of common two-label public suffixes; otherwise (the common single-label
+    suffix case, plus any unknown suffix) we fall back to the second-to-last
+    label as the registrable label.
     """
     labels = [p for p in domain.strip().lower().split(".") if p]
     if not labels:
@@ -250,6 +245,21 @@ def _legit_labels_for(token: str) -> set[str]:
     """Accepted registrable labels for a brand token (defaults to {token})."""
     return _BRAND_LEGIT_DOMAINS.get(token, {token})
 
+
+# Precompiled brand-keyword matchers, built once at import (NOT recompiled per
+# email). Each is a word-ish boundary match so "ups" doesn't fire inside
+# "groups" — and the boundary class includes "-" so it also doesn't fire inside
+# hyphenated words ("back-ups", "start-ups", "follow-ups"). Tuple carries the
+# matched keyword (for longest-match + ambiguity gating) and its canonical token.
+_BRAND_PATTERNS: list[tuple[re.Pattern[str], str, str]] = [
+    (
+        re.compile(r"(?<![a-z0-9-])" + re.escape(keyword) + r"(?![a-z0-9-])"),
+        keyword,
+        token,
+    )
+    for keyword, token in _BRAND_DOMAIN_TOKENS.items()
+]
+
 # Cues (beyond the bare brand name) that an email is *pretending* to act on a
 # brand's behalf — used to grant a moderate impersonation score when the sender
 # domain is unknown (empty) and we therefore cannot prove a mismatch.
@@ -262,6 +272,10 @@ _IMPERSONATION_CUE_PATTERNS = [
     r"\bsecurity (?:alert|notice|warning)\b",
     r"\bsign[\s-]?in to (?:your )?account\b",
     r"\blog[\s-]?in to (?:your )?account\b",
+]
+# Precompiled once at import (not per email).
+_IMPERSONATION_CUE_RE: list[re.Pattern[str]] = [
+    re.compile(p) for p in _IMPERSONATION_CUE_PATTERNS
 ]
 
 # ── Deception facet (heuristic linguistic patterns, CONSTRAINT G4: NO model) ─
@@ -317,6 +331,13 @@ _DECEPTION_SIGNALS: list[tuple[str, float, list[str]]] = [
         r"\bsecurity (?:alert|notice|warning|breach)\b",
         r"\bsomeone (?:has |may have )?(?:accessed|tried to access)\b",
     ]),
+]
+
+# Precompiled deception signals (patterns compiled once at import, not per
+# email): (signal_name, weight, [compiled patterns]).
+_DECEPTION_SIGNALS_COMPILED: list[tuple[str, float, list[re.Pattern[str]]]] = [
+    (name, weight, [re.compile(p) for p in patterns])
+    for name, weight, patterns in _DECEPTION_SIGNALS
 ]
 
 # Saturation constant: the total weighted deception score at (or above) which
@@ -667,20 +688,22 @@ class NLPInferenceEngine:
 
         # Find all claimed-brand matches; prefer the longest phrase (most specific).
         matched: list[tuple[str, str]] = []  # (keyword, canonical_token)
-        for keyword, token in _BRAND_DOMAIN_TOKENS.items():
-            # word-ish boundary match so "ups" doesn't fire inside "groups".
-            if re.search(r"(?<![a-z0-9])" + re.escape(keyword) + r"(?![a-z0-9])", text_lower):
+        for pattern, keyword, token in _BRAND_PATTERNS:
+            if pattern.search(text_lower):
                 matched.append((keyword, token))
 
         if not matched:
             return 0.0, None
 
-        # Longest keyword wins (e.g. "bank of america" over "bank"-like cues).
+        # Longest keyword wins (e.g. "bank of america" over "bank"-like cues,
+        # and "icloud" over a bare "apple" so sub-brands aren't downgraded).
         matched.sort(key=lambda kt: len(kt[0]), reverse=True)
-        _, claimed_token = matched[0]
+        claimed_keyword, claimed_token = matched[0]
 
-        has_cues = any(re.search(p, text_lower) for p in _IMPERSONATION_CUE_PATTERNS)
-        is_ambiguous = claimed_token in _AMBIGUOUS_WORD_BRANDS
+        # Ambiguity is keyed on the matched KEYWORD, not the canonical token:
+        # bare "apple" is ambiguous, but "icloud"/"itunes"/"appleid" are not.
+        has_cues = any(p.search(text_lower) for p in _IMPERSONATION_CUE_RE)
+        is_ambiguous = claimed_keyword in _AMBIGUOUS_WORD_KEYWORDS
 
         sd = sender_domain.strip().lower()
         if sd:
@@ -720,8 +743,8 @@ class NLPInferenceEngine:
         """
         text_lower = (text or "").lower()
         total = 0.0
-        for _name, weight, patterns in _DECEPTION_SIGNALS:
-            if any(re.search(p, text_lower) for p in patterns):
+        for _name, weight, patterns in _DECEPTION_SIGNALS_COMPILED:
+            if any(p.search(text_lower) for p in patterns):
                 total += weight
         return round(min(1.0, total / _DECEPTION_SATURATION), 4)
 

--- a/services/svc-06-nlp/nlp/inference.py
+++ b/services/svc-06-nlp/nlp/inference.py
@@ -32,7 +32,7 @@ from typing import Optional
 
 import numpy as np
 
-from text_preprocess import preprocess_email
+from text_preprocess import normalize_keep_urls, preprocess_email
 
 logger = logging.getLogger(__name__)
 
@@ -181,6 +181,47 @@ _BRAND_LEGIT_DOMAINS: dict[str, set[str]] = {
     "netflix": {"netflix", "nflxext", "nflximg"},
 }
 
+# STRICT brands (the most-impersonated): legitimacy is decided by the FULL
+# registrable domain (eTLD+1), NOT the bare label — so cousin-TLD lookalikes
+# (paypal.ru, paypal.xyz, microsoft.co) are caught instead of trusted just
+# because the label says "paypal". Each value is the set of registrable domains
+# the brand legitimately sends from. A brand here whose sender uses the right
+# LABEL but an unlisted TLD (e.g. a real but un-enumerated ccTLD like amazon.it)
+# is NOT hard-failed — it is treated as a weak signal that only scores high with
+# corroborating phishing cues (see _detect_impersonation), so a missing ccTLD
+# costs precision noise, not a false "impersonation" alarm. Brands NOT listed
+# here keep the lenient label-only check (_BRAND_LEGIT_DOMAINS / {token}).
+_BRAND_STRICT_DOMAINS: dict[str, set[str]] = {
+    "paypal": {"paypal.com", "paypal.co.uk", "paypal.de", "paypal.fr",
+               "paypal.ca", "paypal.com.au", "paypal.me"},
+    "microsoft": {"microsoft.com", "outlook.com", "office.com", "office365.com",
+                  "microsoftonline.com", "live.com", "msn.com", "hotmail.com",
+                  "sharepoint.com", "windows.com", "skype.com", "azure.com"},
+    "apple": {"apple.com", "icloud.com", "itunes.com", "me.com", "mac.com"},
+    "google": {"google.com", "gmail.com", "googlemail.com", "youtube.com"},
+    "amazon": {"amazon.com", "amazon.co.uk", "amazon.de", "amazon.co.jp",
+               "amazon.ca", "amazon.in", "amazon.com.au", "amazonses.com",
+               "primevideo.com"},
+    "netflix": {"netflix.com"},
+    "docusign": {"docusign.com", "docusign.net"},
+    "coinbase": {"coinbase.com"},
+    "dropbox": {"dropbox.com", "dropboxmail.com"},
+    "adobe": {"adobe.com"},
+    "linkedin": {"linkedin.com"},
+    "facebook": {"facebook.com", "fb.com", "meta.com", "messenger.com"},
+    "instagram": {"instagram.com"},
+    "whatsapp": {"whatsapp.com"},
+    "bankofamerica": {"bankofamerica.com", "bofa.com"},
+    "wellsfargo": {"wellsfargo.com", "wf.com"},
+    "chase": {"chase.com"},
+    "citi": {"citi.com", "citibank.com", "citigroup.com"},
+    "americanexpress": {"americanexpress.com", "aexp.com"},
+    "dhl": {"dhl.com", "dhl.de"},
+    "fedex": {"fedex.com"},
+    "usps": {"usps.com"},
+    "irs": {"irs.gov"},
+}
+
 # Ambiguous-word KEYWORDS: ordinary English words / short tokens that collide
 # with everyday usage ("I'll chase up the invoice", "the back-ups are ready",
 # "an Apple laptop"). Keyed on the matched KEYWORD, NOT the canonical token —
@@ -210,22 +251,22 @@ _TWO_LABEL_PUBLIC_SUFFIXES: set[str] = {
 }
 
 
-def _registrable_label(domain: str) -> str:
+def _registrable_domain(domain: str) -> str:
     """
-    Dependency-free eTLD+1 approximation → the brand-identifying label.
+    Dependency-free eTLD+1 approximation → the registrable domain.
 
-    Splits the host into dot-separated labels and returns the registrable
-    domain's leading label (the part just before the public suffix). Examples:
-      service.paypal.com  → "paypal"   (suffix "com",   eTLD+1 paypal.com)
-      secure-paypal.com   → "secure-paypal"
-      paypal.com.evil.ru  → "evil"     (suffix "ru",    eTLD+1 evil.ru)
-      bank.barclays.co.uk → "barclays" (suffix "co.uk", eTLD+1 barclays.co.uk)
-      onedrive.live.com   → "live"
+    Splits the host into dot-separated labels and returns the registrable domain
+    (the label just before the public suffix, plus the suffix). Examples:
+      service.paypal.com  → "paypal.com"      (suffix "com")
+      secure-paypal.com   → "secure-paypal.com"
+      paypal.com.evil.ru  → "evil.ru"         (suffix "ru")
+      bank.barclays.co.uk → "barclays.co.uk"  (suffix "co.uk")
+      onedrive.live.com   → "live.com"
 
     Heuristic, NOT a real public-suffix list: we recognise a hand-enumerated set
     of common two-label public suffixes; otherwise (the common single-label
-    suffix case, plus any unknown suffix) we fall back to the second-to-last
-    label as the registrable label.
+    suffix case, plus any unknown suffix) we assume a single-label suffix and
+    take the last two labels.
     """
     labels = [p for p in domain.strip().lower().split(".") if p]
     if not labels:
@@ -234,11 +275,17 @@ def _registrable_label(domain: str) -> str:
         return labels[0]
     last_two = ".".join(labels[-2:])
     if last_two in _TWO_LABEL_PUBLIC_SUFFIXES:
-        # eTLD is 2 labels → registrable label is the 3rd-from-last (if present).
-        return labels[-3] if len(labels) >= 3 else labels[0]
-    # Single-label suffix (known or, as a fallback, assumed) → registrable label
-    # is the 2nd-from-last label.
-    return labels[-2]
+        # eTLD is 2 labels → registrable domain is the last THREE labels.
+        return ".".join(labels[-3:]) if len(labels) >= 3 else ".".join(labels)
+    # Single-label suffix (known or assumed) → registrable domain is the last two.
+    return ".".join(labels[-2:])
+
+
+def _registrable_label(domain: str) -> str:
+    """The brand-identifying leading label of the registrable domain (see
+    _registrable_domain). E.g. service.paypal.com → "paypal"."""
+    rd = _registrable_domain(domain)
+    return rd.split(".", 1)[0] if rd else ""
 
 
 def _legit_labels_for(token: str) -> set[str]:
@@ -650,81 +697,95 @@ class NLPInferenceEngine:
     # ── Brand impersonation (heuristic, CONSTRAINT G4: NO NER) ────────────
 
     def _detect_impersonation(
-        self, text: str, sender_domain: str
+        self, text: str, sender_domain: str, brand_text: Optional[str] = None
     ) -> tuple[float, Optional[str]]:
         """
         Heuristic brand-impersonation facet → (impersonation_score, brand|None).
 
-        Step 1 — claimed brand: scan subject+body for a known-brand keyword from
-        _BRAND_DOMAIN_TOKENS. The longest matching phrase wins (so "bank of
-        america" beats a bare "bank"). If no brand is claimed, return (0.0, None).
+        Step 1 — claimed brand: scan for a known-brand keyword. The scan runs on
+        brand_text (defaults to text) — predict() passes the URL-KEEPING text so
+        a brand that appears only inside a link is still seen, while the ML model
+        keeps getting the URL-stripped text. The longest matching phrase wins (so
+        "bank of america" beats a bare "bank", and "icloud" beats a bare
+        "apple"). A brand found ONLY in a link (not in the prose `text`) is a
+        weaker signal than one written in the body — legitimate mail links to
+        brand domains all the time — so it needs a corroborating cue to score
+        high. If no brand is claimed, return (0.0, None).
 
-        Step 2 — sender comparison: compare the claimed brand's accepted
-        registrable-domain LABELS against the sender's registrable label (the
-        eTLD+1 leading label, see _registrable_label). We match on the
-        registrable label, NOT a raw substring, so lookalike/cousin domains are
-        caught (H1: secure-paypal.com, paypal.com.evil.ru, paypal-support.io all
-        have a registrable label != "paypal" → impersonation).
-          • sender_domain known + registrable label ∈ accepted set → legitimate, 0.
-          • sender_domain known + registrable label ∉ accepted set → mismatch =
-            impersonation. For UNAMBIGUOUS brands this is the strongest signal:
-            score 0.9, +0.1 if extra impersonation cues are present (cap 1.0).
-            For AMBIGUOUS-WORD brands (chase/ups/apple/citi, H3) a mismatch alone
-            is NOT enough (they collide with ordinary words) — we require a
-            corroborating cue: with a cue → 0.9(+0.1); without a cue → 0.15.
-          • sender_domain EMPTY (unknown): we CANNOT prove a mismatch, so we do
-            NOT cry impersonation on the brand name alone (legitimate brand mail
-            mentions the brand too). We emit a MODERATE score (0.5) only when the
-            email also carries impersonation cues (verify/confirm/suspended/...);
-            otherwise a low score (0.15) just flagging that a brand was named.
-            Ambiguous-word brands with no sender and no cues → 0.0 (just a word).
+        Step 2 — sender comparison:
+          • STRICT brands (_BRAND_STRICT_DOMAINS, the most-impersonated): compare
+            the sender's full registrable domain (eTLD+1). In the brand's domain
+            set → legitimate, 0. Right LABEL but unlisted TLD (a real but
+            un-enumerated ccTLD, or a cousin-TLD attack like paypal.ru) → weak:
+            cue → 0.9(+0.1), no cue → 0.15. Different label entirely
+            (secure-paypal.com, paypal.com.evil.ru) → lookalike → strong 0.9.
+          • Non-strict brands: lenient registrable-LABEL match against the
+            accepted set (_BRAND_LEGIT_DOMAINS / {token}).
+          • Either way, AMBIGUOUS-WORD keywords (chase/ups/apple/citi) and
+            link-only mentions need a cue before scoring high; without one → 0.15.
+          • sender_domain EMPTY: cannot prove a mismatch → 0.5 with cues, else
+            0.15 (weak signals with no cue → 0.0, just a word/link).
 
         Returns the matched brand keyword's canonical token as impersonated_brand
         whenever a non-trivial impersonation score is produced.
         """
         text = text or ""
+        brand_text = brand_text if brand_text is not None else text
         sender_domain = sender_domain or ""
         text_lower = text.lower()
+        brand_lower = brand_text.lower()
 
-        # Find all claimed-brand matches; prefer the longest phrase (most specific).
-        matched: list[tuple[str, str]] = []  # (keyword, canonical_token)
+        # Find all claimed-brand matches; track whether each appears in the prose
+        # text or only in a link. Prefer the longest phrase (most specific).
+        matched: list[tuple[str, str, bool]] = []  # (keyword, token, in_prose)
         for pattern, keyword, token in _BRAND_PATTERNS:
-            if pattern.search(text_lower):
-                matched.append((keyword, token))
+            if pattern.search(brand_lower):
+                matched.append((keyword, token, bool(pattern.search(text_lower))))
 
         if not matched:
             return 0.0, None
 
-        # Longest keyword wins (e.g. "bank of america" over "bank"-like cues,
-        # and "icloud" over a bare "apple" so sub-brands aren't downgraded).
-        matched.sort(key=lambda kt: len(kt[0]), reverse=True)
-        claimed_keyword, claimed_token = matched[0]
+        matched.sort(key=lambda m: len(m[0]), reverse=True)
+        claimed_keyword, claimed_token, in_prose = matched[0]
 
-        # Ambiguity is keyed on the matched KEYWORD, not the canonical token:
-        # bare "apple" is ambiguous, but "icloud"/"itunes"/"appleid" are not.
-        has_cues = any(p.search(text_lower) for p in _IMPERSONATION_CUE_RE)
-        is_ambiguous = claimed_keyword in _AMBIGUOUS_WORD_KEYWORDS
+        has_cues = any(p.search(brand_lower) for p in _IMPERSONATION_CUE_RE)
+        # A signal is "weak" — needs a corroborating cue to score high — when the
+        # keyword is an ordinary word (ambiguity keyed on the KEYWORD, so bare
+        # "apple" is weak but "icloud"/"itunes" are not) OR the brand only showed
+        # up inside a link rather than the body prose.
+        weak_signal = (claimed_keyword in _AMBIGUOUS_WORD_KEYWORDS) or (not in_prose)
+
+        def _score_mismatch() -> tuple[float, Optional[str]]:
+            if weak_signal and not has_cues:
+                return 0.15, claimed_token
+            return round(min(1.0, 0.9 + (0.1 if has_cues else 0.0)), 4), claimed_token
 
         sd = sender_domain.strip().lower()
         if sd:
-            # We have a sender domain → confirm or refute via the registrable label.
-            reg_label = _registrable_label(sd)
-            if reg_label in _legit_labels_for(claimed_token):
-                # Sender's registrable domain belongs to the brand → not impersonation.
+            strict = _BRAND_STRICT_DOMAINS.get(claimed_token)
+            if strict is not None:
+                if _registrable_domain(sd) in strict:
+                    # Sender uses one of the brand's real domains → not impersonation.
+                    return 0.0, None
+                if _registrable_label(sd) in _legit_labels_for(claimed_token):
+                    # Right brand label, unlisted TLD: a real ccTLD we don't track
+                    # OR a cousin-TLD attack. Only strong with corroborating cues.
+                    if has_cues:
+                        return round(min(1.0, 1.0), 4), claimed_token
+                    return 0.15, claimed_token
+                # Label doesn't match at all → classic lookalike/cousin domain.
+                return _score_mismatch()
+            # Non-strict brand: lenient registrable-label match (legacy behaviour).
+            if _registrable_label(sd) in _legit_labels_for(claimed_token):
                 return 0.0, None
-            # Brand claimed but the sender's registrable domain is NOT the brand's.
-            if is_ambiguous and not has_cues:
-                # Ordinary word + mismatched domain but no impersonation cue → low.
-                return 0.15, claimed_token
-            score = 0.9 + (0.1 if has_cues else 0.0)
-            return round(min(1.0, score), 4), claimed_token
+            return _score_mismatch()
 
         # sender_domain unknown: cannot prove a mismatch.
         if has_cues:
             # Brand + classic impersonation cues, but unverifiable sender → moderate.
             return 0.5, claimed_token
-        if is_ambiguous:
-            # Ambiguous word, no cue, no sender → almost certainly just a word.
+        if weak_signal:
+            # Ambiguous word / link-only mention, no cue, no sender → just noise.
             return 0.0, None
         # Just a brand mention with no cues and no sender to check → low confidence.
         return 0.15, claimed_token
@@ -827,10 +888,14 @@ class NLPInferenceEngine:
 
         # 8. Heuristic facets (CONSTRAINT G4: rule-based only, no NER / no model).
         #    Brand impersonation compares the claimed brand against sender_domain;
-        #    deception scores phishing linguistic cues. Both run on the
-        #    preprocessed text so they share the train/serve-safe canonicalization.
+        #    deception scores phishing linguistic cues. Deception runs on the
+        #    model's preprocessed text. The brand scan additionally gets a
+        #    URL-KEEPING copy (brand_text) so a brand that appears only inside a
+        #    link is still caught — the model itself never sees that copy, so
+        #    there is no train/serve skew.
+        brand_text = normalize_keep_urls(subject, body_plain, body_html)
         impersonation_score, impersonated_brand = self._detect_impersonation(
-            text, sender_domain
+            text, sender_domain, brand_text=brand_text
         )
         deception_score = self._compute_deception(text)
 

--- a/services/svc-06-nlp/nlp/test_inference.py
+++ b/services/svc-06-nlp/nlp/test_inference.py
@@ -645,6 +645,72 @@ class TestImpersonationFacet:
         assert result["impersonation_score"] == 0.0
         assert result["impersonated_brand"] is None
 
+    # ── H4: strict-brand cousin-TLD must be caught, real ccTLD must not FP ──
+    def test_strict_cousin_tld_with_cues_flagged(self):
+        # paypal.ru has the right label but wrong TLD; with phishing cues it is a
+        # cousin-TLD impersonation, not legitimate PayPal mail.
+        score, brand = self.engine._detect_impersonation(
+            "Your PayPal account is suspended, verify your account", "paypal.ru"
+        )
+        assert score >= 0.9
+        assert brand == "paypal"
+
+    def test_strict_cousin_tld_no_cues_low(self):
+        # Right label, wrong TLD, but no cue → low (could be a real ccTLD).
+        score, brand = self.engine._detect_impersonation(
+            "Your PayPal statement is ready", "paypal.ru"
+        )
+        assert score <= 0.2
+        assert brand == "paypal"
+
+    def test_strict_real_cctld_label_match_not_false_positive(self):
+        # A real but un-enumerated brand ccTLD (amazon.it) with ordinary order
+        # text must NOT be hard-flagged as 0.9 impersonation.
+        score, _ = self.engine._detect_impersonation(
+            "Your Amazon order has shipped", "amazon.it"
+        )
+        assert score <= 0.2
+
+    def test_strict_real_domain_legit_zero(self):
+        score, brand = self.engine._detect_impersonation(
+            "Your Amazon order has shipped", "amazon.com"
+        )
+        assert score == 0.0
+        assert brand is None
+
+    # ── H5: brand that appears only inside a link (brand_text) ─────────────
+    def test_link_only_brand_with_cues_flagged(self):
+        # Brand is gone from the prose (URL stripped for the model) but present in
+        # the URL-keeping brand_text; with cues it is impersonation.
+        score, brand = self.engine._detect_impersonation(
+            "Click to verify your account",
+            "mailer.sendgrid.net",
+            brand_text="Click http://paypal.com.evil.ru/login to verify your account",
+        )
+        assert score >= 0.9
+        assert brand == "paypal"
+
+    def test_link_only_brand_no_cues_not_false_positive(self):
+        # Legitimate mail that merely links to a brand domain (no phishing cues)
+        # must NOT be flagged as strong impersonation.
+        score, _ = self.engine._detect_impersonation(
+            "Watch our latest update",
+            "newsletter.mycompany.com",
+            brand_text="Watch our latest update at https://youtube.com/xyz",
+        )
+        assert score <= 0.2
+
+    def test_predict_catches_brand_in_link(self):
+        # End-to-end via predict(): brand only in a link is still scored.
+        engine = _engine_with_logits([0.0, 0.0, 10.0])
+        result = engine.predict(
+            "Action required",
+            "Please verify your account at http://paypal.com.evil.ru/login",
+            sender_domain="mailer.example.net",
+        )
+        assert result["impersonation_score"] >= 0.9
+        assert result["impersonated_brand"] == "paypal"
+
 
 # ─────────────────────────────────────────────────────────────────────────────
 # 7c. Deception facet (heuristic, P4.2)

--- a/services/svc-06-nlp/nlp/test_inference.py
+++ b/services/svc-06-nlp/nlp/test_inference.py
@@ -415,7 +415,9 @@ class TestPredict:
         expected_keys = {
             "classification", "confidence", "phishing_probability",
             "spam_probability", "content_risk_score", "intent_labels",
-            "urgency_score", "obfuscation_detected", "top_tokens",
+            "urgency_score", "obfuscation_detected",
+            "impersonation_score", "impersonated_brand", "deception_score",
+            "top_tokens",
         }
         assert set(result.keys()) == expected_keys
 
@@ -461,6 +463,146 @@ class TestPredict:
         result = engine.predict("s", "b")
         assert result["phishing_probability"] < 0.8
         assert result["classification"] == "legitimate"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 7b. Brand-impersonation facet (heuristic, P4.2)
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestImpersonationFacet:
+    def setup_method(self):
+        self.engine = _make_engine()
+
+    # ── unit-level _detect_impersonation ──────────────────────────────────
+    def test_brand_claimed_mismatched_sender_high_score(self):
+        score, brand = self.engine._detect_impersonation(
+            "Your PayPal account has been suspended, verify your account",
+            "secure-login.example.com",
+        )
+        assert score >= 0.9
+        assert brand == "paypal"
+
+    def test_brand_claimed_matching_sender_zero(self):
+        score, brand = self.engine._detect_impersonation(
+            "Your PayPal receipt is ready", "service.paypal.com"
+        )
+        assert score == 0.0
+        assert brand is None
+
+    def test_no_brand_claimed_zero_none(self):
+        score, brand = self.engine._detect_impersonation(
+            "Lunch tomorrow at noon?", "coworker.example.com"
+        )
+        assert score == 0.0
+        assert brand is None
+
+    def test_empty_sender_with_cues_moderate(self):
+        # Unknown sender + brand + impersonation cues → moderate, can't prove.
+        score, brand = self.engine._detect_impersonation(
+            "Microsoft security alert: verify your account immediately", ""
+        )
+        assert score == 0.5
+        assert brand == "microsoft"
+
+    def test_empty_sender_no_cues_low(self):
+        # Just a brand mention, no cues, no sender to check → low confidence.
+        score, brand = self.engine._detect_impersonation(
+            "I love my new Apple laptop", ""
+        )
+        assert score == 0.15
+        assert brand == "apple"
+
+    def test_longest_brand_phrase_wins(self):
+        score, brand = self.engine._detect_impersonation(
+            "Bank of America: confirm your details", "phish.example.com"
+        )
+        assert brand == "bankofamerica"
+        assert score >= 0.9
+
+    def test_word_boundary_no_false_brand(self):
+        # "ups" must not fire inside "groups".
+        score, brand = self.engine._detect_impersonation(
+            "Join our community groups today", "newsletter.example.com"
+        )
+        assert score == 0.0
+        assert brand is None
+
+    # ── via predict() ─────────────────────────────────────────────────────
+    def test_predict_carries_impersonation_fields(self):
+        engine = _engine_with_logits([0.0, 0.0, 10.0])
+        result = engine.predict(
+            "PayPal: verify your account",
+            "Your account has been suspended, confirm your identity",
+            sender_domain="secure-login.example.com",
+        )
+        assert result["impersonation_score"] >= 0.9
+        assert result["impersonated_brand"] == "paypal"
+
+    def test_predict_default_sender_domain_still_works(self):
+        # Existing-style call (no sender_domain) must not error and must emit keys.
+        engine = _engine_with_logits([5.0, 0.0, 0.0])
+        result = engine.predict("Hello", "Just checking in")
+        assert "impersonation_score" in result
+        assert result["impersonation_score"] == 0.0
+        assert result["impersonated_brand"] is None
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 7c. Deception facet (heuristic, P4.2)
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestDeceptionFacet:
+    def setup_method(self):
+        self.engine = _make_engine()
+
+    def test_clearly_deceptive_text_high(self):
+        text = (
+            "Dear customer, your account has been suspended. "
+            "Verify your password immediately or your account will be deleted. "
+            "Click here within 24 hours to avoid suspension."
+        )
+        assert self.engine._compute_deception(text) >= 0.75
+
+    def test_benign_neutral_text_low(self):
+        assert self.engine._compute_deception("Lunch tomorrow?") < 0.25
+
+    def test_benign_meeting_text_zero(self):
+        assert self.engine._compute_deception(
+            "Hi team, attaching the slides for Thursday's review. Thanks!"
+        ) == 0.0
+
+    def test_signal_credential_request(self):
+        assert self.engine._compute_deception("Please verify your password now") > 0.0
+
+    def test_signal_generic_greeting(self):
+        assert self.engine._compute_deception("Dear customer, hello") > 0.0
+
+    def test_signal_reward_lure(self):
+        assert self.engine._compute_deception(
+            "Congratulations! You have won a free gift card, claim your prize"
+        ) > 0.0
+
+    def test_score_bounded_and_capped(self):
+        text = (
+            "Dear customer act now within 24 hours, verify your password, "
+            "your account will be deleted, you have won a prize, click here, "
+            "unusual activity detected, security alert"
+        )
+        score = self.engine._compute_deception(text)
+        assert 0.0 <= score <= 1.0
+        assert score == 1.0
+
+    def test_score_rounded_to_4dp(self):
+        score = self.engine._compute_deception("verify your password")
+        assert score == round(score, 4)
+
+    def test_predict_carries_deception_field(self):
+        engine = _engine_with_logits([0.0, 0.0, 10.0])
+        result = engine.predict(
+            "Account suspended",
+            "Dear customer, verify your password immediately or your account will be closed",
+        )
+        assert result["deception_score"] >= 0.5
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/services/svc-06-nlp/nlp/test_inference.py
+++ b/services/svc-06-nlp/nlp/test_inference.py
@@ -506,11 +506,110 @@ class TestImpersonationFacet:
 
     def test_empty_sender_no_cues_low(self):
         # Just a brand mention, no cues, no sender to check → low confidence.
+        # Use an UNAMBIGUOUS brand (paypal); ambiguous words have their own case.
         score, brand = self.engine._detect_impersonation(
-            "I love my new Apple laptop", ""
+            "I got my PayPal statement", ""
         )
         assert score == 0.15
+        assert brand == "paypal"
+
+    # ── H1: lookalike / cousin domains must be flagged (not legit) ─────────
+    def test_lookalike_domain_secure_paypal_flagged(self):
+        score, brand = self.engine._detect_impersonation(
+            "Your PayPal account has been suspended, verify your account",
+            "secure-paypal.com",
+        )
+        assert score > 0.5
+        assert brand == "paypal"
+
+    def test_lookalike_domain_subdomain_evil_flagged(self):
+        score, brand = self.engine._detect_impersonation(
+            "PayPal: confirm your identity", "paypal.com.evil.ru"
+        )
+        assert score > 0.5
+        assert brand == "paypal"
+
+    def test_lookalike_domain_paypal_support_flagged(self):
+        score, brand = self.engine._detect_impersonation(
+            "PayPal support: update your account information", "paypal-support.io"
+        )
+        assert score > 0.5
+        assert brand == "paypal"
+
+    def test_lookalike_apple_id_verify_flagged_with_cue(self):
+        score, brand = self.engine._detect_impersonation(
+            "Apple ID: verify your account, unusual activity detected",
+            "apple-id-verify.ru",
+        )
+        assert score > 0.5
         assert brand == "apple"
+
+    # ── H2: legit first-party product domains must NOT be flagged ─────────
+    def test_legit_first_party_gmail(self):
+        score, brand = self.engine._detect_impersonation(
+            "Your Gmail security settings were updated", "gmail.com"
+        )
+        assert score == 0.0
+        assert brand is None
+
+    def test_legit_first_party_icloud(self):
+        score, brand = self.engine._detect_impersonation(
+            "Your iCloud storage is almost full", "icloud.com"
+        )
+        assert score == 0.0
+        assert brand is None
+
+    def test_legit_first_party_outlook(self):
+        score, brand = self.engine._detect_impersonation(
+            "Your Outlook inbox summary", "outlook.com"
+        )
+        assert score == 0.0
+        assert brand is None
+
+    def test_legit_first_party_onedrive_subdomain(self):
+        score, brand = self.engine._detect_impersonation(
+            "Your OneDrive files are shared", "onedrive.live.com"
+        )
+        assert score == 0.0
+        assert brand is None
+
+    def test_legit_first_party_office365_subdomain(self):
+        score, brand = self.engine._detect_impersonation(
+            "Your Office 365 subscription", "outlook.office365.com"
+        )
+        assert score == 0.0
+        assert brand is None
+
+    # ── H3: ambiguous dictionary-word brands gated on cues ────────────────
+    def test_ambiguous_word_chase_no_cue_low(self):
+        # "chase up the invoice" is ordinary English, benign sender, no cue.
+        score, brand = self.engine._detect_impersonation(
+            "I will chase up the invoice tomorrow", "mycompany.com"
+        )
+        assert score <= 0.2
+
+    def test_ambiguous_word_ups_no_cue_low(self):
+        score, brand = self.engine._detect_impersonation(
+            "The back-ups are ready for review", "internal.corp.com"
+        )
+        assert score <= 0.2
+
+    def test_ambiguous_word_chase_with_cue_high(self):
+        score, brand = self.engine._detect_impersonation(
+            "Chase: verify your account, unusual activity detected",
+            "phish.example.com",
+        )
+        assert score >= 0.9
+        assert brand == "chase"
+
+    # ── L1: None-safety must not crash ────────────────────────────────────
+    def test_none_text_and_domain_safe(self):
+        score, brand = self.engine._detect_impersonation(None, None)
+        assert score == 0.0
+        assert brand is None
+
+    def test_deception_none_safe(self):
+        assert self.engine._compute_deception(None) == 0.0
 
     def test_longest_brand_phrase_wins(self):
         score, brand = self.engine._detect_impersonation(

--- a/services/svc-06-nlp/nlp/text_preprocess.py
+++ b/services/svc-06-nlp/nlp/text_preprocess.py
@@ -150,6 +150,25 @@ def preprocess_email(subject: str, body_plain: str, body_html: str = "") -> tupl
     return _INPUT_FORMAT.format(subject=subj, body=body), obfuscation
 
 
+def normalize_keep_urls(subject: str, body_plain: str, body_html: str = "") -> str:
+    """
+    Normalized subject+body that KEEPS URLs and email addresses.
+
+    Same normalization as preprocess_email (homoglyph/leet/zero-width/whitespace
+    folding) but WITHOUT the URL/email stripping step, so a brand that appears
+    only inside a link ("http://paypal.com/login") is still visible. Used ONLY by
+    the heuristic brand-impersonation keyword scan — the ML model is always fed
+    the URL-stripped preprocess_email() text, so there is no train/serve skew.
+    """
+    subject = subject or ""
+    body_plain = body_plain or ""
+    if not body_plain.strip() and body_html:
+        body_plain = strip_html(body_html)
+    subj = normalize(subject)
+    body = normalize(body_plain)
+    return _INPUT_FORMAT.format(subject=subj, body=body)
+
+
 def preprocess_composed(text: str) -> str:
     """
     Re-run an already-composed 'Subject: .. Body: ..' string through the same

--- a/services/svc-07-aggregator/internal/aggregator/aggregator_test.go
+++ b/services/svc-07-aggregator/internal/aggregator/aggregator_test.go
@@ -363,6 +363,72 @@ func TestPackager_FlatHeaderShapeForwardedRaw(t *testing.T) {
 	assert.JSONEq(t, string(headerBody), string(out.ComponentDetails.Header))
 }
 
+// A fail-soft NLP score (details.fallback=true, the neutral 50 svc-06 emits on
+// a model timeout) must be COUNTED (score present, analysis not partial) but
+// flagged in DegradedComponents so the best-effort nature is visible.
+func TestPackager_FallbackScoreMarkedDegraded(t *testing.T) {
+	t.Parallel()
+
+	nlpBody, err := json.Marshal(contracts.ScoreEnvelope{ //nolint:staticcheck // G13: sanctioned legacy ScoreEnvelope test producer.
+		Meta:      contracts.NewMeta("e1", 1),
+		Component: contracts.ComponentNLP,
+		Score:     50,
+		Details:   map[string]interface{}{"fallback": true, "fallback_reason": "nlp_predict_timeout"},
+	})
+	require.NoError(t, err)
+
+	planBody, err := json.Marshal(contracts.AnalysisPlan{
+		ExpectedScores: []string{contracts.TopicScoresNLP},
+	})
+	require.NoError(t, err)
+
+	ft := testPartitionFetchedAt(t).UTC().Format(startedLayout)
+	state := map[string]string{
+		fieldPartitionFetchedAt:  ft,
+		fieldPlan:                string(planBody),
+		fieldOrgID:               "1",
+		fieldStartedAt:           time.Now().UTC().Format(startedLayout),
+		contracts.TopicScoresNLP: string(nlpBody),
+	}
+	out, err := packageState("e1", 1, state, time.Now().UTC(), false)
+	require.NoError(t, err)
+	require.NotNil(t, out.NLPScore)
+	assert.Equal(t, 50, *out.NLPScore)
+	assert.False(t, out.PartialAnalysis, "a present fallback score is not a partial analysis")
+	assert.Empty(t, out.MissingComponents)
+	assert.Equal(t, []string{contracts.TopicScoresNLP}, out.DegradedComponents)
+}
+
+// A normal (non-fallback) score must NOT be flagged degraded.
+func TestPackager_NormalScoreNotDegraded(t *testing.T) {
+	t.Parallel()
+
+	nlpBody, err := json.Marshal(contracts.ScoreEnvelope{ //nolint:staticcheck // G13: sanctioned legacy ScoreEnvelope test producer.
+		Meta:      contracts.NewMeta("e1", 1),
+		Component: contracts.ComponentNLP,
+		Score:     72,
+		Details:   map[string]interface{}{"classification": "phishing"},
+	})
+	require.NoError(t, err)
+
+	planBody, err := json.Marshal(contracts.AnalysisPlan{
+		ExpectedScores: []string{contracts.TopicScoresNLP},
+	})
+	require.NoError(t, err)
+
+	ft := testPartitionFetchedAt(t).UTC().Format(startedLayout)
+	state := map[string]string{
+		fieldPartitionFetchedAt:  ft,
+		fieldPlan:                string(planBody),
+		fieldOrgID:               "1",
+		fieldStartedAt:           time.Now().UTC().Format(startedLayout),
+		contracts.TopicScoresNLP: string(nlpBody),
+	}
+	out, err := packageState("e1", 1, state, time.Now().UTC(), false)
+	require.NoError(t, err)
+	assert.Empty(t, out.DegradedComponents)
+}
+
 // emails.scored must carry the DB-assigned internal_id forwarded from
 // scores.header (svc-02 -> analysis.headers -> svc-04), NOT email_id — so SVC-08
 // updates the parser-owned row. email_id is a UUIDv7 string and can NOT

--- a/services/svc-07-aggregator/internal/aggregator/packager.go
+++ b/services/svc-07-aggregator/internal/aggregator/packager.go
@@ -77,6 +77,7 @@ func packageState(
 	}
 
 	missing := []string{}
+	degraded := []string{}
 	for _, expected := range plan.ExpectedScores {
 		raw, ok := state[expected]
 		if !ok {
@@ -102,6 +103,12 @@ func packageState(
 			out.NLPScore = &s
 			out.ComponentDetails.NLP = json.RawMessage(raw)
 		}
+		// A present-but-fail-soft score (e.g. svc-06's neutral 50 after a model
+		// timeout) is flagged degraded so the score is still counted but the
+		// best-effort nature is visible downstream.
+		if isFallbackScore([]byte(raw)) {
+			degraded = append(degraded, expected)
+		}
 	}
 
 	if len(missing) > 0 {
@@ -109,7 +116,28 @@ func packageState(
 		out.MissingComponents = missing
 		out.PartialAnalysis = true
 	}
+	if len(degraded) > 0 {
+		sort.Strings(degraded)
+		out.DegradedComponents = degraded
+	}
 	return out, nil
+}
+
+// isFallbackScore reports whether a component's score envelope was produced on
+// a fail-soft fallback path, signalled by details.fallback == true.
+func isFallbackScore(raw []byte) bool {
+	if len(raw) == 0 {
+		return false
+	}
+	var env struct {
+		Details struct {
+			Fallback bool `json:"fallback"`
+		} `json:"details"`
+	}
+	if err := json.Unmarshal(raw, &env); err != nil {
+		return false
+	}
+	return env.Details.Fallback
 }
 
 // completionStatus determines whether the gathered state is sufficient

--- a/shared/contracts/kafka/emails.go
+++ b/shared/contracts/kafka/emails.go
@@ -83,8 +83,16 @@ type EmailsScored struct {
 	AttachmentScore *int `json:"attachment_score,omitempty"`
 	NLPScore        *int `json:"nlp_score,omitempty"`
 
-	PartialAnalysis      bool     `json:"partial_analysis"`
-	MissingComponents    []string `json:"missing_components,omitempty"`
+	PartialAnalysis   bool     `json:"partial_analysis"`
+	MissingComponents []string `json:"missing_components,omitempty"`
+	// DegradedComponents lists components that DID produce a score but on a
+	// fail-soft fallback path (e.g. svc-06 emitting the neutral content score
+	// of 50 after the model timed out). Unlike MissingComponents these scores
+	// are present, so PartialAnalysis is not forced — but downstream consumers
+	// and operators can see the score is a degraded best-effort rather than a
+	// real model output. Populated from each component's
+	// component_details.<x>.details.fallback flag.
+	DegradedComponents   []string `json:"degraded_components,omitempty"`
 	TimeoutTriggered     bool     `json:"timeout_triggered,omitempty"`
 	AggregationLatencyMS int64    `json:"aggregation_latency_ms,omitempty"`
 


### PR DESCRIPTION
## Summary

Adds the application layer on top of the v2 generalization-hardened NLP model
(merged in #205): structured facets, a 5-label intent signal, brand-impersonation
/ deception heuristics, and a timeout fail-soft so a slow NLP predict can't wedge
a Kafka partition. Builds directly on `24ef221` (the v2 model that's live on main —
svc-06's model bytes are unchanged here), so it rebases onto main as a clean
fast-forward of the svc-06 service code.

## What's in it

- **Structured facets on `scores.nlp`** — svc-06 now emits `facets{}` and
  `model_versions{}` alongside the content score, surfacing heuristic
  brand-impersonation and deception signals to downstream consumers.
- **5-label intent** — the NLP output carries an intent classification in
  addition to the binary phishing probability.
- **Brand-impersonation + deception heuristics** (Python side), with correctness
  fixes for the brand-impersonation matcher.
- **Timeout fail-soft** — on an NLP predict timeout the pipeline emits a neutral
  `score=50` fallback instead of stalling the partition, and distinguishes
  `nlp_predict_timeout` from `nlp_predict_failed` in the fallback reason.

## Validation

`go build`/`go vet` green; svc-06 unit tests pass (incl. the new facet/intent and
timeout-fallback coverage in `main_test.go` and `test_inference.py`).

## Notes

- No model change — `metrics.json`/ONNX are byte-identical to main's v2 model;
  this PR is purely the svc-06 service + Python inference glue.