### PR TITLE
fix(svc-06): score content_risk as P(phishing), not maliciousness

### DIFF
--- a/services/svc-06-nlp/nlp/inference.py
+++ b/services/svc-06-nlp/nlp/inference.py
@@ -12,11 +12,13 @@ Expected artifacts (relative to service root):
     tokenizer/             HuggingFace DistilBertTokenizerFast files
     config.json            Thresholds (T, phish_threshold), label map, intent taxonomy
 
-Scoring (v3): content_risk_score = round((1 - P(legitimate)) * 100), i.e. overall
-maliciousness (spam + phishing). Spam / advance-fee scams ARE threats and DO
-contribute to the risk; the 3-class label still distinguishes phishing vs spam vs
-legitimate. URLs are stripped before tokenization — their reputation is SVC-03's
-job (combined at the aggregator).
+Scoring (v4): content_risk_score = round(P(phishing) * 100). SVC-08 detects phishing,
+so the numeric risk is phishing-specific; benign marketing spam scores ~0 (it must not
+pollute the score the aggregator fuses), while advance-fee scams are phishing-labelled
+and stay high. The 3-class label and spam_probability still distinguish phishing vs spam
+vs legitimate. (v3 scored maliciousness = 1 - P(legit), which flagged real spam as
+phishing — see PR #215.) URLs are stripped before tokenization — their reputation is
+SVC-03's job (combined at the aggregator).
 ALL preprocessing is delegated to the canonical text_preprocess.preprocess_email
 so the serving path is byte-identical to training (no train/serve skew).
 
@@ -882,17 +884,21 @@ class NLPInferenceEngine:
         spam_prob = float(probs[1])
         phish_prob = float(probs[2])
 
-        # 5. Scoring scheme (v3): content risk = overall maliciousness, i.e.
-        #    1 - P(legitimate) = P(spam) + P(phishing). Spam and advance-fee
-        #    scams ARE threats for this deployment, so they must contribute to the
-        #    risk fed to the aggregator. The v2 scheme scored P(phishing) ALONE,
-        #    which left high-confidence spam/scam at ~0 content_risk and let it
-        #    pass fusion as benign — the dominant whole-system recall leak. The
-        #    3-class label below still distinguishes phishing vs spam vs
-        #    legitimate (so callers that only care about phishing can read the
-        #    label / phishing_probability); only the numeric risk broadens.
+        # 5. Scoring scheme (v4): content risk = P(phishing). SVC-08 detects PHISHING
+        #    (the verdict pipeline has no automated spam label), so the numeric risk it
+        #    fuses must be phishing-specific. The v3 scheme scored maliciousness
+        #    (1 - P(legit) = P(spam) + P(phishing)); on the corrected fp32 model that
+        #    fires on real spam (median content_risk 99), so the aggregator flagged
+        #    ~94% of held-out real spam as phishing — the system's verdicts then had
+        #    far lower precision than the NLP phishing head alone ("the individual
+        #    model beats the whole"). Advance-fee / 419 SCAMS are labelled *phishing*
+        #    and score high under P(phishing), so they stay caught; only benign
+        #    marketing spam drops to ~0, which is correct (it is not a phishing threat).
+        #    Independently validated by the leakage-safe fusion search (PR #215, FINDINGS
+        #    §3a "drop content_risk / use phishing_probability"). The 3-class label and
+        #    spam_probability below are unchanged, so callers wanting a spam signal keep it.
         phish_prob_rounded = round(phish_prob, 4)
-        content_risk_score = round((1.0 - leg_prob) * 100)
+        content_risk_score = round(phish_prob * 100)
 
         # 6. Label: phishing if P(phish) clears the tuned operating point
         #    (phish_threshold, fitted for recall target at min FPR); otherwise

--- a/services/svc-06-nlp/nlp/test_inference.py
+++ b/services/svc-06-nlp/nlp/test_inference.py
@@ -10,10 +10,10 @@ v2 notes:
     train/serve skew). Preprocessing tests exercise that module directly,
     including the adversarial canonicalization defenses (homoglyph / leet /
     letter-spacing folding).
-  - Scoring (v3): content_risk_score = round((1 - P(legit)) * 100) = overall
-    maliciousness (spam + phishing). Spam keeps its own label but now counts
-    toward the risk score (phishing vs spam is still distinguishable via the
-    label / phishing_probability).
+  - Scoring (v4): content_risk_score = round(P(phishing) * 100). Benign spam scores
+    low (not a phishing threat); scams are phishing-labelled and stay high. Spam vs
+    phishing is still distinguishable via the label / spam_probability. (v3 scored
+    maliciousness = 1 - P(legit), which flagged real spam as phishing; see PR #215.)
 
 Run:
     cd services/svc-06-nlp/nlp
@@ -367,16 +367,16 @@ class TestPredict:
         assert result["phishing_probability"] > 0.8
         assert result["confidence"] == result["phishing_probability"]
 
-    def test_spam_counts_toward_risk(self):
-        # v3: spam is still its OWN class (the label is distinct from phishing),
-        # but it IS a threat, so a high-confidence spam email yields an elevated
-        # content_risk_score (it was ~0 under the v2 P(phishing)-only scheme,
-        # which let spam/scam pass fusion as benign).
+    def test_spam_low_phishing_risk(self):
+        # v4: content_risk = P(phishing). Benign marketing spam keeps its own (spam)
+        # label but is NOT a phishing threat, so its content_risk is LOW — it must not
+        # pollute the phishing-detection score the aggregator fuses (the v3 maliciousness
+        # scheme scored it ~99, which flagged real spam as phishing; see PR #215).
         engine = _engine_with_logits([0.0, 5.0, 0.0])
         result = engine.predict("Special offer", "Limited time discount unsubscribe")
         assert result["classification"] == "spam"
         assert result["spam_probability"] > 0.9
-        assert result["content_risk_score"] > 50
+        assert result["content_risk_score"] < 50
 
     def test_legitimate_classification(self):
         engine = _engine_with_logits([5.0, 0.0, 0.0])
@@ -389,11 +389,10 @@ class TestPredict:
         assert 0 <= result["content_risk_score"] <= 100
 
     def test_content_risk_score_formula(self):
-        # v3: content_risk = round((1 - P(legit)) * 100) = round((P(spam)+P(phish))*100).
-        engine = _engine_with_logits([0.0, 4.0, 2.0])  # mixed spam+phish, low legit
+        # v4: content_risk = round(P(phishing) * 100).
+        engine = _engine_with_logits([0.0, 2.0, 4.0])  # phishing-dominant
         result = engine.predict("s", "b")
-        malicious = result["spam_probability"] + result["phishing_probability"]
-        assert abs(result["content_risk_score"] - round(malicious * 100)) <= 1
+        assert abs(result["content_risk_score"] - round(result["phishing_probability"] * 100)) <= 1
         assert result["content_risk_score"] > 50
 
     def test_top_tokens_always_empty(self):


### PR DESCRIPTION
## The problem: the whole system was worse than its strongest part

"Why do the individual models beat the verdict?" — three causes, **two already merged**:

1. svc-06 shipped a **dangling-symlink / stale model** → fallback for every email (#216, merged).
2. svc-03 lexical url **over-flagged** → diluted the blend (#211 corroboration cap, merged).
3. **This PR:** `content_risk = maliciousness` = `1 − P(legit)` = `P(spam) + P(phishing)`.

On the corrected fp32 model, the maliciousness score fires on **real spam** (median ~99), so the aggregator flags spam as phishing. The deployed system then runs at **precision 70% / spam-flag 55%**, while the NLP **phishing head alone** is **88% / 5%** — fusing the maliciousness score makes the whole *worse* than its best part. That is the "individual model beats the system" effect, and #216/#211 alone don't remove it.

## The fix

`content_risk_score = round(P(phishing) * 100)`. Phishing-labelled scams (advance-fee / 419) still score high and stay caught; benign marketing spam drops to ~0 (correct — it isn't a phishing threat). The 3-class label and `spam_probability` are unchanged, so any caller wanting a spam signal keeps it. This reverts the v3 scoring (`b9f8c6d`).

## Verification (10k benchmark; deployed weighted-average fusion; production-capped url; op point = 1% legit-FPR)

| content scheme | recall | spam-flagged | precision |
|---|---|---|---|
| maliciousness (current main) | 92.6% | **55%** | **70%** |
| **P(phishing) — this PR** | 92.5% | **7%** | **88%** |
| NLP-alone (phishing head) | 84.5% | 5% | 88% |

With this fix the whole system (**92.5% / 88%**) finally **beats its strongest part** (84.5% / 88%) on recall while matching precision and nearly matching spam-flag. The header + url channels add the header-spoof / typosquat phishing NLP can't see, which is what lifts recall above NLP-alone once the content channel stops polluting.

Independently corroborated by the merged leakage-safe fusion search (**PR #215**, FINDINGS §3a: "drop `content_risk` / use the phishing head" — `content_risk` flags ~94% of held-out real spam). 108 svc-06 unit tests pass.

> Note: this is the minimal, complete fix **given #216 and #211 are merged**. No svc-08 change is needed — the deployed weighted-average fusion already clears NLP-alone once the url is corroboration-capped (#211) and the content score is phishing-specific (this PR). A calibrated-OR fusion is a separate, optional +recall refinement, not required to make whole ≥ parts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)