### PR TITLE
feat(svc-08): calibrated-OR fusion on P(phishing), re-fit on the corrected model

### DIFF
--- a/services/svc-06-nlp/nlp/inference.py
+++ b/services/svc-06-nlp/nlp/inference.py
@@ -12,11 +12,15 @@ Expected artifacts (relative to service root):
     tokenizer/             HuggingFace DistilBertTokenizerFast files
     config.json            Thresholds (T, phish_threshold), label map, intent taxonomy
 
-Scoring (v3): content_risk_score = round((1 - P(legitimate)) * 100), i.e. overall
-maliciousness (spam + phishing). Spam / advance-fee scams ARE threats and DO
-contribute to the risk; the 3-class label still distinguishes phishing vs spam vs
-legitimate. URLs are stripped before tokenization — their reputation is SVC-03's
-job (combined at the aggregator).
+Scoring (v4): content_risk_score = round(P(phishing) * 100). SVC-08 detects phishing,
+so the numeric risk must be phishing-specific. v3 used maliciousness (1 - P(legitimate)
+= P(spam) + P(phishing)); that conflates benign marketing spam with threats and is the
+dominant View-A false-positive source on real traffic (see benchmark/FINDINGS.md).
+Advance-fee / 419 scams are *phishing*-labelled, so they stay high under P(phishing);
+only benign marketing spam drops to ~0 (correct — it is not a phishing threat). The
+3-class label and spam_probability are unchanged, so callers wanting a spam signal keep
+it. URLs are stripped before tokenization — their reputation is SVC-03's job (combined
+at the aggregator).
 ALL preprocessing is delegated to the canonical text_preprocess.preprocess_email
 so the serving path is byte-identical to training (no train/serve skew).
 
@@ -882,17 +886,18 @@ class NLPInferenceEngine:
         spam_prob = float(probs[1])
         phish_prob = float(probs[2])
 
-        # 5. Scoring scheme (v3): content risk = overall maliciousness, i.e.
-        #    1 - P(legitimate) = P(spam) + P(phishing). Spam and advance-fee
-        #    scams ARE threats for this deployment, so they must contribute to the
-        #    risk fed to the aggregator. The v2 scheme scored P(phishing) ALONE,
-        #    which left high-confidence spam/scam at ~0 content_risk and let it
-        #    pass fusion as benign — the dominant whole-system recall leak. The
-        #    3-class label below still distinguishes phishing vs spam vs
-        #    legitimate (so callers that only care about phishing can read the
-        #    label / phishing_probability); only the numeric risk broadens.
+        # 5. Scoring scheme (v4): content risk = P(phishing). SVC-08 detects PHISHING
+        #    (the verdict pipeline has no automated spam label), so the numeric risk it
+        #    consumes must be phishing-specific. v3 scored maliciousness (1 - P(legitimate)
+        #    = P(spam) + P(phishing)) to stop advance-fee scams passing as benign, but that
+        #    conflated benign MARKETING spam with threats: on the corrected-model benchmark
+        #    (benchmark/FINDINGS.md) a maliciousness-based fusion flags ~55-94% of held-out
+        #    real spam as phishing (the dominant View-A false-positive source). Advance-fee
+        #    / 419 scams are *phishing*-labelled, so they stay high under P(phishing); only
+        #    benign marketing spam drops to ~0, which is correct. The 3-class label and
+        #    spam_probability below are unchanged, so callers wanting a spam signal keep it.
         phish_prob_rounded = round(phish_prob, 4)
-        content_risk_score = round((1.0 - leg_prob) * 100)
+        content_risk_score = round(phish_prob * 100)
 
         # 6. Label: phishing if P(phish) clears the tuned operating point
         #    (phish_threshold, fitted for recall target at min FPR); otherwise

--- a/services/svc-06-nlp/nlp/test_inference.py
+++ b/services/svc-06-nlp/nlp/test_inference.py
@@ -367,16 +367,16 @@ class TestPredict:
         assert result["phishing_probability"] > 0.8
         assert result["confidence"] == result["phishing_probability"]
 
-    def test_spam_counts_toward_risk(self):
-        # v3: spam is still its OWN class (the label is distinct from phishing),
-        # but it IS a threat, so a high-confidence spam email yields an elevated
-        # content_risk_score (it was ~0 under the v2 P(phishing)-only scheme,
-        # which let spam/scam pass fusion as benign).
+    def test_spam_low_phishing_risk(self):
+        # v4: content_risk = P(phishing). Benign marketing spam keeps its own (spam)
+        # label but is NOT a phishing threat, so its content_risk is LOW — it must not
+        # pollute the phishing-detection score fed to the aggregator. (Advance-fee SCAMS
+        # are labelled *phishing*, score high under P(phishing), and stay caught.)
         engine = _engine_with_logits([0.0, 5.0, 0.0])
         result = engine.predict("Special offer", "Limited time discount unsubscribe")
         assert result["classification"] == "spam"
         assert result["spam_probability"] > 0.9
-        assert result["content_risk_score"] > 50
+        assert result["content_risk_score"] < 50
 
     def test_legitimate_classification(self):
         engine = _engine_with_logits([5.0, 0.0, 0.0])
@@ -389,11 +389,10 @@ class TestPredict:
         assert 0 <= result["content_risk_score"] <= 100
 
     def test_content_risk_score_formula(self):
-        # v3: content_risk = round((1 - P(legit)) * 100) = round((P(spam)+P(phish))*100).
-        engine = _engine_with_logits([0.0, 4.0, 2.0])  # mixed spam+phish, low legit
+        # v4: content_risk = round(P(phishing) * 100).
+        engine = _engine_with_logits([0.0, 2.0, 4.0])  # phishing-dominant
         result = engine.predict("s", "b")
-        malicious = result["spam_probability"] + result["phishing_probability"]
-        assert abs(result["content_risk_score"] - round(malicious * 100)) <= 1
+        assert abs(result["content_risk_score"] - round(result["phishing_probability"] * 100)) <= 1
         assert result["content_risk_score"] > 50
 
     def test_top_tokens_always_empty(self):

--- a/services/svc-08-decision/internal/engine/calibrated_blender.go
+++ b/services/svc-08-decision/internal/engine/calibrated_blender.go
@@ -1,0 +1,100 @@
+package engine
+
+// Calibrated probabilistic-OR blender — the production fusion (design brief §3.4).
+//
+// Each present component's raw 0–100 score is mapped through a per-channel calibration
+// curve to a phishing/maliciousness probability p_c = calib_c(score_c); the channels
+// are combined with a probabilistic-OR and the fused raw score is passed through a
+// final calibration curve so the output is a true P(malicious)·100:
+//
+//	raw  = 100 · ( 1 − Π_present (1 − clip(calib_c(score_c), 0, cap)) )
+//	risk = 100 · final(raw)
+//
+// Why this, established on the consistent real-model base (benchmark/FINDINGS.md):
+//   - No dilution. A clean channel calibrates low and contributes a factor ≈ 1, so a
+//     single confident channel is never averaged below threshold (the weighted-average
+//     bug that dropped recall@1%FPR to 58% — below NLP alone at 72%).
+//   - Reliability is LEARNED, not hand-set. The curves come from each channel's measured
+//     P(malicious|score); the noisy lexical-URL channel calibrates to ~0 automatically
+//     (no magic 0.22). Raw OR without calibration scores 29% — calibration is essential.
+//   - Calibrated output. The final curve makes risk a real probability, so the §3.6
+//     verdict bands stay meaningful (ECE ≈ 0.005).
+//
+// Channels with no measured curve fall back to identity (p = score/100), preserving a
+// confident signal (e.g. a confirmed-malware attachment) without inventing a weight.
+//
+// URL note: the lexical/L2 URL score is NOT trusted here (it is noise on offline data
+// and unmeasurable without live enrichment). URL re-enters as an authoritative channel
+// (TI / domain-guard → reliability ≈ 1.0) once SVC-03 forwards guard_hit/ti_matched.
+
+// CalibratedORBlender implements Blender with the calibrated probabilistic-OR above.
+type CalibratedORBlender struct {
+	cal Calibration
+}
+
+// NewCalibratedORBlender builds the blender from the embedded calibration artifact.
+func NewCalibratedORBlender() *CalibratedORBlender {
+	return &CalibratedORBlender{cal: loadEmbeddedCalibration()}
+}
+
+// channelProb maps a present component score to its calibrated probability, clamped
+// to [0, cap]. A channel absent from the artifact uses identity (score/100).
+func (b *CalibratedORBlender) channelProb(name string, score int) float64 {
+	s := float64(score)
+	if s < 0 {
+		s = 0
+	} else if s > 100 {
+		s = 100
+	}
+	var p float64
+	if ch, ok := b.cal.Channels[name]; ok {
+		p = ch.curve().predict(s)
+	} else {
+		p = s / 100.0 // identity fallback for an uncalibrated channel
+	}
+	if p < 0 {
+		p = 0
+	}
+	if p > b.cal.Cap {
+		p = b.cal.Cap
+	}
+	return p
+}
+
+// Blend implements Blender.
+func (b *CalibratedORBlender) Blend(c Components) BlendResult {
+	contributions := make(map[string]float64, 4)
+	pNot := 1.0
+	present := 0
+
+	fold := func(name string, score *int) {
+		if score == nil {
+			return
+		}
+		p := b.channelProb(name, *score)
+		contributions[name] = p
+		pNot *= (1 - p)
+		present++
+	}
+	fold("url", c.URL)
+	fold("header", c.Header)
+	fold("nlp", c.NLP)
+	fold("attachment", c.Attachment)
+
+	if present == 0 {
+		return BlendResult{Score: 0, Contributions: contributions, WeightSum: 0}
+	}
+
+	raw := (1 - pNot) * 100
+	score := b.cal.Final.predict(raw) * 100
+	if score < 0 {
+		score = 0
+	} else if score > 100 {
+		score = 100
+	}
+	return BlendResult{
+		Score:         score,
+		Contributions: contributions,
+		WeightSum:     float64(present),
+	}
+}

--- a/services/svc-08-decision/internal/engine/calibrated_blender_test.go
+++ b/services/svc-08-decision/internal/engine/calibrated_blender_test.go
@@ -1,0 +1,166 @@
+package engine
+
+import (
+	_ "embed"
+	"encoding/json"
+	"math"
+	"testing"
+
+	contracts "github.com/saif/cybersiren/shared/contracts/kafka"
+)
+
+//go:embed calibration/parity_fixture_v1.json
+var parityFixtureJSON []byte
+
+type parityCase struct {
+	NLP        *float64 `json:"nlp"`
+	URL        *float64 `json:"url"`
+	Header     *float64 `json:"header"`
+	Attachment *float64 `json:"attachment"`
+	Score      float64  `json:"score"`
+}
+
+func toIptr(v *float64) *int {
+	if v == nil {
+		return nil
+	}
+	i := int(math.Round(*v))
+	return &i
+}
+
+// TestCalibratedOR_ParityWithPython is the train/serve-skew guard: the Go blender must
+// reproduce the Python reference scorer (benchmark/export_artifact.py) on every fixture
+// case to <0.5 (the fixture scores are computed from float inputs; the Go path rounds
+// the component to int first, so allow the rounding gap — bounded below).
+func TestCalibratedOR_ParityWithPython(t *testing.T) {
+	var fx struct {
+		Fixture []parityCase `json:"fixture"`
+	}
+	if err := json.Unmarshal(parityFixtureJSON, &fx); err != nil {
+		t.Fatalf("decode fixture: %v", err)
+	}
+	if len(fx.Fixture) == 0 {
+		t.Fatal("empty parity fixture")
+	}
+	b := NewCalibratedORBlender()
+	var maxDiff float64
+	for i, c := range fx.Fixture {
+		// Cases with non-integer inputs (e.g. -5, 150) exercise clamping; the Python
+		// fixture clamps the same way. Integer-valued inputs match exactly.
+		got := b.Blend(Components{
+			NLP:        toIptr(c.NLP),
+			URL:        toIptr(c.URL),
+			Header:     toIptr(c.Header),
+			Attachment: toIptr(c.Attachment),
+		}).Score
+		diff := math.Abs(got - c.Score)
+		if diff > maxDiff {
+			maxDiff = diff
+		}
+		if diff > 0.5 {
+			t.Errorf("case %d (nlp=%v url=%v header=%v att=%v): Go=%.4f Python=%.4f diff=%.4f",
+				i, c.NLP, c.URL, c.Header, c.Attachment, got, c.Score, diff)
+		}
+	}
+	t.Logf("parity over %d cases: max diff = %.5f", len(fx.Fixture), maxDiff)
+}
+
+// TestCalibratedOR_NoDilution: a confident single channel must not be averaged below
+// threshold by clean/absent companions (the weighted-average bug).
+func TestCalibratedOR_NoDilution(t *testing.T) {
+	b := NewCalibratedORBlender()
+	// text-only malicious: NLP=100, header clean present.
+	if got := b.Blend(Components{NLP: iptr(100), Header: iptr(0)}).Score; got <= 50 {
+		t.Fatalf("NLP=100 diluted by clean header: got %.1f, want > 50", got)
+	}
+	// NLP=100 alone must stay high.
+	if got := b.Blend(Components{NLP: iptr(100)}).Score; got <= 50 {
+		t.Fatalf("NLP=100 alone should fire: got %.1f", got)
+	}
+}
+
+// TestCalibratedOR_Monotonic: raising any present component never lowers the fused score
+// (the whole pipeline — per-channel calibration, OR, final calibration — is monotone).
+func TestCalibratedOR_Monotonic(t *testing.T) {
+	b := NewCalibratedORBlender()
+	prev := math.Inf(-1)
+	for s := 0; s <= 100; s += 5 {
+		got := b.Blend(Components{NLP: iptr(s), Header: iptr(20)}).Score
+		if got < prev-1e-9 {
+			t.Fatalf("non-monotonic in NLP at %d: %.4f < previous %.4f", s, got, prev)
+		}
+		prev = got
+	}
+}
+
+// TestCalibratedOR_Bounds: output always in [0,100]; out-of-range and negative inputs
+// are clamped; all-nil yields 0.
+func TestCalibratedOR_Bounds(t *testing.T) {
+	b := NewCalibratedORBlender()
+	for _, c := range []Components{
+		{}, {NLP: iptr(-50)}, {URL: iptr(1000), Header: iptr(-3), NLP: iptr(50)},
+		{NLP: iptr(100), URL: iptr(100), Header: iptr(100), Attachment: iptr(100)},
+	} {
+		got := b.Blend(c).Score
+		if got < 0 || got > 100 {
+			t.Fatalf("score out of bounds: %.4f for %+v", got, c)
+		}
+	}
+	if res := b.Blend(Components{}); res.Score != 0 || res.WeightSum != 0 {
+		t.Fatalf("all-nil: got score=%.4f weightSum=%.1f, want 0/0", res.Score, res.WeightSum)
+	}
+}
+
+// TestCalibratedOR_AttachmentIdentity: attachment has no measured curve, so it uses
+// identity — a confirmed-malware attachment (high score) must fire even alone (it must
+// NOT be crushed by a hand-set weight).
+func TestCalibratedOR_AttachmentIdentity(t *testing.T) {
+	b := NewCalibratedORBlender()
+	if got := b.Blend(Components{Attachment: iptr(95)}).Score; got <= 50 {
+		t.Fatalf("confirmed-malware attachment alone should fire: got %.1f", got)
+	}
+}
+
+// TestCalibratedOR_URLNeutral: the lexical URL channel is neutralised — a high URL
+// score ALONE must not clear threshold (it is noise until authoritative TI/guard
+// forwarding exists). A clean email with a noisy URL must stay benign.
+func TestCalibratedOR_URLNeutral(t *testing.T) {
+	b := NewCalibratedORBlender()
+	if got := b.Blend(Components{URL: iptr(100), NLP: iptr(2), Header: iptr(2)}).Score; got > 50 {
+		t.Fatalf("noisy URL on a clean email should stay benign: got %.1f", got)
+	}
+}
+
+// TestComponentsFrom_DropsDegraded: a fail-soft (degraded) score must be treated as
+// ABSENT, not fused — svc-06's neutral 50 is a moderate phishing value under the
+// P(phishing) content scoring and must not push a legit verdict during an NLP outage.
+func TestComponentsFrom_DropsDegraded(t *testing.T) {
+	nlp50 := 50
+	hdr80 := 80
+	scored := contracts.EmailsScored{
+		NLPScore:           &nlp50,
+		HeaderScore:        &hdr80,
+		DegradedComponents: []string{contracts.TopicScoresNLP},
+	}
+	c := ComponentsFrom(scored)
+	if c.NLP != nil {
+		t.Fatalf("degraded NLP should be dropped (absent), got %d", *c.NLP)
+	}
+	if c.Header == nil || *c.Header != 80 {
+		t.Fatalf("non-degraded header should pass through, got %v", c.Header)
+	}
+	// a degraded NLP-only message must blend to benign (no real signal present).
+	if got := NewCalibratedORBlender().Blend(c).Score; c.Header == nil && got > 50 {
+		t.Fatalf("degraded-only should not fire, got %.1f", got)
+	}
+}
+
+// TestParseCalibration_Rejects guards the loader against malformed artifacts.
+func TestParseCalibration_Rejects(t *testing.T) {
+	if _, err := parseCalibration([]byte(`{"channels":{"nlp":{"x":[0],"y":[]}}}`)); err == nil {
+		t.Fatal("expected error on mismatched knot lengths")
+	}
+	if _, err := parseCalibration([]byte(`{"final":{"x":[],"y":[]}}`)); err == nil {
+		t.Fatal("expected error on missing final curve")
+	}
+}

--- a/services/svc-08-decision/internal/engine/calibration.go
+++ b/services/svc-08-decision/internal/engine/calibration.go
@@ -1,0 +1,95 @@
+package engine
+
+import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+)
+
+// fusionCalibrationJSON is the versioned per-channel calibration artifact produced
+// by benchmark/export_artifact.py from the consistent real-model base. It maps each
+// channel's raw 0–100 score to a calibrated P(malicious) and a final raw→P curve.
+// See docs/design/svc-07-08-design-brief.md §3.4 and benchmark/FINDINGS.md.
+//
+//go:embed calibration/fusion_calibration_v1.json
+var fusionCalibrationJSON []byte
+
+// pieceWiseLinear is a monotone calibration curve stored as (x, y) knots. Predict
+// does np.interp-style linear interpolation, clamping outside [x0, xN] to y0 / yN —
+// byte-for-byte matching the Python reference (benchmark/export_artifact.py:interp).
+type pieceWiseLinear struct {
+	X []float64 `json:"x"`
+	Y []float64 `json:"y"`
+}
+
+func (c pieceWiseLinear) predict(x float64) float64 {
+	n := len(c.X)
+	if n == 0 {
+		return 0
+	}
+	if x <= c.X[0] {
+		return c.Y[0]
+	}
+	if x >= c.X[n-1] {
+		return c.Y[n-1]
+	}
+	for i := 1; i < n; i++ {
+		if x <= c.X[i] {
+			dx := c.X[i] - c.X[i-1]
+			if dx == 0 {
+				return c.Y[i]
+			}
+			t := (x - c.X[i-1]) / dx
+			return c.Y[i-1] + t*(c.Y[i]-c.Y[i-1])
+		}
+	}
+	return c.Y[n-1]
+}
+
+// channelCalibration is one channel's curve plus its kind (isotonic / neutral /
+// identity) — kind is informational; predict() is the same interpolation for all.
+type channelCalibration struct {
+	Kind string    `json:"kind"`
+	X    []float64 `json:"x"`
+	Y    []float64 `json:"y"`
+}
+
+func (c channelCalibration) curve() pieceWiseLinear { return pieceWiseLinear{X: c.X, Y: c.Y} }
+
+// Calibration is the parsed fusion-calibration artifact.
+type Calibration struct {
+	Version  string                        `json:"version"`
+	Cap      float64                       `json:"cap"`
+	Final    pieceWiseLinear               `json:"final"`
+	Channels map[string]channelCalibration `json:"channels"`
+}
+
+// loadEmbeddedCalibration parses the embedded artifact. It panics on a malformed
+// artifact because the binary cannot run a calibrated fusion without it — this is a
+// build-time asset, so a parse failure is a programming error, not runtime input.
+func loadEmbeddedCalibration() Calibration {
+	c, err := parseCalibration(fusionCalibrationJSON)
+	if err != nil {
+		panic(fmt.Sprintf("svc-08: embedded fusion calibration is invalid: %v", err))
+	}
+	return c
+}
+
+func parseCalibration(b []byte) (Calibration, error) {
+	var c Calibration
+	if err := json.Unmarshal(b, &c); err != nil {
+		return c, fmt.Errorf("unmarshal calibration: %w", err)
+	}
+	if c.Cap <= 0 || c.Cap >= 1 {
+		c.Cap = 0.999
+	}
+	if len(c.Final.X) == 0 {
+		return c, fmt.Errorf("calibration: missing final curve")
+	}
+	for name, ch := range c.Channels {
+		if len(ch.X) != len(ch.Y) || len(ch.X) == 0 {
+			return c, fmt.Errorf("calibration: channel %q has malformed knots", name)
+		}
+	}
+	return c, nil
+}

--- a/services/svc-08-decision/internal/engine/calibration/fusion_calibration_v1.json
+++ b/services/svc-08-decision/internal/engine/calibration/fusion_calibration_v1.json
@@ -1,0 +1,124 @@
+{
+  "version": "fusion-calibration-v1",
+  "objective": "phishing: positive = (label == phishing). Scams are phishing-labelled; benign marketing spam is negative.",
+  "method": "per-channel isotonic P(phishing|score) -> probabilistic-OR -> final isotonic",
+  "fused_formula": "raw=100*(1-prod_present(1-clip(calib_c(s_c),0,cap))); risk=100*final(raw)",
+  "interpolation": "piecewise-linear; clip outside [x0,xN] to y0/yN",
+  "trained_on": "corrected fp32 full capture (raw_rich_fp32_full.json), NLP=round(P(phishing)*100); n=10677, phish=1010",
+  "cap": 0.999,
+  "final": {
+    "kind": "isotonic",
+    "x": [
+      7.9792,
+      11.455,
+      35.7434,
+      41.4669,
+      57.1623,
+      62.6143,
+      87.2549,
+      98.1583,
+      98.5046,
+      99.9015,
+      99.9999
+    ],
+    "y": [
+      0.008464,
+      0.052632,
+      0.255102,
+      0.255102,
+      0.3125,
+      0.6,
+      0.863636,
+      0.980296,
+      0.983607,
+      1.0,
+      1.0
+    ]
+  },
+  "channels": {
+    "nlp": {
+      "kind": "isotonic",
+      "x": [
+        0.0,
+        1.0,
+        2.0,
+        3.0,
+        4.0,
+        16.0,
+        17.0,
+        36.0,
+        37.0,
+        43.0,
+        46.0,
+        57.0,
+        58.0,
+        89.0,
+        90.0,
+        99.0,
+        100.0
+      ],
+      "y": [
+        0.015443,
+        0.052632,
+        0.052632,
+        0.3125,
+        0.373737,
+        0.373737,
+        0.541667,
+        0.541667,
+        0.6,
+        0.6,
+        0.863636,
+        0.863636,
+        0.980296,
+        0.980296,
+        0.984,
+        0.984,
+        1.0
+      ],
+      "n_fit": 10677,
+      "note": "input is svc-06 v4 content_risk = round(P(phishing)*100)"
+    },
+    "header": {
+      "kind": "isotonic",
+      "x": [
+        10.0,
+        25.0,
+        60.0,
+        80.0
+      ],
+      "y": [
+        0.065358,
+        0.065358,
+        1.0,
+        1.0
+      ],
+      "n_fit": 10677
+    },
+    "url": {
+      "kind": "neutral",
+      "x": [
+        0.0,
+        100.0
+      ],
+      "y": [
+        0.0,
+        0.0
+      ],
+      "n_fit": 0,
+      "note": "NEUTRAL: composite url_score conflates authoritative(guard/TI) with lexical noise; re-enable as an authoritative curve once guard_hit/ti_matched is forwarded (follow-up)"
+    },
+    "attachment": {
+      "kind": "identity",
+      "x": [
+        0.0,
+        100.0
+      ],
+      "y": [
+        0.0,
+        1.0
+      ],
+      "n_fit": 0
+    }
+  }
+}

--- a/services/svc-08-decision/internal/engine/calibration/parity_fixture_v1.json
+++ b/services/svc-08-decision/internal/engine/calibration/parity_fixture_v1.json
@@ -1,0 +1,354 @@
+{
+  "fixture": [
+    {
+      "nlp": 100,
+      "url": null,
+      "header": null,
+      "attachment": null,
+      "score": 99.99824
+    },
+    {
+      "nlp": 95,
+      "url": null,
+      "header": null,
+      "attachment": null,
+      "score": 98.260691
+    },
+    {
+      "nlp": 3,
+      "url": 100,
+      "header": 3,
+      "attachment": null,
+      "score": 25.510169
+    },
+    {
+      "nlp": 0,
+      "url": null,
+      "header": 80,
+      "attachment": null,
+      "score": 100.0
+    },
+    {
+      "nlp": 3,
+      "url": null,
+      "header": 45,
+      "attachment": null,
+      "score": 70.535705
+    },
+    {
+      "nlp": null,
+      "url": null,
+      "header": null,
+      "attachment": 95,
+      "score": 94.650404
+    },
+    {
+      "nlp": 50,
+      "url": 50,
+      "header": 50,
+      "attachment": 50,
+      "score": 98.049644
+    },
+    {
+      "nlp": -5,
+      "url": 150,
+      "header": 50,
+      "attachment": null,
+      "score": 71.869787
+    },
+    {
+      "nlp": null,
+      "url": null,
+      "header": null,
+      "attachment": null,
+      "score": 0.0
+    },
+    {
+      "nlp": 60,
+      "url": 100,
+      "header": 10,
+      "attachment": null,
+      "score": 98.029678
+    },
+    {
+      "nlp": 0,
+      "url": null,
+      "header": 10,
+      "attachment": null,
+      "score": 0.8464
+    },
+    {
+      "nlp": 0,
+      "url": null,
+      "header": 10,
+      "attachment": null,
+      "score": 0.8464
+    },
+    {
+      "nlp": 0,
+      "url": null,
+      "header": 10,
+      "attachment": null,
+      "score": 0.8464
+    },
+    {
+      "nlp": 0,
+      "url": null,
+      "header": 10,
+      "attachment": null,
+      "score": 0.8464
+    },
+    {
+      "nlp": 0,
+      "url": null,
+      "header": 10,
+      "attachment": null,
+      "score": 0.8464
+    },
+    {
+      "nlp": 100,
+      "url": null,
+      "header": 60,
+      "attachment": null,
+      "score": 100.0
+    },
+    {
+      "nlp": 0,
+      "url": null,
+      "header": 80,
+      "attachment": null,
+      "score": 100.0
+    },
+    {
+      "nlp": 0,
+      "url": null,
+      "header": 10,
+      "attachment": null,
+      "score": 0.8464
+    },
+    {
+      "nlp": 0,
+      "url": null,
+      "header": 10,
+      "attachment": null,
+      "score": 0.8464
+    },
+    {
+      "nlp": 0,
+      "url": null,
+      "header": 10,
+      "attachment": null,
+      "score": 0.8464
+    },
+    {
+      "nlp": 0,
+      "url": null,
+      "header": 10,
+      "attachment": null,
+      "score": 0.8464
+    },
+    {
+      "nlp": 0,
+      "url": null,
+      "header": 10,
+      "attachment": null,
+      "score": 0.8464
+    },
+    {
+      "nlp": 0,
+      "url": null,
+      "header": 10,
+      "attachment": null,
+      "score": 0.8464
+    },
+    {
+      "nlp": 0,
+      "url": null,
+      "header": 10,
+      "attachment": null,
+      "score": 0.8464
+    },
+    {
+      "nlp": 0,
+      "url": null,
+      "header": 10,
+      "attachment": null,
+      "score": 0.8464
+    },
+    {
+      "nlp": 1,
+      "url": null,
+      "header": 10,
+      "attachment": null,
+      "score": 5.263206
+    },
+    {
+      "nlp": 0,
+      "url": null,
+      "header": 10,
+      "attachment": null,
+      "score": 0.8464
+    },
+    {
+      "nlp": 0,
+      "url": null,
+      "header": 25,
+      "attachment": null,
+      "score": 0.8464
+    },
+    {
+      "nlp": 0,
+      "url": null,
+      "header": 10,
+      "attachment": null,
+      "score": 0.8464
+    },
+    {
+      "nlp": 0,
+      "url": null,
+      "header": 10,
+      "attachment": null,
+      "score": 0.8464
+    },
+    {
+      "nlp": 100,
+      "url": null,
+      "header": 10,
+      "attachment": null,
+      "score": 100.0
+    },
+    {
+      "nlp": 0,
+      "url": null,
+      "header": 10,
+      "attachment": null,
+      "score": 0.8464
+    },
+    {
+      "nlp": 0,
+      "url": null,
+      "header": 10,
+      "attachment": null,
+      "score": 0.8464
+    },
+    {
+      "nlp": 0,
+      "url": null,
+      "header": 10,
+      "attachment": null,
+      "score": 0.8464
+    },
+    {
+      "nlp": 0,
+      "url": null,
+      "header": 10,
+      "attachment": null,
+      "score": 0.8464
+    },
+    {
+      "nlp": 0,
+      "url": null,
+      "header": 10,
+      "attachment": null,
+      "score": 0.8464
+    },
+    {
+      "nlp": 0,
+      "url": null,
+      "header": 10,
+      "attachment": null,
+      "score": 0.8464
+    },
+    {
+      "nlp": 46,
+      "url": null,
+      "header": 10,
+      "attachment": null,
+      "score": 86.363544
+    },
+    {
+      "nlp": 0,
+      "url": null,
+      "header": 10,
+      "attachment": null,
+      "score": 0.8464
+    },
+    {
+      "nlp": 0,
+      "url": null,
+      "header": 10,
+      "attachment": null,
+      "score": 0.8464
+    },
+    {
+      "nlp": 0,
+      "url": null,
+      "header": 25,
+      "attachment": null,
+      "score": 0.8464
+    },
+    {
+      "nlp": 0,
+      "url": null,
+      "header": 10,
+      "attachment": null,
+      "score": 0.8464
+    },
+    {
+      "nlp": 0,
+      "url": null,
+      "header": 10,
+      "attachment": null,
+      "score": 0.8464
+    },
+    {
+      "nlp": 0,
+      "url": null,
+      "header": 10,
+      "attachment": null,
+      "score": 0.8464
+    },
+    {
+      "nlp": 0,
+      "url": null,
+      "header": 10,
+      "attachment": null,
+      "score": 0.8464
+    },
+    {
+      "nlp": 0,
+      "url": null,
+      "header": 10,
+      "attachment": null,
+      "score": 0.8464
+    },
+    {
+      "nlp": 100,
+      "url": null,
+      "header": 10,
+      "attachment": null,
+      "score": 100.0
+    },
+    {
+      "nlp": 0,
+      "url": null,
+      "header": 10,
+      "attachment": null,
+      "score": 0.8464
+    },
+    {
+      "nlp": 0,
+      "url": null,
+      "header": 10,
+      "attachment": null,
+      "score": 0.8464
+    },
+    {
+      "nlp": 0,
+      "url": null,
+      "header": 10,
+      "attachment": null,
+      "score": 0.8464
+    }
+  ]
+}

--- a/services/svc-08-decision/internal/engine/engine.go
+++ b/services/svc-08-decision/internal/engine/engine.go
@@ -27,10 +27,16 @@ import (
 const (
 	// FusionWeightedAverage is the v1 weighted mean (design brief §3.4).
 	FusionWeightedAverage = "weighted_average"
-	// FusionNoisyOR is the probabilistic-OR blender (see noisyor_blender.go): never
-	// dilutes a confident channel and preserves a confirmed single-channel signal
-	// (OR-floor). Opt-in/shadow until the §3.6 bands are recalibrated for it.
+	// FusionNoisyOR is the hand-set reliability probabilistic-OR blender (see
+	// noisyor_blender.go): never dilutes a confident channel but uses hand-set
+	// reliabilities. Kept as a rollback/shadow.
 	FusionNoisyOR = "noisy_or"
+	// FusionCalibratedOR is the calibrated probabilistic-OR blender (see
+	// calibrated_blender.go): per-channel learned calibration → OR → final
+	// calibration. It is the production fusion — on the consistent real-model base
+	// it scores 83.5% recall@1%FPR (vs weighted_average 58.4%, NLP-alone 79.4%) and
+	// is well calibrated (ECE ≈ 0.005) so the §3.6 bands hold. See benchmark/FINDINGS.md.
+	FusionCalibratedOR = "calibrated_or"
 )
 
 // Config holds the runtime knobs for the decision engine.
@@ -89,11 +95,16 @@ func (c Config) Defaults() Config {
 // both here removes the duplicated, mutually-inverted selector logic.
 func buildBlenders(cfg Config) (active, other Blender) {
 	wa := NewWeightedAverageBlender(cfg.BlendWeights)
-	no := NewReliabilityNoisyORBlender(cfg.Reliabilities)
-	if cfg.FusionMode == FusionNoisyOR {
-		return no, wa
+	switch cfg.FusionMode {
+	case FusionCalibratedOR:
+		// Shadow against the current default (weighted_average) to measure the
+		// verdict-band shift before/while ramping the calibrated fusion.
+		return NewCalibratedORBlender(), wa
+	case FusionNoisyOR:
+		return NewReliabilityNoisyORBlender(cfg.Reliabilities), wa
+	default:
+		return wa, NewReliabilityNoisyORBlender(cfg.Reliabilities)
 	}
-	return wa, no
 }
 
 // Publisher is the producer for emails.verdict (subset of

--- a/services/svc-08-decision/internal/engine/snapshot.go
+++ b/services/svc-08-decision/internal/engine/snapshot.go
@@ -63,11 +63,32 @@ func BuildSnapshot(in SnapshotInputs) rules.SignalSnapshot {
 // ComponentsFrom extracts the typed Components view from an EmailsScored
 // message — the engine operates on the typed view rather than the raw
 // JSON throughout.
+//
+// A component flagged in DegradedComponents produced a score on a fail-soft
+// fallback path (e.g. svc-06's neutral content score after a model timeout). A
+// fallback is not a measurement, so it is treated as ABSENT rather than fused:
+// otherwise svc-06's neutral 50 — which under the P(phishing) content scoring is
+// a *moderate phishing* value, not a neutral one — would push a legit email's
+// verdict up during an NLP outage. Absent means the verdict relies on the other
+// channels (or stays benign), which is the correct fail-soft behaviour.
 func ComponentsFrom(s contracts.EmailsScored) Components {
-	return Components{
+	c := Components{
 		URL:        s.URLScore,
 		Header:     s.HeaderScore,
 		NLP:        s.NLPScore,
 		Attachment: s.AttachmentScore,
 	}
+	for _, d := range s.DegradedComponents {
+		switch d {
+		case contracts.TopicScoresURL:
+			c.URL = nil
+		case contracts.TopicScoresHeader:
+			c.Header = nil
+		case contracts.TopicScoresNLP:
+			c.NLP = nil
+		case contracts.TopicScoresAttachment:
+			c.Attachment = nil
+		}
+	}
+	return c
 }

--- a/shared/config/config.go
+++ b/shared/config/config.go
@@ -58,8 +58,9 @@ type Config struct {
 // Set via env (e.g. CYBERSIREN_DECISION__FUSION_MODE=noisy_or) or config.yaml
 // (decision.fusion_mode). See docs/design/svc-07-08-design-brief.md §3.4/§3.6.
 type DecisionConfig struct {
-	// FusionMode selects the blender: "weighted_average" (default, v1) or
-	// "noisy_or" (probabilistic OR, opt-in until §3.6 bands are recalibrated).
+	// FusionMode selects the blender: "calibrated_or" (default; calibrated
+	// probabilistic-OR — see §3.4), "weighted_average" (v1 rollback), or
+	// "noisy_or" (hand-set probabilistic OR, rollback).
 	FusionMode string `koanf:"fusion_mode"`
 	// FusionShadow, when true, computes the non-active method per email and records
 	// decision_fusion_shadow_disagree_total so a switch can be measured first.
@@ -81,9 +82,9 @@ type ReliabilityConfig struct {
 // startup, like HeaderConfig.Validate) so other services are unaffected.
 func (d DecisionConfig) Validate() error {
 	switch d.FusionMode {
-	case "", "weighted_average", "noisy_or":
+	case "", "weighted_average", "noisy_or", "calibrated_or":
 	default:
-		return fmt.Errorf("decision.fusion_mode must be one of: weighted_average, noisy_or; got %q", d.FusionMode)
+		return fmt.Errorf("decision.fusion_mode must be one of: calibrated_or, weighted_average, noisy_or; got %q", d.FusionMode)
 	}
 	channels := map[string]float64{
 		"url": d.Reliability.URL, "header": d.Reliability.Header,
@@ -488,7 +489,7 @@ func Load() (*Config, error) {
 			HTTPTimeout:  30 * time.Second,
 		},
 		Decision: DecisionConfig{
-			FusionMode:   "weighted_average",
+			FusionMode:   "calibrated_or",
 			FusionShadow: false,
 			Reliability:  ReliabilityConfig{URL: 1.0, Header: 1.0, NLP: 1.0, Attachment: 1.0},
 		},

--- a/shared/config/config_test.go
+++ b/shared/config/config_test.go
@@ -906,8 +906,8 @@ func TestLoad_DecisionDefaults(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Load() returned error: %v", err)
 	}
-	if cfg.Decision.FusionMode != "weighted_average" {
-		t.Errorf("default Decision.FusionMode = %q, want weighted_average", cfg.Decision.FusionMode)
+	if cfg.Decision.FusionMode != "calibrated_or" {
+		t.Errorf("default Decision.FusionMode = %q, want calibrated_or", cfg.Decision.FusionMode)
 	}
 	if cfg.Decision.FusionShadow {
 		t.Errorf("default Decision.FusionShadow = true, want false")


### PR DESCRIPTION
## Summary

Implements the svc-08 fusion the corrected-model benchmark concluded is best (`benchmark/FINDINGS.md`, merged in #215), on the fixed fp32 model (#216): **calibrated probabilistic-OR over `phishing_probability` + header, dropping maliciousness `content_risk`.** This is the production counterpart to the now-closed #213/#214 — engine ported from #213 (reviewed correct), but with the calibration **re-fit on the corrected model** and the broken-model benchmark churn dropped.

Metric of record is **View-A** (positive = phishing; negative = legitimate + spam; flagging spam is a false positive).

## What changes

- **svc-06 v4 scoring** (`inference.py`): `content_risk_score = round(P(phishing)*100)` (was `1 − P(legit)` = maliciousness = P(spam)+P(phishing)). Benign marketing spam → ~0; advance-fee/419 scams are *phishing*-labelled and stay high. The 3-class label + `spam_probability` are unchanged. (Keeps #216's ORT optimized-graph cache invalidation.)
- **svc-08 calibrated-OR blender** (`calibrated_blender.go`, `calibration.go`): per-channel calibrated `P(phishing)` → noisy-OR → final isotonic. `fusion_mode` default = `calibrated_or`; `weighted_average` / `noisy_or` remain as rollbacks. Channels: **nlp = P(phishing)** (isotonic), **header** (isotonic), **url NEUTRAL** (the composite url_score conflates an authoritative guard/TI hit with lexical noise — re-enable as an authoritative curve once `guard_hit`/`ti_matched` is forwarded; follow-up), **attachment** identity.
- **Calibration artifact + parity fixture re-fit on the corrected fp32 full capture** (`fusion_calibration_v1.json`, `parity_fixture_v1.json`): `n=10,677`, `phish=1,010`. *Not* the broken-model data the original #213 artifact used.

## Why drop `content_risk`

`content_risk = 1 − P(legit) = P(spam) + P(phishing)` fires on **real spam** (median ~99), so a maliciousness-based fusion flags **~94%** of held-out real spam as phishing. `P(phishing)` scores spam ≈ 0 and separates cleanly. Full evidence (grouped-OOF real-spam FP, provenance holdout, the broken-model→corrected-model story) is in the merged `benchmark/FINDINGS.md`.

## Results (held-out, View-A, band > 25.5)

| | recall | FPR(legit+spam) | F1 | precision | held-out real-spam FP |
|---|---|---|---|---|---|
| this PR (calibrated-OR + P(phishing)) | 0.879 | 0.008 | **0.898** | 0.917 | **3.7%** |

(For contrast, the previous `weighted_average` + maliciousness path: F1 ~0.77, FPR ~0.044, real-spam FP ~94%.)

## Caveats (honest)

- **Operating threshold needs real-traffic re-calibration**: the synthetic-trained header channel maps the baseline header value to a non-trivial probability, so the synth→real domain shift inflates FPR at a fixed threshold; re-tune the band on real traffic before relying on absolute FPR.
- **Real-phishing recall** in the benchmark is partly training-contaminated (Nazario/Nigerian are public corpora) — see FINDINGS §5. The content-drop result is independent of this (it's a real-spam FP effect).
- `url` is intentionally neutral pending the `guard_hit`/`ti_matched` forwarding contract.

Supersedes #213/#214 (both closed).
