### PR TITLE
Add JOSS submission kit (MIT license, paper.md, contributing guidelines)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,54 @@
+# Contributing to CyberSiren
+
+Thanks for your interest in CyberSiren. This document explains how to contribute
+code, report problems, and get help. These guidelines also satisfy the community
+requirements for our Journal of Open Source Software (JOSS) submission.
+
+## Reporting issues or problems
+
+Please open an issue at <https://github.com/XHCFS/cybersiren/issues>. When reporting
+a bug, include:
+
+- what you ran (the `make` target or command),
+- what you expected and what happened,
+- relevant logs or trace output (services emit structured logs and OpenTelemetry traces),
+- your OS, Go version, Python version, and Docker/Compose versions.
+
+For security-sensitive reports, please open a minimal issue asking the maintainers to
+contact you rather than posting exploit details publicly.
+
+## Seeking support
+
+- Read the README and the published documentation at <https://xhcfs.github.io/cybersiren/>.
+- For usage questions, open a GitHub issue with the `question` label.
+
+## Contributing code
+
+1. **Discuss first.** For non-trivial changes, open an issue describing the change before
+   sending a pull request.
+2. **Fork and branch.** Create a topic branch from `main`.
+3. **Develop and test locally:**
+   ```bash
+   make up                # start infra (postgres, valkey, kafka, jaeger)
+   make test-short        # unit tests, no infra required
+   make test-svc svc=svc-03-url-analysis
+   make lint
+   make build
+   ```
+   Python services have their own tests under each service's `nlp/` or `ml/` directory.
+4. **Keep tests green and add tests** for new behaviour. CI runs the Go and Python test
+   suites and linting on every pull request (`.github/workflows/ci.yml`).
+5. **Match the surrounding style.** Go code is formatted with `gofmt`/`golangci-lint`;
+   Python follows the existing module conventions.
+6. **Open a pull request** against `main` with a clear description and a link to the issue
+   it addresses. A maintainer will review it.
+
+## Code of conduct
+
+Be respectful and constructive. Harassment or abusive behaviour is not tolerated.
+Maintainers may remove comments, commits, or contributions that violate this principle.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the project's
+MIT License (see `LICENSE`).

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Saifelden M. Ismail, Aser O. Ibrahim, Omar A. Mahmoud
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/docs/JOSS_SUBMISSION.md
+++ b/docs/JOSS_SUBMISSION.md
@@ -1,0 +1,51 @@
+# JOSS Submission Guide — CyberSiren
+
+Everything needed to submit `CyberSiren` to the Journal of Open Source Software
+(<https://joss.theoj.org>). JOSS reviews the **software repository**, not research claims.
+
+## AI usage disclosure (paste into the submission / review thread)
+
+> The authors used Claude (Anthropic) for code and test scaffolding, documentation
+> drafting, and copy-editing. All architectural decisions, the system design, the
+> machine-learning methodology, and the experimental work were made and carried out by the
+> human authors, who reviewed and take full responsibility for all outputs. No AI was or
+> will be used in the author–reviewer review conversation, per JOSS policy.
+
+## Readiness checklist (JOSS review criteria)
+
+| Requirement | Status |
+|---|---|
+| Public open-source repository | ✅ <https://github.com/XHCFS/cybersiren> |
+| OSI-approved **LICENSE** | ✅ MIT (`LICENSE`) — *confirm with all co-authors / the institution* |
+| `paper.md` (summary + statement of need + references) | ✅ at repo root |
+| `paper.bib` | ✅ at repo root |
+| **Installation** instructions | ✅ README "Quick Start" + Docker Compose |
+| **Example usage** | ✅ README demo (`make demo …`), web UIs |
+| **Automated tests** | ✅ 113 Go + 5 Python tests, run in CI (`.github/workflows/ci.yml`) |
+| **Community guidelines** (contribute / report / support) | ✅ `CONTRIBUTING.md` |
+| Statement of need | ✅ in `paper.md` |
+| AI usage disclosure | ✅ above |
+
+## Remaining manual steps (must be done by a human author)
+
+1. **Confirm the LICENSE choice** with all co-authors and the XHCFS organization. MIT is
+   the default; swap to Apache-2.0 if a patent grant is wanted.
+2. **Tag a release** of the repository (e.g., `v1.0.0`) so there is a citable version.
+3. **Archive the tagged release on Zenodo** (or figshare) to get a DOI. Connect the GitHub
+   repo to Zenodo, then publish the release; Zenodo mints an archive DOI. JOSS requires this
+   at acceptance.
+4. **Submit** at <https://joss.theoj.org/papers/new>: provide the repository URL, the
+   version/tag, and the Zenodo DOI. Paste the AI usage disclosure when prompted (or in the
+   review thread).
+5. **During review**, respond to the reviewer/editor **yourself** on the GitHub review
+   issue — JOSS prohibits AI in the author–reviewer conversation.
+
+## Honest expectation
+
+JOSS is achievable and the AI question is a non-issue with the disclosure above. The real
+gate is JOSS's **"substantial scholarly effort"** criterion: the editor judges whether this
+is research software for the community rather than a one-off project. Your strongest
+evidence is the associated preprint (arXiv:2606.21690), the released datasets and the
+leakage-controlled benchmark, the full test suite and CI, and the end-to-end instrumentation.
+The soft spot is the absence of external adopters; the `paper.md` statement of need is
+written to lean on the reusable artifacts rather than on adoption.

--- a/paper.bib
+++ b/paper.bib
@@ -1,0 +1,17 @@
+@article{sanh2019distilbert,
+  author  = {Sanh, Victor and Debut, Lysandre and Chaumond, Julien and Wolf, Thomas},
+  title   = {{DistilBERT}, a distilled version of {BERT}: smaller, faster, cheaper and lighter},
+  journal = {arXiv preprint arXiv:1910.01108},
+  year    = {2019},
+  doi     = {10.48550/arXiv.1910.01108}
+}
+
+@misc{cybersiren2026preprint,
+  author       = {Ismail, Saifelden M. and Ibrahim, Aser O. and Mahmoud, Omar A.},
+  title        = {Generalization-Hardened Phishing Detection: Campaign-Aware Splitting and
+                  Shared Canonicalization, with a Characterized Multi-Channel Fusion Stage},
+  year         = {2026},
+  howpublished = {arXiv preprint arXiv:2606.21690},
+  doi          = {10.48550/arXiv.2606.21690},
+  url          = {https://arxiv.org/abs/2606.21690}
+}

--- a/paper.md
+++ b/paper.md
@@ -1,0 +1,94 @@
+---
+title: 'CyberSiren: An open, instrumented multi-service pipeline for multi-modal phishing detection'
+tags:
+  - phishing detection
+  - email security
+  - machine learning
+  - microservices
+  - reproducible research
+  - Go
+  - Python
+authors:
+  - name: Saifelden M. Ismail
+    orcid: 0009-0002-8867-6533
+    corresponding: true
+    affiliation: 1
+  - name: Aser O. Ibrahim
+    affiliation: 1
+  - name: Omar A. Mahmoud
+    orcid: 0009-0003-9266-4102
+    affiliation: 1
+affiliations:
+  - name: Department of Communications and Information Engineering, Zewail City of Science and Technology, Giza, Egypt
+    index: 1
+date: 30 June 2026
+bibliography: paper.bib
+---
+
+# Summary
+
+`CyberSiren` is an open, end-to-end pipeline for detecting phishing in email. It
+ingests raw messages and scores each modality of a message — the URLs it carries, its
+text, its sender/header metadata, and its attachments — with a dedicated engine, then
+recombines those signals into a single verdict at a decision-fusion stage. The system is
+implemented as eleven event-driven Go and Python microservices over a Kafka-API broker,
+and it is instrumented end to end with Prometheus metrics, OpenTelemetry traces exported
+to Jaeger, and structured logs, so that every message can be followed across the pipeline.
+
+Three detection engines are fully implemented and independently runnable: a four-stage URL
+analysis stack (a deterministic domain guard, a gradient-boosted lexical model, a
+threat-intelligence lookup, and a fusion sidecar over live host enrichment), a fine-tuned
+DistilBERT [@sanh2019distilbert] email-text classifier served through ONNX Runtime, and a
+scheduled threat-intelligence synchronizer that ingests public feeds. The repository ships
+the trained models, the supervised corpora used to build them, a leakage-controlled
+whole-system benchmark, a Docker Compose demonstration stack with auto-provisioned
+dashboards, and a test suite (over one hundred Go and Python tests) run in continuous
+integration.
+
+# Statement of need
+
+Research on phishing detection is difficult to reproduce and to deploy. Published detectors
+are typically released as a notebook and a metrics table, without an end-to-end system, the
+assembled training data, or an evaluation harness; this makes it hard to compare methods on
+equal footing or to study how a detector behaves once it is wired into a realistic pipeline.
+Multi-modal approaches that combine URL, text, and sender signals are especially
+under-served by available tooling, because evaluating fusion requires the upstream engines,
+the message bus, and the data plumbing to exist together.
+
+`CyberSiren` addresses this gap by providing a complete, open, instrumented reference
+implementation rather than a single model. Researchers and practitioners can run the
+individual engines, reproduce the released benchmarks, swap in their own models behind the
+same service interfaces, and observe behaviour through the built-in tracing and metrics.
+The project also makes common evaluation pitfalls concrete and reproducible: it ships a
+**campaign-aware** dataset-splitting procedure (splitting at the level of message campaigns
+rather than individual messages, to prevent template leakage across train and test) and a
+held-out real-phishing evaluation slice, which together expose how strongly reported
+generalization depends on the splitting and slicing choices. Making these artifacts and
+procedures openly available lowers the barrier to deployment-realistic, reproducible
+phishing-detection research.
+
+The software has been used as the basis of a graduation research project and an associated
+preprint [@cybersiren2026preprint], and is released so that its engines, datasets, and
+benchmarks can be reused and scrutinized.
+
+# Functionality
+
+- **Modality engines.** Independently runnable URL, email-text, and threat-intelligence
+  services, each with a documented score envelope, plus designed stubs for header and
+  attachment analysis.
+- **Decision fusion.** A configurable aggregator and decision engine that combine channel
+  scores (calibrated probabilistic-OR, weighted average, or hand-set noisy-OR) into a
+  verdict with campaign fingerprinting.
+- **Reproducible data and benchmarks.** Released supervised corpora, a campaign-aware
+  splitter, a held-out real-phishing slice, and a whole-system benchmark.
+- **Observability.** Prometheus, OpenTelemetry/Jaeger, and structured logging across all
+  services, with auto-provisioned Grafana dashboards.
+- **Deployment.** A Docker Compose demonstration profile and Kubernetes manifests; trained
+  models exported to ONNX for CPU serving.
+
+# Acknowledgements
+
+We thank Dr. Mohamed Samir for his academic supervision, and the engineers at Zinad for
+advisory support. The authors received no financial support for this work.
+
+# References


### PR DESCRIPTION
Adds the materials needed to submit CyberSiren to the **Journal of Open Source Software** (JOSS), which reviews the open-source software repository.

## What's included
- **LICENSE** — MIT (confirmed by the authors).
- **paper.md** + **paper.bib** — the JOSS software paper (summary, statement of need, references). Validated: YAML frontmatter parses, citation keys resolve.
- **CONTRIBUTING.md** — community guidelines (how to contribute, report issues, seek support) per the JOSS checklist.
- **docs/JOSS_SUBMISSION.md** — submission guide, readiness checklist, and the required AI-usage disclosure.

## Notes
- The paper is framed around the software artifact (no research-accuracy claims), per JOSS scope.
- Remaining manual steps after merge: tag a release, archive on Zenodo for a DOI, and submit at joss.theoj.org. See `docs/JOSS_SUBMISSION.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)