### PR TITLE
svc-06: score content risk as overall maliciousness (spam + phishing) — fixes whole-system recall

### DIFF
--- a/services/svc-06-nlp/internal/nlp/client.go
+++ b/services/svc-06-nlp/internal/nlp/client.go
@@ -39,16 +39,17 @@ type TokenScore struct {
 // PredictResponse mirrors the Python PredictResponse model (spec §8.3).
 //
 // The v2 model has a live 3-class head (legitimate / spam / phishing) and
-// classification can be any of the three. ContentRiskScore = round(P(phishing)
-// * 100): spam is a distinct, non-threat class and does NOT inflate the risk
-// score (the v1 spam+phishing collapse is retired). URL reputation is scored
-// separately by SVC-03 and combined at the aggregator.
+// classification can be any of the three. Scoring (v3): ContentRiskScore =
+// round((1 - P(legitimate)) * 100) = overall maliciousness (spam + phishing).
+// Spam / advance-fee scams ARE threats and contribute to the risk; the label
+// still distinguishes phishing vs spam. URL reputation is scored separately by
+// SVC-03 and combined at the aggregator.
 type PredictResponse struct {
 	Classification      string       `json:"classification"`       // "phishing" | "spam" | "legitimate"
 	Confidence          float64      `json:"confidence"`           // 0.0 – 1.0
 	PhishingProbability float64      `json:"phishing_probability"` // 0.0 – 1.0  P(phishing) alone
-	SpamProbability     float64      `json:"spam_probability"`     // 0.0 – 1.0  P(spam); not a threat
-	ContentRiskScore    int          `json:"content_risk_score"`   // 0 – 100  = round(P(phishing)*100)
+	SpamProbability     float64      `json:"spam_probability"`     // 0.0 – 1.0  P(spam); now counts toward risk
+	ContentRiskScore    int          `json:"content_risk_score"`   // 0 – 100  = round((1 - P(legit))*100)
 	IntentLabels        []string     `json:"intent_labels"`
 	UrgencyScore        float64      `json:"urgency_score"` // 0.0 – 1.0
 	ObfuscationDetected bool         `json:"obfuscation_detected"`

--- a/services/svc-06-nlp/nlp/app.py
+++ b/services/svc-06-nlp/nlp/app.py
@@ -73,9 +73,10 @@ app = FastAPI(
         "SVC-06 — email text classifier (legitimate / spam / phishing). "
         "Backbone: distilbert-base-uncased (fp32 ONNX). Spec: NLP-SPEC-v2.0 "
         "(cycle-12, generalization-hardened). "
-        "Scoring: content_risk_score = round(P(phishing) * 100). Spam is a "
-        "distinct, non-threat class and does NOT inflate the risk score (the v1 "
-        "spam+phishing collapse is retired now that the phishing class is live). "
+        "Scoring (v3): content_risk_score = round((1 - P(legitimate)) * 100) = "
+        "overall maliciousness (spam + phishing). Spam / advance-fee scams ARE "
+        "threats and contribute to the risk; the 3-class label still "
+        "distinguishes phishing vs spam vs legitimate. "
         "URLs are stripped before tokenization — their reputation is scored "
         "separately by SVC-03 and combined at the aggregator."
     ),
@@ -106,8 +107,8 @@ class PredictResponse(BaseModel):
     classification: str          # "phishing" | "spam" | "legitimate"
     confidence: float            # 0.0 – 1.0
     phishing_probability: float  # 0.0 – 1.0  P(phishing) alone
-    spam_probability: float      # 0.0 – 1.0  P(spam); spam is NOT a threat
-    content_risk_score: int      # 0 – 100  = round(P(phishing) * 100); feeds emails.content_risk_score
+    spam_probability: float      # 0.0 – 1.0  P(spam); now counts toward risk
+    content_risk_score: int      # 0 – 100  = round((1 - P(legit)) * 100); feeds emails.content_risk_score
     intent_labels: list[str]     # e.g. ["credential_harvest", "urgency_threat"]
     urgency_score: float         # 0.0 – 1.0
     obfuscation_detected: bool

--- a/services/svc-06-nlp/nlp/inference.py
+++ b/services/svc-06-nlp/nlp/inference.py
@@ -12,9 +12,11 @@ Expected artifacts (relative to service root):
     tokenizer/             HuggingFace DistilBertTokenizerFast files
     config.json            Thresholds (T, phish_threshold), label map, intent taxonomy
 
-Scoring (v2): content_risk_score = round(P(phishing) * 100). Spam is a distinct,
-NON-threat class and never inflates the risk score. URLs are stripped before
-tokenization — their reputation is SVC-03's job (combined at the aggregator).
+Scoring (v3): content_risk_score = round((1 - P(legitimate)) * 100), i.e. overall
+maliciousness (spam + phishing). Spam / advance-fee scams ARE threats and DO
+contribute to the risk; the 3-class label still distinguishes phishing vs spam vs
+legitimate. URLs are stripped before tokenization — their reputation is SVC-03's
+job (combined at the aggregator).
 ALL preprocessing is delegated to the canonical text_preprocess.preprocess_email
 so the serving path is byte-identical to training (no train/serve skew).
 
@@ -861,15 +863,17 @@ class NLPInferenceEngine:
         spam_prob = float(probs[1])
         phish_prob = float(probs[2])
 
-        # 5. Scoring scheme (v2): spam != threat. The CONTENT RISK is the
-        #    phishing probability ALONE — spam is inbox noise, not a phishing/
-        #    malware threat, so it must not inflate the risk score. (The old
-        #    checkpoint collapsed spam+phish into the risk because its phishing
-        #    class was dead; the v2 model has a live phishing class, so the
-        #    collapse is retired.) URL maliciousness is scored separately by
-        #    SVC-03 and combined at the aggregator.
+        # 5. Scoring scheme (v3): content risk = overall maliciousness, i.e.
+        #    1 - P(legitimate) = P(spam) + P(phishing). Spam and advance-fee
+        #    scams ARE threats for this deployment, so they must contribute to the
+        #    risk fed to the aggregator. The v2 scheme scored P(phishing) ALONE,
+        #    which left high-confidence spam/scam at ~0 content_risk and let it
+        #    pass fusion as benign — the dominant whole-system recall leak. The
+        #    3-class label below still distinguishes phishing vs spam vs
+        #    legitimate (so callers that only care about phishing can read the
+        #    label / phishing_probability); only the numeric risk broadens.
         phish_prob_rounded = round(phish_prob, 4)
-        content_risk_score = round(phish_prob_rounded * 100)
+        content_risk_score = round((1.0 - leg_prob) * 100)
 
         # 6. Label: phishing if P(phish) clears the tuned operating point
         #    (phish_threshold, fitted for recall target at min FPR); otherwise

--- a/services/svc-06-nlp/nlp/test_inference.py
+++ b/services/svc-06-nlp/nlp/test_inference.py
@@ -10,9 +10,10 @@ v2 notes:
     train/serve skew). Preprocessing tests exercise that module directly,
     including the adversarial canonicalization defenses (homoglyph / leet /
     letter-spacing folding).
-  - Scoring: content_risk_score = round(P(phishing) * 100). Spam is a distinct,
-    NON-threat class — it does NOT collapse into phishing and does NOT inflate
-    the risk score.
+  - Scoring (v3): content_risk_score = round((1 - P(legit)) * 100) = overall
+    maliciousness (spam + phishing). Spam keeps its own label but now counts
+    toward the risk score (phishing vs spam is still distinguishable via the
+    label / phishing_probability).
 
 Run:
     cd services/svc-06-nlp/nlp
@@ -366,14 +367,16 @@ class TestPredict:
         assert result["phishing_probability"] > 0.8
         assert result["confidence"] == result["phishing_probability"]
 
-    def test_spam_is_distinct_and_not_a_threat(self):
-        # v2: spam is its OWN class (not collapsed into phishing) and its
-        # content_risk_score stays low because risk = P(phishing) alone.
+    def test_spam_counts_toward_risk(self):
+        # v3: spam is still its OWN class (the label is distinct from phishing),
+        # but it IS a threat, so a high-confidence spam email yields an elevated
+        # content_risk_score (it was ~0 under the v2 P(phishing)-only scheme,
+        # which let spam/scam pass fusion as benign).
         engine = _engine_with_logits([0.0, 5.0, 0.0])
         result = engine.predict("Special offer", "Limited time discount unsubscribe")
         assert result["classification"] == "spam"
         assert result["spam_probability"] > 0.9
-        assert result["content_risk_score"] < 50
+        assert result["content_risk_score"] > 50
 
     def test_legitimate_classification(self):
         engine = _engine_with_logits([5.0, 0.0, 0.0])
@@ -386,9 +389,12 @@ class TestPredict:
         assert 0 <= result["content_risk_score"] <= 100
 
     def test_content_risk_score_formula(self):
-        engine = _engine_with_logits([0.0, 0.0, 10.0])
+        # v3: content_risk = round((1 - P(legit)) * 100) = round((P(spam)+P(phish))*100).
+        engine = _engine_with_logits([0.0, 4.0, 2.0])  # mixed spam+phish, low legit
         result = engine.predict("s", "b")
-        assert result["content_risk_score"] == round(result["phishing_probability"] * 100)
+        malicious = result["spam_probability"] + result["phishing_probability"]
+        assert abs(result["content_risk_score"] - round(malicious * 100)) <= 1
+        assert result["content_risk_score"] > 50
 
     def test_top_tokens_always_empty(self):
         engine = _engine_with_logits([2.0, 1.0, 0.0])


### PR DESCRIPTION
## Summary

Whole-pipeline recall was collapsing even though the NLP classifier is accurate:
on a ~1,000-email benchmark the fused system passed almost every threat through
as benign (binary recall ≈ 0.10), with `phishing→benign`, `spam→benign`,
`suspicious→benign` dominating the confusion matrix.

Root cause: `content_risk_score` was `round(P(phishing) * 100)` — the v2 "spam is
inbox noise, not a threat" scheme (`services/svc-06-nlp/nlp/inference.py`). The
model correctly tags spam/advance-fee scams as `spam`@~0.99 with a
`credential_harvesting` intent, but those emails get `P(phishing)≈0`, so their
`content_risk_score` was ~0 and the signal never reached the aggregator. The
strongest component the system has contributed nothing for the bulk of the
threat corpus.

## Change

Score content risk as overall maliciousness:

```
content_risk_score = round((1 - P(legitimate)) * 100)   # = P(spam) + P(phishing)
```

- Spam / advance-fee scams now contribute to the fused risk (they are threats
  for this deployment).
- The 3-class label and `phishing_probability` are unchanged, so anything that
  only cares about phishing can still read those.
- Benign mail stays low (`1 - P(legit) ≈ 0`); the only cost is when the model
  mis-reads benign mail as spam (benign classification is ~98% on the benchmark,
  so the FPR impact is small).
- URL reputation is still scored separately by SVC-03 and combined at the
  aggregator — unchanged.

Verified live: a high-confidence spam email now returns `content_risk_score=100`
(was ~0).

## Before / after (whole system, identical 1,011-email sample; SVC-03 PR #211 also active)

| metric | v2: content = P(phishing) | v3: content = 1 − P(legit) |
|---|---|---|
| binary precision | 0.83 | **0.96** |
| binary recall | **0.10** | **0.89** |
| binary F1 | 0.19 | **0.92** |
| benign FPR | 0.022 | 0.060 |
| phishing recall | 0.13 | **0.97** |
| spam recall | 0.08 | **0.97** |
| suspicious recall | 0.00 | 0.50 |
| benign recall | 0.98 | 0.94 |

Recall jumps 0.10 → 0.89 and F1 0.19 → 0.92; precision actually rises (the NLP
signal now lands as true positives instead of being discarded). The benign FPR
rises 2% → 6% — the deliberate tradeoff — and most of that is pre-existing TI/URL
noise, with only ~5 of the 24 benign false positives newly content-driven.

## Tests
- `services/svc-06-nlp/nlp/test_inference.py` updated (spam now contributes to
  risk; formula = maliciousness) — **108 pass**.
- `go build` / `go test` / `golangci-lint` on `services/svc-06-nlp/...` — green.
