### PR TITLE
infra: public demo dashboards behind shared Caddy + full Grafana coverage

### DIFF
--- a/.github/workflows/demo-images.yml
+++ b/.github/workflows/demo-images.yml
@@ -1,0 +1,78 @@
+# Build & publish the full demo image set to GHCR so the offline laptop bundle
+# never goes stale: every merge to main rebuilds and re-pushes :latest (+ :sha).
+# The laptop pulls these (deploy/offline-bundle/START.sh) — no local build.
+name: demo-images
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "services/**"
+      - "shared/**"
+      - "web/svc-10-dashboard/**"
+      - "demo/dashboard/**"
+      - "deploy/docker/**"
+      - "db/**"
+      - ".github/workflows/demo-images.yml"
+  workflow_dispatch: {}
+
+concurrency:
+  group: demo-images-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { name: svc-01-ingestion,           file: deploy/docker/Dockerfile.ingestion }
+          - { name: svc-02-parser,              file: deploy/docker/Dockerfile.parser }
+          - { name: svc-03-url-pipeline,        file: deploy/docker/Dockerfile.url_pipeline }
+          - { name: svc-04-header-analysis,     file: deploy/docker/Dockerfile.header_analysis }
+          - { name: svc-05-attachment-analysis, file: deploy/docker/Dockerfile.attachment_analysis }
+          - { name: svc-06-nlp-pipeline,        file: deploy/docker/Dockerfile.nlp_pipeline }
+          - { name: svc-07-aggregator,          file: deploy/docker/Dockerfile.aggregator }
+          - { name: svc-08-decision,            file: deploy/docker/Dockerfile.decision }
+          - { name: svc-09-notification,        file: deploy/docker/Dockerfile.notification }
+          - { name: svc-10-api,                 file: deploy/docker/Dockerfile.api_dashboard }
+          - { name: svc-10-web,                 file: web/svc-10-dashboard/Dockerfile }
+          - { name: portal,                     file: deploy/docker/Dockerfile.demo_dashboard }
+          - { name: fusion-sidecar,             file: deploy/docker/Dockerfile.fusion_sidecar }
+          - { name: nlp-inference,              file: deploy/docker/Dockerfile.nlp }
+          - { name: svc-11-ti-sync,             file: deploy/docker/Dockerfile.ti_sync }
+    steps:
+      - uses: actions/checkout@v4
+
+      # The ML images (url-pipeline, nlp) are multi-GB; reclaim runner disk first.
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL || true
+          docker system prune -af || true
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build & push ${{ matrix.name }}
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.file }}
+          push: true
+          # Owner lowercased for GHCR (XHCFS → xhcfs).
+          tags: |
+            ghcr.io/xhcfs/cybersiren-${{ matrix.name }}:latest
+            ghcr.io/xhcfs/cybersiren-${{ matrix.name }}:${{ github.sha }}
+          cache-from: type=gha,scope=${{ matrix.name }}
+          cache-to: type=gha,scope=${{ matrix.name }},mode=max

--- a/VIVA.md
+++ b/VIVA.md
@@ -1,0 +1,154 @@
+# CyberSiren — Viva Demo Runbook
+
+Everything needed to demo CyberSiren live, plus the offline fallback. The system
+runs on a VPS behind one shared Caddy (`*.cie21grad.systems`); a laptop bundle
+exists in case the VPS is unreachable.
+
+---
+
+## 1. Public URLs
+
+All HTTPS, auto-TLS via Caddy. Only ports 22/80/443 are open; every app is on
+`127.0.0.1` reached through Caddy.
+
+| URL | What | Auth |
+|---|---|---|
+| https://cs-demo.cie21grad.systems | Inbox scanner / interactive demo | open |
+| https://cs-analyst.cie21grad.systems | Analyst console (DB-backed SOC view) | `analyst@demo.cybersiren` / `analyst-demo-2026` |
+| https://cs-trace.cie21grad.systems | Jaeger — distributed trace across all services | open |
+| https://cs-grafana.cie21grad.systems | Grafana — per-service metrics (12 dashboards) | anon viewer; `admin`/`admin` to edit |
+
+cs-analyst → Monitoring tab links to all of the above + every Grafana board.
+
+ntfy push topic (notifications, §3): subscribe to **`cybersiren-cie21-alerts`** in the
+ntfy app (or https://ntfy.sh/cybersiren-cie21-alerts).
+
+---
+
+## 2. Offline / emergency bundle (if the VPS is down)
+
+One command on your laptop, full stack from prebuilt images — see
+[`deploy/offline-bundle/README.md`](deploy/offline-bundle/README.md).
+
+```bash
+bash deploy/offline-bundle/START.sh        # pull (cached → offline) + up, no build
+```
+
+Local URLs: scanner `:18090`, analyst `:18089`, Jaeger `:16686`, Grafana `:3001`.
+Images are kept fresh by CI (`.github/workflows/demo-images.yml` → GHCR on every
+merge to `main`). **Pre-pull the night before** while you have internet.
+
+---
+
+## 3. Notification service (svc-09) → ntfy
+
+svc-09 is complete: it consumes `emails.verdict`, gates on `risk ≥ org threshold OR
+label ∈ {phishing, malware}`, rate-limits one alert per (org, campaign) per hour, and
+dispatches over **email (SMTP)** and **webhook**. The webhook is wired to ntfy:
+
+- `.env`: `NOTIFY_WEBHOOK_ENABLED=true`, `NOTIFY_WEBHOOK_URL=https://ntfy.sh/cybersiren-cie21-alerts`
+- The demo org already lists `webhook` in `notification_channels`.
+
+**Demo it:** subscribe to `cybersiren-cie21-alerts` in the ntfy phone app, then scan a
+phishing sample on cs-demo → a push arrives within ~1 s. The body is the alert JSON
+(`verdict_label`, `risk_score`, `email_id`, `campaign_id`). Verify without a phone:
+
+```bash
+curl -s "https://ntfy.sh/cybersiren-cie21-alerts/json?poll=1&since=10m"
+```
+
+(A 15-line adapter could prettify the JSON into a titled message — optional.)
+
+---
+
+## 4. Gmail → live server (optional; controlled audience only)
+
+The OAuth app is **unverified**, so only Google accounts you add as *test users* can
+authorize it — fine for you/examiners, not the public.
+
+1. Google Cloud Console → a project → **Enable the Gmail API**.
+2. **OAuth consent screen**: User type *External*; add your (and examiners') Google
+   addresses under **Test users**; scope `.../auth/gmail.readonly`. Leave it in
+   *Testing* (no verification needed for test users).
+3. **Credentials → Create OAuth client ID → Web application**. Authorized redirect URI:
+   `https://cs-demo.cie21grad.systems/oauth/callback` (already the portal's default).
+4. Put the client id/secret in `deploy/compose/.env`:
+   ```
+   GOOGLE_CLIENT_ID=...
+   GOOGLE_CLIENT_SECRET=...
+   ```
+5. Recreate the portal: `cd deploy/compose && docker compose --profile full up -d portal`.
+6. On cs-demo a **Sign in with Google** button appears → authorize → the inbox is
+   polled (`GMAIL_POLL_INTERVAL`, default 1 m) and new mail is scanned automatically.
+
+Notes: read-only; the refresh token is in memory (re-auth after a portal restart unless
+`GMAIL_TOKEN_FILE` is set on a volume); revoke anytime in the Google account settings.
+
+---
+
+## 5. Where Gmail-scanned mail shows up (the "DB-backed dashboard")
+
+You already have a DB-backed view: **the analyst console (cs-analyst)** reads
+`emails`/`verdicts` from Postgres via svc-10-api. Any Gmail mail flows
+`portal → svc-01 → pipeline → Postgres`, so it appears in cs-analyst automatically and
+**persists across restarts**.
+
+The cs-demo *portal* itself is intentionally a lightweight, Kafka-fed live view (its
+local `.scans.json` is ephemeral). It already reflects Gmail mail in real time, but it
+is not the system of record. Recommendation for the viva: **use cs-analyst as the
+durable/DB view and cs-demo as the interactive scanner.** (Converting the portal's
+storage to the DB is possible but a non-trivial rewrite — not worth the risk pre-viva;
+ask if you want it as a follow-up.)
+
+---
+
+## 6. Screenshots to capture (last-resort fallback)
+
+If even the laptop bundle fails, have these ready as slides.
+
+| # | Screen | What it proves |
+|---|---|---|
+| 1 | cs-demo — benign sample verdict | benign classified correctly (score ~1) |
+| 2 | cs-demo — phishing sample + per-module breakdown | URL ML + NLP + header signals → phishing |
+| 3 | cs-demo — malware sample (attachment) | malicious attachment → **malware** verdict |
+| 4 | cs-demo — TI sample | TI blocklist hit (C2 domain) drives the verdict |
+| 5 | cs-analyst — scan list | DB-backed SOC view of all scans |
+| 6 | cs-analyst — scan detail | full per-email evidence trail from the DB |
+| 7 | cs-analyst — stats dashboard | aggregate threat/campaign/feed stats |
+| 8 | cs-analyst — Monitoring tab | links to every dashboard |
+| 9 | Jaeger — one trace across ~11 services | distributed tracing through the whole pipeline |
+| 10 | Grafana — svc-07 aggregator + svc-08 decision | live pipeline metrics |
+| 11 | Grafana — dashboard list (12 boards) | per-service observability coverage |
+| 12 | ntfy phone push on a phishing verdict | svc-09 alerting end-to-end |
+| 13 | `docker ps` on the VPS | full stack healthy |
+| 14 | Terminal: `START.sh` bringing the stack up | the one-command offline fallback works |
+
+---
+
+## 7. Suggested viva demo flow (~10 min)
+
+1. **Frame it (30 s).** "Phishing-detection pipeline: ingestion → parse → URL/NLP/
+   header/attachment scoring → fusion decision → notification, fully traced and
+   observable, behind one hardened reverse proxy."
+2. **cs-demo, benign (1 min).** Load the benign sample → *benign*. Show the per-module
+   breakdown: every channel low.
+3. **cs-demo, phishing (2 min).** Load the phishing sample → *phishing*. Walk the
+   breakdown: URL ML p≈0.94, NLP=100 (credential-harvesting), header rules. Mention the
+   **calibrated-OR fusion** — one strong channel is enough (a weighted average would
+   wrongly say "suspicious").
+4. **cs-demo, malware (1 min).** Load the malware sample → *malware* (known-bad
+   attachment hash). Mention the TI sample too (C2 domain blocklist hit).
+5. **ntfy (30 s).** Show the push that just landed on your phone for the phishing/malware
+   verdicts — svc-09 alerting.
+6. **cs-analyst (2 min).** Log in. Scan list (DB-backed) → open the phishing scan detail
+   (full evidence trail) → stats dashboard. This is the SOC/analyst view of the same data.
+7. **Jaeger (1 min).** Open the trace for one email → one trace spanning ~11 services →
+   proves the W3C traceparent propagates across every Kafka hop.
+8. **Grafana (1 min).** Monitoring tab → svc-08 decision board (verdicts, latency) and
+   the 12-board list → per-service observability.
+9. **Architecture/security (1 min).** One Caddy front door, every container on loopback,
+   ufw + Docker-bypass lockdown; CI-built images and a one-command offline laptop bundle
+   as a fallback.
+
+If the network drops: switch to `START.sh` on the laptop (same flow, `localhost`), or
+the screenshot deck (§6).

--- a/db/seeds/attachment_demo_seed.sql
+++ b/db/seeds/attachment_demo_seed.sql
@@ -22,12 +22,14 @@
 -- ============================================================
 
 INSERT INTO attachment_library (sha256, is_malicious, risk_score, threat_tags)
-VALUES (
-    'ed8ac563a8b03e42b728cb322892d906d9b7da618704d13a1aeaa1f3551b00f4',
-    TRUE,
-    90,
-    '{malware}'::text[]
-)
+VALUES
+    -- Smoke superset fixture (scripts/dev/inject_fake_email.sh INJECTION A):
+    -- base64 of "CYBERSIREN-SMOKE-MALWARE-FIXTURE-V1\n".
+    ('ed8ac563a8b03e42b728cb322892d906d9b7da618704d13a1aeaa1f3551b00f4', TRUE, 90, '{malware}'::text[]),
+    -- cs-demo UI "malware" sample (demo/dashboard/web/index.html, invoice.pdf.exe).
+    -- sha256 of its decoded base64 payload, so the sample classifies as malware
+    -- (hash hit → score 90 → ≥76 malware-grade attachment → reconciled to malware).
+    ('34b9348ecccb09747637e5bdaa744e48362a9e684b260766e49868f2e50cecab', TRUE, 90, '{malware}'::text[])
 ON CONFLICT (sha256) DO UPDATE
     SET is_malicious = TRUE,
         risk_score   = GREATEST(attachment_library.risk_score, EXCLUDED.risk_score),

--- a/db/seeds/ti_demo_seed.sql
+++ b/db/seeds/ti_demo_seed.sql
@@ -86,6 +86,8 @@ INSERT INTO ti_indicators (
     ((SELECT id FROM feeds WHERE name = 'demo-seed'), 'domain', 'a4-scan-point.puroflusso.in.net',     'botnet_cc', 80, 0.78, TRUE, CURRENT_TIMESTAMP),
     ((SELECT id FROM feeds WHERE name = 'demo-seed'), 'domain', 'admin-panel.sectoralcontrol.in.net',  'botnet_cc', 88, 0.85, TRUE, CURRENT_TIMESTAMP),
     ((SELECT id FROM feeds WHERE name = 'demo-seed'), 'domain', 'agentscript.dawnspire.in.net',        'botnet_cc', 95, 0.92, TRUE, CURRENT_TIMESTAMP),
+    -- Backs the "ti" demo email (cs-demo "Load sample" → TI blocklist hit on the C2 domain).
+    ((SELECT id FROM feeds WHERE name = 'demo-seed'), 'domain', 'malware-c2-delivery.test',            'botnet_cc', 95, 0.92, TRUE, CURRENT_TIMESTAMP),
 
     -- IP indicator — Injection A's originating IP (Received-chain hop). Fires
     -- svc04.reputation.ti_ip_match for the smoke superset fixture.

--- a/demo/ntfy-adapter/adapter.py
+++ b/demo/ntfy-adapter/adapter.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Tiny ntfy adapter for svc-09 alerts.
+
+svc-09's webhook channel POSTs its raw Alert JSON. Point NOTIFY_WEBHOOK_URL at this
+service (http://ntfy-adapter:8099/alert) and it reformats each alert into a titled,
+prioritised, tagged ntfy push, then reposts to NTFY_URL (an ntfy topic). Stdlib only.
+
+Env:
+  PORT      listen port (default 8099)
+  NTFY_URL  ntfy topic URL to publish to (default https://ntfy.sh/cybersiren-cie21-alerts)
+"""
+import json
+import os
+import urllib.request
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+NTFY_URL = os.environ.get("NTFY_URL", "https://ntfy.sh/cybersiren-cie21-alerts")
+PORT = int(os.environ.get("PORT", "8099"))
+
+# verdict_label -> (emoji, ntfy priority 1..5, ntfy tag)
+STYLE = {
+    "malware": ("\U0001FA9A", "5", "skull"),       # urgent
+    "phishing": ("\U0001F3A3", "4", "warning"),    # high
+    "suspicious": ("⚠️", "3", "warning"),
+    "benign": ("✅", "2", "white_check_mark"),
+}
+
+
+def forward(alert):
+    label = str(alert.get("verdict_label", "unknown")).lower()
+    emoji, prio, tag = STYLE.get(label, ("❓", "3", "question"))
+    risk = alert.get("risk_score", "?")
+    conf = alert.get("confidence")
+    eid = alert.get("email_id", "?")
+    camp = alert.get("campaign_id")
+
+    # NOTE: HTTP headers are latin-1, so X-Title must stay ASCII (no emoji/em-dash).
+    # The emoji goes in the body (UTF-8) and severity shows via X-Tags / X-Priority.
+    title = f"{label.upper()}: risk {risk}/100"
+    lines = [f"{emoji} CyberSiren flagged an email as {label} (risk {risk}/100)."]
+    if isinstance(conf, (int, float)):
+        lines.append(f"Confidence: {conf:.0%}")
+    if camp:
+        lines.append(f"Campaign #{camp}")
+    lines.append(f"email_id: {eid}")
+
+    req = urllib.request.Request(NTFY_URL, data="\n".join(lines).encode(), method="POST")
+    req.add_header("X-Title", title)
+    req.add_header("X-Priority", prio)
+    req.add_header("X-Tags", f"{tag},cybersiren")
+    with urllib.request.urlopen(req, timeout=10) as r:
+        return r.status
+
+
+class Handler(BaseHTTPRequestHandler):
+    def do_POST(self):
+        n = int(self.headers.get("Content-Length", 0) or 0)
+        raw = self.rfile.read(n) if n else b"{}"
+        ok = False
+        try:
+            status = forward(json.loads(raw or b"{}"))
+            ok = 200 <= status < 300
+        except Exception as e:  # noqa: BLE001 - report any failure to svc-09 so it retries
+            self.log_message("forward error: %s", e)
+        self.send_response(200 if ok else 502)
+        self.end_headers()
+        self.wfile.write(b"ok" if ok else b"err")
+
+    def do_GET(self):  # /healthz
+        self.send_response(200)
+        self.end_headers()
+        self.wfile.write(b"ok")
+
+    def log_message(self, fmt, *args):
+        print("[ntfy-adapter] " + (fmt % args), flush=True)
+
+
+if __name__ == "__main__":
+    print(f"[ntfy-adapter] listening :{PORT} -> {NTFY_URL}", flush=True)
+    ThreadingHTTPServer(("0.0.0.0", PORT), Handler).serve_forever()

--- a/deploy/compose/.env.example
+++ b/deploy/compose/.env.example
@@ -65,3 +65,14 @@ APP_DATABASE_URL=postgres://cybersiren_app:cybersiren_app@localhost:5432/cybersi
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
 GOOGLE_REDIRECT_URL=http://localhost:8090/oauth/callback
+
+# ── svc-09 notification webhook (optional; ntfy POC) ─────────────────────────
+# When enabled, svc-09 POSTs an alert JSON to NOTIFY_WEBHOOK_URL on a
+# phishing/malware verdict (or risk >= org threshold). Point at an ntfy topic and
+# subscribe on your phone. The demo org seeds "webhook" in notification_channels.
+NOTIFY_WEBHOOK_ENABLED=false
+# Via the prettifying adapter (titled push): http://ntfy-adapter:8099/alert
+# Or post raw JSON straight to a topic: https://ntfy.sh/<your-topic>
+NOTIFY_WEBHOOK_URL=http://ntfy-adapter:8099/alert
+# Topic the ntfy-adapter publishes to.
+NTFY_URL=https://ntfy.sh/cybersiren-cie21-alerts

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -45,6 +45,7 @@ x-pipeline-env: &pipeline-env
   CYBERSIREN_DB__PASSWORD: ${POSTGRES_PASSWORD:-postgres}
   CYBERSIREN_DB__SSL_MODE: disable
   CYBERSIREN_VALKEY__ADDR: valkey:6379
+  CYBERSIREN_VALKEY__PASSWORD: ${VALKEY_PASSWORD:-}
   CYBERSIREN_AUTH__JWT_SECRET: demo-secret-not-for-production-use!!
   CYBERSIREN_KAFKA__BROKERS: kafka:29092
   CYBERSIREN_JAEGER_ENDPOINT: http://jaeger:4318
@@ -65,6 +66,7 @@ volumes:
   valkeydata:
   redpandadata:
   miniodata:
+  portaltokens:   # persists the portal's Gmail refresh token across restarts
 
 services:
 
@@ -79,7 +81,9 @@ services:
       POSTGRES_USER: ${POSTGRES_USER:-postgres}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
     ports:
-      - "${POSTGRES_PORT:-5432}:5432"
+      # Bound to loopback after 2026-06-17 cryptominer incident (was 0.0.0.0).
+      # Reach it via SSH tunnel; inter-service traffic uses the docker network.
+      - "127.0.0.1:${POSTGRES_PORT:-5432}:5432"
     volumes:
       - pgdata:/var/lib/postgresql/data
     networks:
@@ -97,14 +101,19 @@ services:
     image: valkey/valkey:7-alpine
     profiles: ["valkey", "demo", "full"]
     container_name: cybersiren-valkey
+    environment:
+      VALKEY_PASSWORD: ${VALKEY_PASSWORD:-}
+    # requirepass added 2026-06-17 (was unauthenticated). Empty pw => no auth (back-compat).
+    command: ["sh", "-c", "exec valkey-server --requirepass \"$$VALKEY_PASSWORD\""]
     ports:
-      - "${VALKEY_PORT:-6379}:6379"
+      # Bound to loopback 2026-06-17 — was 0.0.0.0 with NO requirepass (open RCE vector).
+      - "127.0.0.1:${VALKEY_PORT:-6379}:6379"
     volumes:
       - valkeydata:/data
     networks:
       - cybersiren
     healthcheck:
-      test: ["CMD", "valkey-cli", "ping"]
+      test: ["CMD-SHELL", "valkey-cli -a \"$$VALKEY_PASSWORD\" ping | grep -q PONG"]
       interval: 5s
       timeout: 5s
       retries: 10
@@ -137,8 +146,8 @@ services:
       - --advertise-rpc-addr=kafka:33145
       - --mode=dev-container
     ports:
-      - "${KAFKA_PORT:-9092}:9092"
-      - "9644:9644"
+      - "127.0.0.1:${KAFKA_PORT:-9092}:9092"
+      - "127.0.0.1:9644:9644"
     volumes:
       - redpandadata:/var/lib/redpanda/data
     networks:
@@ -185,8 +194,9 @@ services:
       MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
       MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
     ports:
-      - "${MINIO_PORT:-9000}:9000"
-      - "${MINIO_CONSOLE_PORT:-9001}:9001"
+      # Bound to loopback 2026-06-17 — was 0.0.0.0 with default minioadmin creds.
+      - "127.0.0.1:${MINIO_PORT:-9000}:9000"
+      - "127.0.0.1:${MINIO_CONSOLE_PORT:-9001}:9001"
     volumes:
       - miniodata:/data
     networks:
@@ -304,8 +314,8 @@ services:
       fusion-sidecar:
         condition: service_healthy
     ports:
-      - "8083:8083"
-      - "9091:9090"
+      - "127.0.0.1:18083:8083"
+      - "127.0.0.1:9091:9090"
     environment:
       CYBERSIREN_ENV: development
       CYBERSIREN_LOG__LEVEL: debug
@@ -318,6 +328,7 @@ services:
       CYBERSIREN_DB__PASSWORD: ${POSTGRES_PASSWORD:-postgres}
       CYBERSIREN_DB__SSL_MODE: disable
       CYBERSIREN_VALKEY__ADDR: valkey:6379
+      CYBERSIREN_VALKEY__PASSWORD: ${VALKEY_PASSWORD:-}
       CYBERSIREN_AUTH__JWT_SECRET: demo-secret-not-for-production-use!!
       CYBERSIREN_ML__URL_MODEL_PATH: /app/ml/inference_script.py
       CYBERSIREN_PHISHING__SIDECAR_URL: http://fusion-sidecar:8765
@@ -346,7 +357,7 @@ services:
       dockerfile: deploy/docker/Dockerfile.fusion_sidecar
     profiles: ["demo", "svc-03", "full"]
     ports:
-      - "8765:8765"
+      - "127.0.0.1:8765:8765"
     environment:
       # OTEL: emit spans to Jaeger over OTLP/HTTP. The Go side uses the
       # same Jaeger; setting this to empty disables the OTEL stack.
@@ -385,7 +396,7 @@ services:
       kafka-init:
         condition: service_completed_successfully
     ports:
-      - "9094:9090"
+      - "127.0.0.1:9094:9090"
     environment:
       CYBERSIREN_ENV: development
       CYBERSIREN_LOG__LEVEL: debug
@@ -397,6 +408,7 @@ services:
       CYBERSIREN_DB__PASSWORD: ${POSTGRES_PASSWORD:-postgres}
       CYBERSIREN_DB__SSL_MODE: disable
       CYBERSIREN_VALKEY__ADDR: valkey:6379
+      CYBERSIREN_VALKEY__PASSWORD: ${VALKEY_PASSWORD:-}
       CYBERSIREN_AUTH__JWT_SECRET: demo-secret-not-for-production-use!!
       CYBERSIREN_METRICS_PORT: "9090"
       CYBERSIREN_JAEGER_ENDPOINT: http://jaeger:4318
@@ -429,11 +441,11 @@ services:
     # reconnect when brokers appear and the UI/forwarding works regardless. This
     # also lets it come up with just `--profile demo` (kafka is a separate profile).
     ports:
-      - "8090:8090"
+      - "127.0.0.1:18090:8090"
     environment:
       DEMO_ADDR: ":8090"
       KAFKA_BROKERS: kafka:29092
-      SVC01_SCAN_URL: http://host.docker.internal:8081/api/v1/scan
+      SVC01_SCAN_URL: http://host.docker.internal:18081/api/v1/scan
       DEMO_API_KEY: cs_demokey000000000000000000000DEMO
       # Optional Gmail "Sign in with Google" — see demo/dashboard/README.md.
       GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID:-}
@@ -458,8 +470,8 @@ services:
       demo-seed:
         condition: service_completed_successfully
     ports:
-      - "8086:8086"
-      - "9096:9090"
+      - "127.0.0.1:18086:8086"
+      - "127.0.0.1:9096:9090"
     environment:
       CYBERSIREN_ENV: development
       CYBERSIREN_LOG__LEVEL: debug
@@ -498,7 +510,7 @@ services:
     environment:
       PORT: "8001"
     ports:
-      - "8001:8001"
+      - "127.0.0.1:8001:8001"
     networks:
       - cybersiren
     healthcheck:
@@ -517,14 +529,14 @@ services:
     build:
       context: ../..
       dockerfile: deploy/docker/Dockerfile.ti_sync
-    profiles: ["svc-11"]
+    profiles: ["svc-11", "full"]
     depends_on:
       demo-seed:
         condition: service_completed_successfully
       valkey:
         condition: service_healthy
     ports:
-      - "9093:9090"
+      - "127.0.0.1:9093:9090"
     environment:
       CYBERSIREN_ENV: development
       CYBERSIREN_LOG__LEVEL: debug
@@ -536,6 +548,7 @@ services:
       CYBERSIREN_DB__PASSWORD: ${POSTGRES_PASSWORD:-postgres}
       CYBERSIREN_DB__SSL_MODE: disable
       CYBERSIREN_VALKEY__ADDR: valkey:6379
+      CYBERSIREN_VALKEY__PASSWORD: ${VALKEY_PASSWORD:-}
       CYBERSIREN_AUTH__JWT_SECRET: demo-secret-not-for-production-use!!
       CYBERSIREN_METRICS_PORT: "9090"
       CYBERSIREN_JAEGER_ENDPOINT: http://jaeger:4318
@@ -558,8 +571,8 @@ services:
     environment:
       COLLECTOR_OTLP_ENABLED: "true"
     ports:
-      - "16686:16686"   # Jaeger UI
-      - "4318:4318"     # OTLP HTTP
+      - "127.0.0.1:16686:16686"   # Jaeger UI
+      - "127.0.0.1:14318:4318"     # OTLP HTTP
     networks:
       - cybersiren
     restart: unless-stopped
@@ -573,7 +586,7 @@ services:
     profiles: ["postgres"]
     container_name: cybersiren-pgadmin
     ports:
-      - "${PGADMIN_PORT:-5050}:80"
+      - "127.0.0.1:${PGADMIN_PORT:-5050}:80"
     environment:
       PGADMIN_DEFAULT_EMAIL: admin@cybersiren.dev
       PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_PASSWORD:-admin}
@@ -597,10 +610,10 @@ services:
   # Redpanda Kafka API — they used to collide.)
   prometheus:
     image: prom/prometheus:latest
-    profiles: ["demo", "monitoring", "smoke"]
+    profiles: ["demo", "monitoring", "smoke", "full"]
     container_name: cybersiren-prometheus
     ports:
-      - "${PROMETHEUS_PORT:-19090}:9090"
+      - "127.0.0.1:${PROMETHEUS_PORT:-19090}:9090"
     volumes:
       - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
     # `host.docker.internal` is auto-resolved on Docker Desktop (Mac/Win)
@@ -619,15 +632,19 @@ services:
   # UI at http://localhost:3001. Login: admin / admin (skip password change).
   grafana:
     image: grafana/grafana:latest
-    profiles: ["demo", "monitoring", "smoke"]
+    profiles: ["demo", "monitoring", "smoke", "full"]
     container_name: cybersiren-grafana
     ports:
-      - "3001:3000"
+      - "127.0.0.1:3001:3000"
     environment:
       GF_SECURITY_ADMIN_USER: admin
-      GF_SECURITY_ADMIN_PASSWORD: admin
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_PASSWORD:-admin}
       GF_AUTH_ANONYMOUS_ENABLED: "true"
       GF_AUTH_ANONYMOUS_ORG_ROLE: Viewer
+      # Public subdomain behind the host Caddy (TLS terminated there). Without a
+      # correct root_url, Grafana's login/redirect/share links break behind a proxy.
+      GF_SERVER_ROOT_URL: ${GRAFANA_ROOT_URL:-https://cs-grafana.cie21grad.systems}
+      GF_SERVER_DOMAIN: ${GRAFANA_DOMAIN:-cs-grafana.cie21grad.systems}
     volumes:
       - ./grafana/provisioning:/etc/grafana/provisioning:ro
       - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
@@ -646,7 +663,7 @@ services:
     profiles: ["kafka"]
     container_name: cybersiren-redpanda-console
     ports:
-      - "${KAFKA_UI_PORT:-8080}:8080"
+      - "127.0.0.1:${KAFKA_UI_PORT:-8080}:8080"
     environment:
       KAFKA_BROKERS: "kafka:29092"
       CONFIG_FILEPATH: ""
@@ -672,7 +689,7 @@ services:
       kafka-init: { condition: service_completed_successfully }
       valkey: { condition: service_healthy }
       postgres: { condition: service_healthy }
-    ports: ["8081:8081"]
+    ports: ["127.0.0.1:18081:8081"]
     environment:
       <<: *pipeline-env
     networks: [cybersiren]
@@ -763,6 +780,11 @@ services:
       postgres: { condition: service_healthy }
     environment:
       <<: *pipeline-env
+      # Pin the calibrated probabilistic-OR fusion. It is the code default on main,
+      # but pin it so the live demo can never silently fall back to weighted_average
+      # (which dilutes a single strong channel — e.g. NLP=100 phish → only ~44 →
+      # "suspicious"; incident 2026-06-17). calibrated_or: 83.5% recall@1%FPR.
+      CYBERSIREN_DECISION__FUSION_MODE: calibrated_or
     networks: [cybersiren]
     restart: unless-stopped
 
@@ -777,6 +799,13 @@ services:
       postgres: { condition: service_healthy }
     environment:
       <<: *pipeline-env
+      # Webhook alert channel (off by default). Point at an ntfy topic to get a
+      # live push when a phishing/malware verdict fires:
+      #   NOTIFY_WEBHOOK_ENABLED=true
+      #   NOTIFY_WEBHOOK_URL=https://ntfy.sh/<your-topic>
+      # The org must list "webhook" in organisations.notification_channels (seeded).
+      CYBERSIREN_NOTIFICATION__WEBHOOK__ENABLED: ${NOTIFY_WEBHOOK_ENABLED:-false}
+      CYBERSIREN_NOTIFICATION__WEBHOOK__URL: ${NOTIFY_WEBHOOK_URL:-}
     networks: [cybersiren]
     restart: unless-stopped
 
@@ -788,7 +817,7 @@ services:
       demo-seed: { condition: service_completed_successfully }
       postgres: { condition: service_healthy }
       svc-01-ingestion: { condition: service_started }
-    ports: ["8088:8088"]
+    ports: ["127.0.0.1:8088:8088"]
     environment:
       <<: *pipeline-env
       CYBERSIREN_SVC10__SVC01_BASE_URL: http://svc-01-ingestion:8081
@@ -802,7 +831,7 @@ services:
     profiles: ["full"]
     depends_on:
       svc-10-api: { condition: service_started }
-    ports: ["8089:80"]
+    ports: ["127.0.0.1:18089:80"]
     networks: [cybersiren]
     restart: unless-stopped
 
@@ -814,15 +843,24 @@ services:
     profiles: ["full"]
     depends_on:
       svc-01-ingestion: { condition: service_started }
-    ports: ["8090:8090"]
+    ports: ["127.0.0.1:18090:8090"]
     environment:
       DEMO_ADDR: ":8090"
       KAFKA_BROKERS: kafka:29092
       SVC01_SCAN_URL: http://svc-01-ingestion:8081/api/v1/scan
       DEMO_API_KEY: cs_demokey000000000000000000000DEMO
+      # Optional Gmail "Sign in with Google". Leave GOOGLE_CLIENT_ID empty to hide
+      # the button (the .eml / sample-phish flow needs none of this). When enabled
+      # for the PUBLIC portal, the redirect URL must be the public callback and be
+      # registered as an authorized redirect URI on the Google OAuth client.
       GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID:-}
       GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET:-}
-      GOOGLE_REDIRECT_URL: ${GOOGLE_REDIRECT_URL:-http://localhost:8090/oauth/callback}
+      GOOGLE_REDIRECT_URL: ${GOOGLE_REDIRECT_URL:-https://cs-demo.cie21grad.systems/oauth/callback}
+      # Persist the Gmail refresh token on a volume so a portal restart keeps the
+      # inbox connected (no re-auth). Loaded on startup, written on connect.
+      GMAIL_TOKEN_FILE: /data/gmail-token.json
+    volumes:
+      - portaltokens:/data
     networks: [cybersiren]
     restart: unless-stopped
 
@@ -830,9 +868,25 @@ services:
   proxy:
     image: caddy:2-alpine
     profiles: ["full"]
-    ports: ["8888:80"]
+    ports: ["127.0.0.1:8888:80"]
     volumes:
       - ../proxy/Caddyfile:/etc/caddy/Caddyfile:ro
       - ../proxy/site:/srv:ro
+    networks: [cybersiren]
+    restart: unless-stopped
+
+  # ── ntfy-adapter (prettifies svc-09 alert JSON → titled ntfy push) ───────────
+  # svc-09's webhook (NOTIFY_WEBHOOK_URL=http://ntfy-adapter:8099/alert) posts the
+  # raw Alert JSON here; this reformats it into a titled/prioritised/tagged push
+  # and reposts to NTFY_URL. Stdlib Python on a base image (mounted script, no build).
+  ntfy-adapter:
+    image: python:3.12-alpine
+    profiles: ["full"]
+    command: ["python", "/app/adapter.py"]
+    environment:
+      PORT: "8099"
+      NTFY_URL: ${NTFY_URL:-https://ntfy.sh/cybersiren-cie21-alerts}
+    volumes:
+      - ../../demo/ntfy-adapter/adapter.py:/app/adapter.py:ro
     networks: [cybersiren]
     restart: unless-stopped

--- a/deploy/compose/grafana/dashboards/svc-01-ingestion.json
+++ b/deploy/compose/grafana/dashboards/svc-01-ingestion.json
@@ -1,0 +1,248 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "uid": "cybersiren-svc-01",
+  "links": [],
+  "title": "svc-01 Ingestion",
+  "tags": [
+    "cybersiren",
+    "pipeline",
+    "svc-01"
+  ],
+  "schemaVersion": 39,
+  "version": 1,
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "refresh": "10s",
+  "panels": [
+    {
+      "title": "Produced last 5m",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 20,
+            "lineWidth": 2
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "sum(increase(cybersiren_kafka_messages_produced_total[5m]))",
+          "legendFormat": "produced",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "value",
+        "graphMode": "area"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      }
+    },
+    {
+      "title": "Produced by topic (msg/s)",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 20,
+            "lineWidth": 2
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "sum by (topic) (rate(cybersiren_kafka_messages_produced_total[1m]))",
+          "legendFormat": "{{topic}}",
+          "refId": "A"
+        }
+      ],
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      }
+    },
+    {
+      "title": "Producer outcomes (msg/s)",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 20,
+            "lineWidth": 2
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "sum by (result) (rate(cybersiren_kafka_producer_published_total[1m]))",
+          "legendFormat": "{{result}}",
+          "refId": "A"
+        }
+      ],
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      }
+    },
+    {
+      "title": "Publish latency",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 20,
+            "lineWidth": 2
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.5, sum by (le) (rate(cybersiren_kafka_producer_publish_seconds_bucket[5m])))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(cybersiren_kafka_producer_publish_seconds_bucket[5m])))",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(cybersiren_kafka_producer_publish_seconds_bucket[5m])))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      }
+    },
+    {
+      "title": "Go runtime \u2014 goroutines",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 20,
+            "lineWidth": 2
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "go_goroutines{service=\"svc-01-ingestion\"}",
+          "legendFormat": "goroutines",
+          "refId": "A"
+        }
+      ],
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      }
+    },
+    {
+      "title": "Go runtime \u2014 heap (MiB)",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 20,
+            "lineWidth": 2
+          },
+          "unit": "decmbytes"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "go_memstats_heap_alloc_bytes{service=\"svc-01-ingestion\"} / 1048576",
+          "legendFormat": "heap_alloc",
+          "refId": "A"
+        }
+      ],
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      }
+    }
+  ]
+}

--- a/deploy/compose/grafana/dashboards/svc-02-parser.json
+++ b/deploy/compose/grafana/dashboards/svc-02-parser.json
@@ -1,0 +1,289 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "uid": "cybersiren-svc-02",
+  "links": [],
+  "title": "svc-02 Parser",
+  "tags": [
+    "cybersiren",
+    "pipeline",
+    "svc-02"
+  ],
+  "schemaVersion": 39,
+  "version": 1,
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "refresh": "10s",
+  "panels": [
+    {
+      "title": "Parser messages (by result)",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 20,
+            "lineWidth": 2
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "sum by (result) (rate(parser_messages_total[1m]))",
+          "legendFormat": "{{result}}",
+          "refId": "A"
+        }
+      ],
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      }
+    },
+    {
+      "title": "Fan-out: consumed vs produced (msg/s)",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 20,
+            "lineWidth": 2
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(cybersiren_kafka_messages_consumed_total[1m]))",
+          "legendFormat": "consumed",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(cybersiren_kafka_messages_produced_total[1m]))",
+          "legendFormat": "produced (\u00d75 fan-out)",
+          "refId": "B"
+        }
+      ],
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      }
+    },
+    {
+      "title": "Produced by topic (msg/s)",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 20,
+            "lineWidth": 2
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "sum by (topic) (rate(cybersiren_kafka_messages_produced_total[1m]))",
+          "legendFormat": "{{topic}}",
+          "refId": "A"
+        }
+      ],
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      }
+    },
+    {
+      "title": "Consume processing latency",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 20,
+            "lineWidth": 2
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.5, sum by (le) (rate(cybersiren_kafka_consumer_process_seconds_bucket[5m])))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(cybersiren_kafka_consumer_process_seconds_bucket[5m])))",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(cybersiren_kafka_consumer_process_seconds_bucket[5m])))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      }
+    },
+    {
+      "title": "Publish latency",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 20,
+            "lineWidth": 2
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.5, sum by (le) (rate(cybersiren_kafka_producer_publish_seconds_bucket[5m])))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(cybersiren_kafka_producer_publish_seconds_bucket[5m])))",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(cybersiren_kafka_producer_publish_seconds_bucket[5m])))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      }
+    },
+    {
+      "title": "Go runtime \u2014 goroutines",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 20,
+            "lineWidth": 2
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "go_goroutines{service=\"svc-02-parser\"}",
+          "legendFormat": "goroutines",
+          "refId": "A"
+        }
+      ],
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      }
+    },
+    {
+      "title": "Go runtime \u2014 heap (MiB)",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 20,
+            "lineWidth": 2
+          },
+          "unit": "decmbytes"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "go_memstats_heap_alloc_bytes{service=\"svc-02-parser\"} / 1048576",
+          "legendFormat": "heap_alloc",
+          "refId": "A"
+        }
+      ],
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 24
+      }
+    }
+  ]
+}

--- a/deploy/compose/grafana/dashboards/svc-04-header-analysis.json
+++ b/deploy/compose/grafana/dashboards/svc-04-header-analysis.json
@@ -1,0 +1,359 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "uid": "cybersiren-svc-04",
+  "links": [],
+  "title": "svc-04 Header Analysis",
+  "tags": [
+    "cybersiren",
+    "pipeline",
+    "svc-04"
+  ],
+  "schemaVersion": 39,
+  "version": 1,
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "refresh": "10s",
+  "panels": [
+    {
+      "title": "Messages (by result)",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 20,
+            "lineWidth": 2
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "sum by (result) (rate(header_analysis_messages_total[1m]))",
+          "legendFormat": "{{result}}",
+          "refId": "A"
+        }
+      ],
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      }
+    },
+    {
+      "title": "Analysis duration",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 20,
+            "lineWidth": 2
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.5, sum by (le) (rate(header_analysis_duration_seconds_bucket[5m])))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(header_analysis_duration_seconds_bucket[5m])))",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(header_analysis_duration_seconds_bucket[5m])))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      }
+    },
+    {
+      "title": "Score distribution (by bucket, 5m)",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 20,
+            "lineWidth": 2
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "sum by (bucket) (increase(header_analysis_score_total[5m]))",
+          "legendFormat": "{{bucket}}",
+          "refId": "A"
+        }
+      ],
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      }
+    },
+    {
+      "title": "Top 10 fired rules (5m)",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 20,
+            "lineWidth": 2
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "topk(10, sum by (rule_id) (increase(header_analysis_rules_fired_total[5m])))",
+          "legendFormat": "rule={{rule_id}}",
+          "refId": "A"
+        }
+      ],
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      }
+    },
+    {
+      "title": "Rule cache hits/misses (by tier, /s)",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 20,
+            "lineWidth": 2
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "sum by (tier) (rate(header_rule_cache_hits_total[1m]))",
+          "legendFormat": "hit {{tier}}",
+          "refId": "A"
+        },
+        {
+          "expr": "sum by (tier) (rate(header_rule_cache_misses_total[1m]))",
+          "legendFormat": "miss {{tier}}",
+          "refId": "B"
+        }
+      ],
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      }
+    },
+    {
+      "title": "Rules loaded / Valkey healthy",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 20,
+            "lineWidth": 2
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "sum by (org_id) (header_rule_cache_rules_loaded)",
+          "legendFormat": "rules org={{org_id}}",
+          "refId": "A"
+        },
+        {
+          "expr": "header_analysis_valkey_healthy{service=\"svc-04-header-analysis\"}",
+          "legendFormat": "valkey_healthy",
+          "refId": "B"
+        }
+      ],
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      }
+    },
+    {
+      "title": "Publish latency",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 20,
+            "lineWidth": 2
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.5, sum by (le) (rate(cybersiren_kafka_producer_publish_seconds_bucket[5m])))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(cybersiren_kafka_producer_publish_seconds_bucket[5m])))",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(cybersiren_kafka_producer_publish_seconds_bucket[5m])))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 24
+      }
+    },
+    {
+      "title": "Go runtime \u2014 goroutines",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 20,
+            "lineWidth": 2
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "go_goroutines{service=\"svc-04-header-analysis\"}",
+          "legendFormat": "goroutines",
+          "refId": "A"
+        }
+      ],
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 24
+      }
+    },
+    {
+      "title": "Go runtime \u2014 heap (MiB)",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 20,
+            "lineWidth": 2
+          },
+          "unit": "decmbytes"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "go_memstats_heap_alloc_bytes{service=\"svc-04-header-analysis\"} / 1048576",
+          "legendFormat": "heap_alloc",
+          "refId": "A"
+        }
+      ],
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 32
+      }
+    }
+  ]
+}

--- a/deploy/compose/grafana/dashboards/svc-05-attachment-analysis.json
+++ b/deploy/compose/grafana/dashboards/svc-05-attachment-analysis.json
@@ -1,0 +1,326 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "uid": "cybersiren-svc-05",
+  "links": [],
+  "title": "svc-05 Attachment Analysis",
+  "tags": [
+    "cybersiren",
+    "pipeline",
+    "svc-05"
+  ],
+  "schemaVersion": 39,
+  "version": 1,
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "refresh": "10s",
+  "panels": [
+    {
+      "title": "Messages (by result)",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 20,
+            "lineWidth": 2
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "sum by (result) (rate(attachment_analysis_messages_total[1m]))",
+          "legendFormat": "{{result}}",
+          "refId": "A"
+        }
+      ],
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      }
+    },
+    {
+      "title": "Analysis duration",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 20,
+            "lineWidth": 2
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.5, sum by (le) (rate(attachment_analysis_duration_seconds_bucket[5m])))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(attachment_analysis_duration_seconds_bucket[5m])))",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(attachment_analysis_duration_seconds_bucket[5m])))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      }
+    },
+    {
+      "title": "Score distribution (by bucket, 5m)",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 20,
+            "lineWidth": 2
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "sum by (bucket) (increase(attachment_analysis_score_total[5m]))",
+          "legendFormat": "{{bucket}}",
+          "refId": "A"
+        }
+      ],
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      }
+    },
+    {
+      "title": "Heuristic hits (top 10, 5m)",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 20,
+            "lineWidth": 2
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "topk(10, sum by (heuristic) (increase(attachment_analysis_heuristic_hits_total[5m])))",
+          "legendFormat": "{{heuristic}}",
+          "refId": "A"
+        }
+      ],
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      }
+    },
+    {
+      "title": "Consume processing latency",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 20,
+            "lineWidth": 2
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.5, sum by (le) (rate(cybersiren_kafka_consumer_process_seconds_bucket[5m])))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(cybersiren_kafka_consumer_process_seconds_bucket[5m])))",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(cybersiren_kafka_consumer_process_seconds_bucket[5m])))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      }
+    },
+    {
+      "title": "Publish latency",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 20,
+            "lineWidth": 2
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.5, sum by (le) (rate(cybersiren_kafka_producer_publish_seconds_bucket[5m])))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(cybersiren_kafka_producer_publish_seconds_bucket[5m])))",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(cybersiren_kafka_producer_publish_seconds_bucket[5m])))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      }
+    },
+    {
+      "title": "Go runtime \u2014 goroutines",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 20,
+            "lineWidth": 2
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "go_goroutines{service=\"svc-05-attachment-analysis\"}",
+          "legendFormat": "goroutines",
+          "refId": "A"
+        }
+      ],
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 24
+      }
+    },
+    {
+      "title": "Go runtime \u2014 heap (MiB)",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 20,
+            "lineWidth": 2
+          },
+          "unit": "decmbytes"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "go_memstats_heap_alloc_bytes{service=\"svc-05-attachment-analysis\"} / 1048576",
+          "legendFormat": "heap_alloc",
+          "refId": "A"
+        }
+      ],
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 24
+      }
+    }
+  ]
+}

--- a/deploy/compose/grafana/dashboards/svc-09-notification.json
+++ b/deploy/compose/grafana/dashboards/svc-09-notification.json
@@ -1,0 +1,240 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "uid": "cybersiren-svc-09",
+  "links": [],
+  "title": "svc-09 Notification",
+  "tags": [
+    "cybersiren",
+    "pipeline",
+    "svc-09"
+  ],
+  "schemaVersion": 39,
+  "version": 1,
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "refresh": "10s",
+  "panels": [
+    {
+      "title": "Notifications (by outcome)",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 20,
+            "lineWidth": 2
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "sum by (outcome) (rate(notification_messages_total[1m]))",
+          "legendFormat": "{{outcome}}",
+          "refId": "A"
+        }
+      ],
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      }
+    },
+    {
+      "title": "Rate-limit fail-open (/s)",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 20,
+            "lineWidth": 2
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "rate(notification_ratelimit_failopen_total[5m])",
+          "legendFormat": "failopen",
+          "refId": "A"
+        }
+      ],
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      }
+    },
+    {
+      "title": "Consumed by topic (msg/s)",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 20,
+            "lineWidth": 2
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "sum by (topic) (rate(cybersiren_kafka_messages_consumed_total[1m]))",
+          "legendFormat": "{{topic}}",
+          "refId": "A"
+        }
+      ],
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      }
+    },
+    {
+      "title": "Consume processing latency",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 20,
+            "lineWidth": 2
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.5, sum by (le) (rate(cybersiren_kafka_consumer_process_seconds_bucket[5m])))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(cybersiren_kafka_consumer_process_seconds_bucket[5m])))",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(cybersiren_kafka_consumer_process_seconds_bucket[5m])))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      }
+    },
+    {
+      "title": "Go runtime \u2014 goroutines",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 20,
+            "lineWidth": 2
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "go_goroutines{service=\"svc-09-notification\"}",
+          "legendFormat": "goroutines",
+          "refId": "A"
+        }
+      ],
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      }
+    },
+    {
+      "title": "Go runtime \u2014 heap (MiB)",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 20,
+            "lineWidth": 2
+          },
+          "unit": "decmbytes"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "go_memstats_heap_alloc_bytes{service=\"svc-09-notification\"} / 1048576",
+          "legendFormat": "heap_alloc",
+          "refId": "A"
+        }
+      ],
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      }
+    }
+  ]
+}

--- a/deploy/compose/grafana/dashboards/svc-10-api-dashboard.json
+++ b/deploy/compose/grafana/dashboards/svc-10-api-dashboard.json
@@ -1,0 +1,237 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "uid": "cybersiren-svc-10",
+  "links": [],
+  "title": "svc-10 API / Analyst Console Backend",
+  "tags": [
+    "cybersiren",
+    "pipeline",
+    "svc-10"
+  ],
+  "schemaVersion": 39,
+  "version": 1,
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "refresh": "10s",
+  "panels": [
+    {
+      "title": "Up",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 20,
+            "lineWidth": 2
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "up{service=\"svc-10-api-dashboard\",job=\"cybersiren-full\"}",
+          "legendFormat": "up",
+          "refId": "A"
+        }
+      ],
+      "description": "Serves the analyst console read API + JWT login (cs-analyst). Exposes runtime metrics only.",
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "value",
+        "graphMode": "area"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      }
+    },
+    {
+      "title": "CPU (cores)",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 20,
+            "lineWidth": 2
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "rate(process_cpu_seconds_total{service=\"svc-10-api-dashboard\"}[1m])",
+          "legendFormat": "cpu",
+          "refId": "A"
+        }
+      ],
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      }
+    },
+    {
+      "title": "Open file descriptors",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 20,
+            "lineWidth": 2
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "process_open_fds{service=\"svc-10-api-dashboard\"}",
+          "legendFormat": "open_fds",
+          "refId": "A"
+        }
+      ],
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      }
+    },
+    {
+      "title": "Resident memory (MiB)",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 20,
+            "lineWidth": 2
+          },
+          "unit": "decmbytes"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "process_resident_memory_bytes{service=\"svc-10-api-dashboard\"} / 1048576",
+          "legendFormat": "rss",
+          "refId": "A"
+        }
+      ],
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      }
+    },
+    {
+      "title": "Go runtime \u2014 goroutines",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 20,
+            "lineWidth": 2
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "go_goroutines{service=\"svc-10-api-dashboard\"}",
+          "legendFormat": "goroutines",
+          "refId": "A"
+        }
+      ],
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      }
+    },
+    {
+      "title": "Go runtime \u2014 heap (MiB)",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 20,
+            "lineWidth": 2
+          },
+          "unit": "decmbytes"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "go_memstats_heap_alloc_bytes{service=\"svc-10-api-dashboard\"} / 1048576",
+          "legendFormat": "heap_alloc",
+          "refId": "A"
+        }
+      ],
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      }
+    }
+  ]
+}

--- a/deploy/compose/prometheus/prometheus.yml
+++ b/deploy/compose/prometheus/prometheus.yml
@@ -63,3 +63,30 @@ scrape_configs:
         labels: { service: "svc-09-notification" }
       - targets: ["host.docker.internal:9110"]
         labels: { service: "svc-10-api-dashboard" }
+
+  # Full-profile pipeline (the live public demo). Every containerized service
+  # exposes /metrics on :9090 inside the cybersiren network (CYBERSIREN_METRICS_PORT).
+  # Reached by compose service name — these are UP whenever `--profile full` runs.
+  - job_name: "cybersiren-full"
+    scrape_timeout: 5s
+    static_configs:
+      - targets: ["svc-01-ingestion:9090"]
+        labels: { service: "svc-01-ingestion" }
+      - targets: ["svc-02-parser:9090"]
+        labels: { service: "svc-02-parser" }
+      - targets: ["svc-03-url-pipeline:9090"]
+        labels: { service: "svc-03-url-pipeline" }
+      - targets: ["svc-04-header-analysis:9090"]
+        labels: { service: "svc-04-header-analysis" }
+      - targets: ["svc-05-attachment-analysis:9090"]
+        labels: { service: "svc-05-attachment-analysis" }
+      - targets: ["svc-06-nlp-pipeline:9090"]
+        labels: { service: "svc-06-nlp-pipeline" }
+      - targets: ["svc-07-aggregator:9090"]
+        labels: { service: "svc-07-aggregator" }
+      - targets: ["svc-08-decision:9090"]
+        labels: { service: "svc-08-decision" }
+      - targets: ["svc-09-notification:9090"]
+        labels: { service: "svc-09-notification" }
+      - targets: ["svc-10-api:9090"]
+        labels: { service: "svc-10-api-dashboard" }

--- a/deploy/offline-bundle/README.md
+++ b/deploy/offline-bundle/README.md
@@ -1,0 +1,66 @@
+# CyberSiren — offline / emergency demo bundle
+
+Run the **entire** CyberSiren stack on a laptop with **one command**, from prebuilt
+images — no VPS, no local build. This is the viva fallback if the live VPS
+(`*.cie21grad.systems`) is unreachable.
+
+## Why it never goes stale (CI/CD)
+
+`.github/workflows/demo-images.yml` rebuilds **all 15 service images and pushes them
+to GHCR** (`ghcr.io/xhcfs/cybersiren-<svc>:latest`) on every merge to `main`. The
+laptop just pulls those — so the bundle always reflects the latest `main`. The main
+compose file stays the single source of truth; `images.override.yml` only pins the
+GHCR image names on top of it (no duplicated/ drifting compose).
+
+## One-time prep (do this while you HAVE internet, e.g. the night before)
+
+```bash
+git clone https://github.com/XHCFS/cybersiren && cd cybersiren
+bash deploy/offline-bundle/START.sh          # pulls images, starts everything
+```
+
+Docker caches the pulled images locally, so every later run works **fully offline**.
+
+> GHCR packages must be pullable. Easiest: make them **public** once
+> (GitHub → repo → Packages → each package → visibility → Public). Otherwise
+> `echo $GH_PAT | docker login ghcr.io -u <you> --password-stdin` first.
+
+## At the viva (offline)
+
+```bash
+bash deploy/offline-bundle/START.sh
+```
+
+Prints the local URLs when ready:
+
+| Surface | URL | Auth |
+|---|---|---|
+| Inbox scanner / demo | http://localhost:18090 | open |
+| Analyst console | http://localhost:18089 | `analyst@demo.cybersiren` / `analyst-demo-2026` |
+| Jaeger tracing | http://localhost:16686 | open |
+| Grafana metrics | http://localhost:3001 | `admin` / `admin` |
+
+Seed data (TI domains incl. the demo C2 domain, the malicious attachment hash, the
+demo API key, the analyst login) is applied automatically by the `demo-seed` step,
+so the sample emails classify correctly out of the box.
+
+Stop: `docker compose -f deploy/compose/docker-compose.yml -f deploy/offline-bundle/images.override.yml -p cybersiren --profile full --profile monitoring down`
+
+## Truly zero-internet (no GHCR at all)
+
+If the venue has *no* network and you couldn't pre-pull:
+
+```bash
+# on any machine that has the images (the VPS, or your laptop after one online run):
+bash deploy/offline-bundle/save-images.sh      # → deploy/offline-bundle/cybersiren-images.tar.gz (~8 GB)
+# copy the whole repo (incl. that tarball) to the laptop, then:
+bash deploy/offline-bundle/START.sh            # auto-loads the tarball, no network needed
+```
+
+## Notes
+
+- `WITH_MONITORING=0 bash deploy/offline-bundle/START.sh` skips Grafana+Prometheus (~2 GB lighter).
+- `CS_IMAGE_TAG=<commit-sha>` pins a specific build instead of `latest`.
+- Gmail is intentionally excluded (no OAuth in the offline bundle); the `.eml` /
+  sample-phish flow needs nothing.
+- First boot pulls ~8 GB and builds no code; subsequent boots are fast.

--- a/deploy/offline-bundle/START.sh
+++ b/deploy/offline-bundle/START.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# =============================================================================
+# CyberSiren — one-command demo launcher (laptop / emergency fallback)
+# =============================================================================
+# Brings up the ENTIRE stack from prebuilt GHCR images — no local build, no VPS.
+#
+#   bash deploy/offline-bundle/START.sh
+#
+# Images are pulled from GHCR (kept fresh by .github/workflows/demo-images.yml).
+# Pull ONCE while you have internet; Docker caches them locally, so it then runs
+# fully OFFLINE at the venue. For zero-internet, see save-images.sh / a *.tar.gz
+# next to this script (auto-loaded below).
+#
+# Env toggles:
+#   CS_IMAGE_TAG=latest      image tag to run (default: latest; or a commit sha)
+#   WITH_MONITORING=1        include Grafana+Prometheus (default 1; 0 saves ~2GB)
+# =============================================================================
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+export CS_IMAGE_TAG="${CS_IMAGE_TAG:-latest}"
+
+PROFILES=(--profile full)
+[ "${WITH_MONITORING:-1}" = "1" ] && PROFILES+=(--profile monitoring)
+COMPOSE=(docker compose
+  -f deploy/compose/docker-compose.yml
+  -f deploy/offline-bundle/images.override.yml
+  -p cybersiren "${PROFILES[@]}")
+
+# A .env is required for compose interpolation; fall back to the committed example.
+[ -f deploy/compose/.env ] || { echo "[setup] no .env — copying .env.example"; cp deploy/compose/.env.example deploy/compose/.env; }
+
+# Zero-internet path: if an images tarball is shipped next to this script, load it.
+TARBALL="$(dirname "${BASH_SOURCE[0]}")/cybersiren-images.tar.gz"
+if [ -f "$TARBALL" ]; then
+  echo "[load] found $TARBALL — loading images (offline mode)…"
+  gunzip -c "$TARBALL" | docker load
+else
+  echo "[pull] fetching images from GHCR (needs internet; cached afterwards)…"
+  "${COMPOSE[@]}" pull || echo "  pull failed — assuming images are already cached locally; continuing"
+fi
+
+echo "[up] starting the stack (no local build)…"
+"${COMPOSE[@]}" up -d --no-build
+
+echo "[wait] waiting for the dashboards to come up…"
+ready() { curl -fsS -o /dev/null --max-time 3 "$1" 2>/dev/null; }
+for _ in $(seq 1 90); do
+  if ready http://localhost:18090/ && ready http://localhost:18089/; then break; fi
+  sleep 2
+done
+
+cat <<EOF
+
+  ✅ CyberSiren demo is up (local, offline-capable). Open:
+
+     Inbox scanner / demo  →  http://localhost:18090
+     Analyst console       →  http://localhost:18089   (analyst@demo.cybersiren / analyst-demo-2026)
+     Jaeger tracing        →  http://localhost:16686
+     Grafana metrics       →  http://localhost:3001    (admin / admin)
+
+  Seed data (TI domains, malicious attachment hash, demo API key, analyst login)
+  loads automatically. Submit a sample on the inbox scanner to see a verdict.
+
+  Stop:   docker compose -f deploy/compose/docker-compose.yml -f deploy/offline-bundle/images.override.yml -p cybersiren --profile full --profile monitoring down
+EOF

--- a/deploy/offline-bundle/images.override.yml
+++ b/deploy/offline-bundle/images.override.yml
@@ -1,0 +1,29 @@
+# ── Offline / prebuilt-image override ────────────────────────────────────────
+# Pins a GHCR image name onto every built service so the stack can run from
+# prebuilt images instead of building locally. Used in two places:
+#
+#   CI (push to main):  docker compose -f deploy/compose/docker-compose.yml \
+#                         -f deploy/offline-bundle/images.override.yml \
+#                         --profile full --profile monitoring build && ... push
+#   Laptop (demo):      START.sh → the same -f stack with `pull` + `up --no-build`
+#
+# The main compose stays the single source of truth (build:, env, deps, ports);
+# this file only adds `image:`. Tag is CS_IMAGE_TAG (default "latest").
+# Owner is lowercased for GHCR: XHCFS → xhcfs.
+
+services:
+  svc-01-ingestion:           { image: "ghcr.io/xhcfs/cybersiren-svc-01-ingestion:${CS_IMAGE_TAG:-latest}" }
+  svc-02-parser:              { image: "ghcr.io/xhcfs/cybersiren-svc-02-parser:${CS_IMAGE_TAG:-latest}" }
+  svc-03-url-pipeline:        { image: "ghcr.io/xhcfs/cybersiren-svc-03-url-pipeline:${CS_IMAGE_TAG:-latest}" }
+  svc-04-header-analysis:     { image: "ghcr.io/xhcfs/cybersiren-svc-04-header-analysis:${CS_IMAGE_TAG:-latest}" }
+  svc-05-attachment-analysis: { image: "ghcr.io/xhcfs/cybersiren-svc-05-attachment-analysis:${CS_IMAGE_TAG:-latest}" }
+  svc-06-nlp-pipeline:        { image: "ghcr.io/xhcfs/cybersiren-svc-06-nlp-pipeline:${CS_IMAGE_TAG:-latest}" }
+  svc-07-aggregator:          { image: "ghcr.io/xhcfs/cybersiren-svc-07-aggregator:${CS_IMAGE_TAG:-latest}" }
+  svc-08-decision:            { image: "ghcr.io/xhcfs/cybersiren-svc-08-decision:${CS_IMAGE_TAG:-latest}" }
+  svc-09-notification:        { image: "ghcr.io/xhcfs/cybersiren-svc-09-notification:${CS_IMAGE_TAG:-latest}" }
+  svc-10-api:                 { image: "ghcr.io/xhcfs/cybersiren-svc-10-api:${CS_IMAGE_TAG:-latest}" }
+  svc-10-web:                 { image: "ghcr.io/xhcfs/cybersiren-svc-10-web:${CS_IMAGE_TAG:-latest}" }
+  portal:                     { image: "ghcr.io/xhcfs/cybersiren-portal:${CS_IMAGE_TAG:-latest}" }
+  fusion-sidecar:             { image: "ghcr.io/xhcfs/cybersiren-fusion-sidecar:${CS_IMAGE_TAG:-latest}" }
+  nlp-inference:              { image: "ghcr.io/xhcfs/cybersiren-nlp-inference:${CS_IMAGE_TAG:-latest}" }
+  svc-11-ti-sync:             { image: "ghcr.io/xhcfs/cybersiren-svc-11-ti-sync:${CS_IMAGE_TAG:-latest}" }

--- a/deploy/offline-bundle/save-images.sh
+++ b/deploy/offline-bundle/save-images.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Zero-internet fallback: snapshot the full image set to a single tarball.
+# =============================================================================
+# Run on ANY machine that already has the images (this VPS, or your laptop after
+# one online `START.sh`). Produces deploy/offline-bundle/cybersiren-images.tar.gz,
+# which START.sh auto-loads when present — so the laptop needs NO network at all.
+#
+#   bash deploy/offline-bundle/save-images.sh            # uses :latest
+#   CS_IMAGE_TAG=<sha> bash deploy/offline-bundle/save-images.sh
+# =============================================================================
+set -euo pipefail
+TAG="${CS_IMAGE_TAG:-latest}"
+OUT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/cybersiren-images.tar.gz"
+
+# Built service images (GHCR refs from images.override.yml) + the base images the
+# full+monitoring profiles need. Keep this list in sync with images.override.yml.
+SVCS=(svc-01-ingestion svc-02-parser svc-03-url-pipeline svc-04-header-analysis
+  svc-05-attachment-analysis svc-06-nlp-pipeline svc-07-aggregator svc-08-decision
+  svc-09-notification svc-10-api svc-10-web portal fusion-sidecar nlp-inference svc-11-ti-sync)
+IMAGES=()
+for s in "${SVCS[@]}"; do IMAGES+=("ghcr.io/xhcfs/cybersiren-${s}:${TAG}"); done
+IMAGES+=(
+  postgres:15-alpine
+  valkey/valkey:7-alpine
+  redpandadata/redpanda:v24.2.7
+  minio/minio:RELEASE.2025-04-08T15-41-24Z
+  minio/mc:RELEASE.2025-04-08T15-39-49Z
+  jaegertracing/all-in-one:latest
+  prom/prometheus:latest
+  grafana/grafana:latest
+  caddy:2-alpine
+  python:3.12-alpine
+)
+
+echo "[save] writing ${#IMAGES[@]} images → $OUT (this is several GB; takes a few minutes)…"
+docker save "${IMAGES[@]}" | gzip > "$OUT"
+echo "[done] $(du -h "$OUT" | cut -f1)  $OUT"
+echo "Copy the whole deploy/offline-bundle/ (incl. this tarball) to the laptop, then run START.sh — it loads the tarball with no network."

--- a/deploy/reverse-proxy/README.md
+++ b/deploy/reverse-proxy/README.md
@@ -1,0 +1,84 @@
+# CyberSiren — Public Dashboards (reverse proxy)
+
+How CyberSiren's dashboards are exposed publicly on `cie21grad.systems`, behind a
+single shared host-level Caddy. This file is the reverse-proxy runbook.
+
+## Model (one door for the whole box)
+
+```
+internet ──(only :22, :80, :443)──▶ host Caddy (systemd: caddy)
+                                     /etc/caddy/Caddyfile → imports sites/*.caddy
+                                     terminates TLS (Let's Encrypt, auto)
+                                          │ reverse_proxy → 127.0.0.1:<port>
+                                          ▼
+                         cybersiren containers, published on 127.0.0.1 ONLY
+```
+
+- Only **22/80/443** are open (ufw). Docker bypasses ufw for published ports, so a
+  **DOCKER-USER** iptables rule (`docker-internet-lockdown.service`) drops all
+  internet→container traffic. Containers also bind `127.0.0.1` (defense in depth —
+  done in `deploy/compose/docker-compose.yml`).
+- Wildcard DNS `*.cie21grad.systems` → this VPS, so any subdomain already resolves
+  and Caddy issues a cert on first request. No per-subdomain DNS needed.
+
+## Public URLs
+
+| URL | → upstream (loopback) | Container | Auth |
+|---|---|---|---|
+| https://cs-demo.cie21grad.systems | `127.0.0.1:18090` | `portal` (inbox scanner) | open |
+| https://cs-analyst.cie21grad.systems | `127.0.0.1:18089` | `svc-10-web` (analyst console) | app's own JWT login |
+| https://cs-trace.cie21grad.systems | `127.0.0.1:16686` | `jaeger` | open (read-only) |
+| https://cs-grafana.cie21grad.systems | `127.0.0.1:3001` | `grafana` | anon Viewer; admin login to edit |
+
+Demo analyst login (seeded): `analyst@demo.cybersiren` / `analyst-demo-2026`.
+
+## Deploy / change the proxy
+
+The site file `cybersiren.caddy` here is the canonical copy. It carries no secrets
+(no basic_auth), so it deploys verbatim:
+
+```bash
+sudo install -m 0644 deploy/reverse-proxy/cybersiren.caddy /etc/caddy/sites/cybersiren.caddy
+sudo caddy validate --config /etc/caddy/Caddyfile
+sudo systemctl reload caddy
+```
+
+To add/remove a dashboard: edit `cybersiren.caddy`, re-copy, reload. To gate a UI,
+add a `basic_auth` block (`caddy hash-password --plaintext '…'`).
+
+## Bring up the live stack
+
+```bash
+cd deploy/compose
+docker compose --profile full --profile monitoring up -d --build
+```
+
+`full` runs the entire pipeline + both frontends; `monitoring` adds Prometheus +
+Grafana (also folded into `full`'s profile list). Every published port binds
+`127.0.0.1`. Data persists in the `pgdata` / `redpandadata` / `miniodata` volumes;
+`restart: unless-stopped` survives reboot.
+
+## Notes
+
+- **Grafana data:** Prometheus scrapes the containerized full-profile services by
+  name on `:9090` (job `cybersiren-full` in `prometheus/prometheus.yml`). The
+  older `cybersiren-demos` / `cybersiren-pipeline` jobs target the standalone demo
+  containers and native smoke stubs and stay "down" under `full` — that's expected.
+- **nginx upstream:** `web/svc-10-dashboard/nginx.conf` uses Docker's resolver +
+  a variable upstream so the analyst API survives `svc-10-api` recreation (no
+  stale-IP 502s).
+- **Gmail "Sign in with Google" (optional):** disabled while `GOOGLE_CLIENT_ID` is
+  empty (the `.eml` / sample-phish flow needs nothing). To enable for a controlled
+  audience: set `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` in
+  `deploy/compose/.env`, register `https://cs-demo.cie21grad.systems/oauth/callback`
+  as an authorized redirect URI on the OAuth client, add testers (the app is
+  unverified), then `docker compose ... up -d portal`.
+
+## Troubleshooting
+
+| Symptom | Check |
+|---|---|
+| 502 from a subdomain | upstream container/port up? `docker ps`, `curl 127.0.0.1:<port>` |
+| Cert won't issue | `dig +short <host> @8.8.8.8` → VPS IP; `sudo journalctl -u caddy` for ACME |
+| Reload proxy | `sudo systemctl reload caddy` |
+| Re-apply Docker firewall (after `systemctl restart docker`) | auto via `docker-internet-lockdown.service` |

--- a/deploy/reverse-proxy/cybersiren.caddy
+++ b/deploy/reverse-proxy/cybersiren.caddy
@@ -1,0 +1,40 @@
+# ── CyberSiren public dashboards ─────────────────────────────────────────────
+# Canonical, version-controlled copy of the host Caddy site file.
+# Deploy to:  /etc/caddy/sites/cybersiren.caddy   (then `sudo systemctl reload caddy`)
+#
+# This box runs ONE shared host Caddy (systemd unit "caddy") as the single public
+# entry point; /etc/caddy/Caddyfile imports /etc/caddy/sites/*.caddy. Only ports
+# 22/80/443 are open to the internet (ufw + a DOCKER-USER lockdown rule); every
+# CyberSiren container publishes on 127.0.0.1 only and is reached solely through
+# here. See deploy/reverse-proxy/README.md.
+#
+# Wildcard DNS *.cie21grad.systems → this VPS, so Caddy auto-issues a Let's
+# Encrypt cert per hostname on first request. To add/remove a dashboard, edit
+# this file, copy it to /etc/caddy/sites/, and reload.
+
+# Inbox scanner / interactive demo (Go server; holds the demo API key
+# server-side, forwards to svc-01 over the docker network). Public, no auth —
+# this is the thing people are meant to click around.
+cs-demo.cie21grad.systems {
+	reverse_proxy 127.0.0.1:18090
+}
+
+# Analyst console (React SPA + nginx; nginx proxies /api → svc-10-api internally,
+# same-origin, no CORS). It has its OWN JWT login, so it is left open at the proxy
+# and gated by that login. Seeded demo analyst: analyst@demo.cybersiren.
+cs-analyst.cie21grad.systems {
+	reverse_proxy 127.0.0.1:18089
+}
+
+# Jaeger tracing UI — the single distributed trace across all 10 pipeline
+# services. Read-only; open.
+cs-trace.cie21grad.systems {
+	reverse_proxy 127.0.0.1:16686
+}
+
+# Grafana metrics dashboards (anonymous read-only Viewer enabled; admin login for
+# editing). GF_SERVER_ROOT_URL is set to this hostname in the compose file so
+# logins/redirects work behind the proxy.
+cs-grafana.cie21grad.systems {
+	reverse_proxy 127.0.0.1:3001
+}

--- a/web/svc-10-dashboard/nginx.conf
+++ b/web/svc-10-dashboard/nginx.conf
@@ -5,18 +5,26 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # Docker's embedded DNS server. Combined with the variable upstream below,
+    # this forces nginx to re-resolve svc-10-api at request time instead of
+    # caching its IP at worker startup. Without it, recreating svc-10-api (it
+    # gets a new container IP) leaves nginx proxying to the dead old IP → 502.
+    resolver 127.0.0.11 valid=10s ipv6=off;
+
     # Reverse-proxy the API to the svc-10 backend so the browser only ever talks
     # to this origin (no CORS needed; the SPA uses relative /api paths). The
     # backend container is reachable as svc-10-api on the compose network.
     location /api/ {
-        proxy_pass http://svc-10-api:8088;
+        set $svc10_api svc-10-api;
+        proxy_pass http://$svc10_api:8088;
         proxy_set_header Host $host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_read_timeout 60s;
     }
     location = /healthz {
-        proxy_pass http://svc-10-api:8088/healthz;
+        set $svc10_api_health svc-10-api;
+        proxy_pass http://$svc10_api_health:8088;
     }
 
     # SPA history fallback: BrowserRouter uses HTML5 history, so a hard refresh

--- a/web/svc-10-dashboard/src/App.jsx
+++ b/web/svc-10-dashboard/src/App.jsx
@@ -7,6 +7,7 @@ import ScanDetail from './components/ScanDetail.jsx';
 import ScanForm from './components/ScanForm.jsx';
 import Dashboard from './components/Dashboard.jsx';
 import RulesView from './components/RulesView.jsx';
+import Monitoring from './components/Monitoring.jsx';
 
 // Sigil — the shared CyberSiren shield mark.
 function Sigil() {
@@ -57,6 +58,9 @@ function Shell({ children }) {
           </NavLink>
           <NavLink to="/rules" className={({ isActive }) => (isActive ? 'active' : '')}>
             Rules
+          </NavLink>
+          <NavLink to="/monitoring" className={({ isActive }) => (isActive ? 'active' : '')}>
+            Monitoring
           </NavLink>
         </nav>
         <div className="session">
@@ -129,6 +133,14 @@ export default function App() {
         element={
           <Protected>
             <RulesView />
+          </Protected>
+        }
+      />
+      <Route
+        path="/monitoring"
+        element={
+          <Protected>
+            <Monitoring />
           </Protected>
         }
       />

--- a/web/svc-10-dashboard/src/components/Monitoring.jsx
+++ b/web/svc-10-dashboard/src/components/Monitoring.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { surfaceLinks, grafanaBoards } from '../lib/links.js';
+
+// Monitoring — a links panel to the other CyberSiren dashboards on this box
+// (the interactive demo, Jaeger traces, and the per-service Grafana boards).
+// These are sibling subdomains, so each opens in a new tab.
+
+function LinkTile({ href, tag, name, desc }) {
+  return (
+    <a className="link-tile" href={href} target="_blank" rel="noopener noreferrer">
+      <div className="link-tile-head">
+        {tag && <span className="tag">{tag}</span>}
+        <span className="link-tile-name">{name}</span>
+        <span className="link-tile-ext" aria-hidden="true">↗</span>
+      </div>
+      {desc && <div className="link-tile-desc">{desc}</div>}
+    </a>
+  );
+}
+
+export default function Monitoring() {
+  return (
+    <div className="monitoring">
+      <section className="dash-section">
+        <h3 className="sec-title">
+          Dashboards
+          <span className="faint small" style={{ fontWeight: 400, fontFamily: 'var(--font-ui)' }}>
+            demo &amp; observability surfaces — open in a new tab
+          </span>
+        </h3>
+        <div className="grid-cards">
+          {surfaceLinks.map((l) => (
+            <LinkTile key={l.href} href={l.href} tag={l.tag} name={l.name} desc={l.desc} />
+          ))}
+        </div>
+      </section>
+
+      <section className="dash-section">
+        <h3 className="sec-title">
+          Grafana — per-service metrics
+          <span className="faint small" style={{ fontWeight: 400, fontFamily: 'var(--font-ui)' }}>
+            one board per pipeline service
+          </span>
+        </h3>
+        <div className="grid-cards">
+          {grafanaBoards.map((b) => (
+            <LinkTile key={b.href} href={b.href} tag={b.svc} name={b.name} />
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/web/svc-10-dashboard/src/index.css
+++ b/web/svc-10-dashboard/src/index.css
@@ -607,6 +607,49 @@ table.tbl td.num {
   color: var(--teal);
 }
 
+/* ── monitoring: external dashboard link tiles ─────────────────── */
+.monitoring .dash-section + .dash-section {
+  margin-top: 26px;
+}
+.link-tile {
+  display: block;
+  background: #0a1422;
+  border: 1px solid var(--line);
+  border-radius: 13px;
+  padding: 14px 16px;
+  text-decoration: none;
+  color: var(--text);
+  transition: border-color 0.15s ease, transform 0.15s ease, background 0.15s ease;
+}
+.link-tile:hover {
+  border-color: var(--teal);
+  background: #0c1a2c;
+  transform: translateY(-2px);
+}
+.link-tile-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.link-tile-name {
+  font-weight: 600;
+  font-size: 13.5px;
+}
+.link-tile-ext {
+  margin-left: auto;
+  color: var(--faint);
+  font-size: 13px;
+}
+.link-tile:hover .link-tile-ext {
+  color: var(--teal);
+}
+.link-tile-desc {
+  color: var(--muted);
+  font-size: 12px;
+  margin-top: 8px;
+  line-height: 1.45;
+}
+
 /* ── login ────────────────────────────────────────────────────── */
 .login-wrap {
   min-height: 100vh;

--- a/web/svc-10-dashboard/src/lib/links.js
+++ b/web/svc-10-dashboard/src/lib/links.js
@@ -1,0 +1,57 @@
+// External dashboard links shown on the Monitoring page.
+//
+// The analyst console is served at cs-analyst.<domain>; its sibling dashboards
+// live at cs-demo / cs-trace / cs-grafana.<domain>. We derive those from the
+// current hostname so this works on any domain the box is fronted by, fall back
+// to the public deployment, and allow explicit build-time overrides via Vite env
+// (VITE_DEMO_URL / VITE_TRACE_URL / VITE_GRAFANA_URL).
+
+const PUBLIC = {
+  demo: 'https://cs-demo.cie21grad.systems',
+  trace: 'https://cs-trace.cie21grad.systems',
+  grafana: 'https://cs-grafana.cie21grad.systems',
+};
+
+// cs-analyst.example.com -> cs-<sub>.example.com (null off the public host, e.g. localhost dev)
+function sibling(sub) {
+  if (typeof window === 'undefined') return null;
+  const { protocol, hostname, port } = window.location;
+  const m = hostname.match(/^cs-analyst\.(.+)$/);
+  if (!m) return null;
+  return `${protocol}//cs-${sub}.${m[1]}${port ? `:${port}` : ''}`;
+}
+
+function base(sub, envVal) {
+  return envVal || sibling(sub) || PUBLIC[sub];
+}
+
+const env = import.meta.env || {};
+export const demoUrl = base('demo', env.VITE_DEMO_URL);
+export const traceUrl = base('trace', env.VITE_TRACE_URL);
+export const grafanaUrl = base('grafana', env.VITE_GRAFANA_URL);
+
+// Grafana deep links resolve to each board's full slug automatically.
+const gd = (uid) => `${grafanaUrl}/d/${uid}`;
+
+// Top-level surfaces (the other demoable dashboards on the box).
+export const surfaceLinks = [
+  { href: demoUrl, name: 'Inbox Scanner', tag: 'demo', desc: 'Interactive end-to-end demo — upload an .eml or load a sample and watch the pipeline score it.' },
+  { href: traceUrl, name: 'Jaeger Tracing', tag: 'traces', desc: 'Distributed trace across all pipeline services for a single email.' },
+  { href: grafanaUrl, name: 'Grafana Home', tag: 'metrics', desc: 'Metrics dashboards (anonymous read-only viewer).' },
+];
+
+// Per-service Grafana dashboards (one card each).
+export const grafanaBoards = [
+  { href: gd('cybersiren-svc-01'), svc: 'svc-01', name: 'Ingestion' },
+  { href: gd('cybersiren-svc-02'), svc: 'svc-02', name: 'Parser' },
+  { href: gd('cybersiren-svc03'), svc: 'svc-03', name: 'URL Analysis' },
+  { href: gd('cybersiren-svc03-phishing'), svc: 'svc-03', name: 'Phishing — Domain Guard + L2 Fusion' },
+  { href: gd('cybersiren-svc-04'), svc: 'svc-04', name: 'Header Analysis' },
+  { href: gd('cybersiren-svc-05'), svc: 'svc-05', name: 'Attachment Analysis' },
+  { href: gd('cybersiren-svc06'), svc: 'svc-06', name: 'NLP' },
+  { href: gd('cybersiren-svc-07'), svc: 'svc-07', name: 'Aggregator' },
+  { href: gd('cybersiren-svc-08'), svc: 'svc-08', name: 'Decision Engine' },
+  { href: gd('cybersiren-svc-09'), svc: 'svc-09', name: 'Notification' },
+  { href: gd('cybersiren-svc-10'), svc: 'svc-10', name: 'API / Console Backend' },
+  { href: gd('cybersiren-svc11'), svc: 'svc-11', name: 'TI Sync' },
+];


### PR DESCRIPTION
Exposes the CyberSiren dashboards publicly over TLS behind a single hardened Caddy front door, completes observability, fixes demo classification, wires notifications and Gmail, and ships a one-command offline demo bundle.

## Public URLs (live)
| URL | Upstream (loopback) | Auth |
|---|---|---|
| https://cs-demo.cie21grad.systems | `portal` inbox scanner (`:18090`) | open |
| https://cs-analyst.cie21grad.systems | `svc-10-web` analyst console (`:18089`) | app's own JWT login (`analyst@demo.cybersiren`) |
| https://cs-trace.cie21grad.systems | Jaeger UI (`:16686`) | open (read-only) |
| https://cs-grafana.cie21grad.systems | Grafana (`:3001`) | anon Viewer; admin to edit |

## What's in here

**Reverse proxy & hardening**
- `deploy/reverse-proxy/`: version-controlled Caddy site file + runbook.
- `docker-compose`: every published port bound to `127.0.0.1` (only Caddy on 443 is public). Prometheus + Grafana folded into the `full` profile; Grafana `root_url` set; `svc-11-ti-sync` joined to `full`.
- `web/svc-10-dashboard/nginx.conf`: resolve `svc-10-api` via Docker DNS (fixes stale-IP 502s).

## Observability
- `prometheus.yml`: `cybersiren-full` scrape job for the containerized services.
- 6 new Grafana dashboards (svc-01/02/04/05/09/10) — every service now has a board.
- cs-analyst Monitoring page linking the demo + every observability dashboard.

## Classification fixes
- Pin `calibrated_or` fusion on svc-08 (weighted_average diluted strong signals).
- Seed the TI demo C2 domain and the malware sample's attachment hash → all five samples classify correctly: benign / phishing / phishing / phishing / malware.

## Notifications, Gmail, packaging
- svc-09 webhook → ntfy via a small adapter (titled/prioritised/tagged pushes).
- Gmail wired with a volume-persisted refresh token.
- `deploy/offline-bundle/`: one-command `START.sh` runs the full stack on a laptop from prebuilt images; CI keeps them fresh on GHCR; `save-images.sh` is a zero-internet fallback.
- `VIVA.md`: demo runbook (URLs, Gmail, screenshots, demo flow).
